### PR TITLE
feat(mcp): reference resources — frontapp://tags, inboxes, teammates, conversations/recent

### DIFF
--- a/docs/api-facts.yaml
+++ b/docs/api-facts.yaml
@@ -17,8 +17,8 @@
 #      domain wiring status, full path/method/response info).
 #
 schema_version: 1
-generated_at: '2026-04-26T04:37:33+00:00'
-generated_from_commit: c458f8fa352683a727bc46189b6a0d917ef155fa
+generated_at: '2026-04-26T04:57:14+00:00'
+generated_from_commit: fdcd666378fa8348c8bfde721c9e7d38cb34d16a
 summary:
   list_endpoints_with_field_results:
     - accounts.list_account_contacts

--- a/frontapp_mcp_server/src/frontapp_mcp/resources/__init__.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/resources/__init__.py
@@ -12,8 +12,10 @@ from fastmcp import FastMCP
 def register_all_resources(mcp: FastMCP) -> None:
     """Register all resources with the FastMCP server."""
     from .help import register_resources as register_help_resources
+    from .reference import register_resources as register_reference_resources
 
     register_help_resources(mcp)
+    register_reference_resources(mcp)
 
 
 __all__ = ["register_all_resources"]

--- a/frontapp_mcp_server/src/frontapp_mcp/resources/help.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/resources/help.py
@@ -5,7 +5,23 @@ from __future__ import annotations
 from fastmcp import FastMCP
 
 _HELP_MARKDOWN = """\
-# Frontapp MCP Server — Tool Reference
+# Frontapp MCP Server — Tool & Resource Reference
+
+## Resources (slow-changing reference data, cached 60s)
+
+| URI                              | Use it to…                                                       |
+| -------------------------------- | ---------------------------------------------------------------- |
+| `frontapp://help`                | Read this reference (you're reading it).                         |
+| `frontapp://tags`                | Translate tag names ("urgent", "vip") into `tag_*` ids.          |
+| `frontapp://inboxes`             | Translate inbox names ("Support", "Sales") into `inb_*` ids.     |
+| `frontapp://teammates`           | Translate a teammate name or email into a `tea_*` id.            |
+| `frontapp://conversations/recent`| Orient at session start — 20 most recent conversations.          |
+
+Read these resources before calling mutating tools — they give you the
+`tag_*` / `inb_*` / `tea_*` ids you'll need for `update_conversation` and
+similar tools without asking the user. (Only conversation list/read tools
+are registered today; tags / inboxes / teammates are exposed only as
+resources.)
 
 ## Conversations
 

--- a/frontapp_mcp_server/src/frontapp_mcp/resources/reference.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/resources/reference.py
@@ -1,0 +1,181 @@
+"""MCP reference resources for workspace lookup data.
+
+These resources let an agent translate human-readable names into Front ids
+without burning a tool call. The data is slow-changing and gets a 60s cache
+from the existing ``ResponseCachingMiddleware``.
+
+| URI | Purpose |
+| --- | --- |
+| ``frontapp://tags`` | All workspace tags (id, name, color, privacy). |
+| ``frontapp://inboxes`` | All inboxes (id, name, privacy). |
+| ``frontapp://teammates`` | All teammates (id, username, email, name, availability). |
+| ``frontapp://conversations/recent`` | The 20 most recent conversations as light summaries. |
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any
+
+from fastmcp import Context, FastMCP
+from pydantic import BaseModel, Field
+
+from frontapp_mcp.services import get_services
+from frontapp_public_api_client.utils import unwrap
+
+
+class TagRef(BaseModel):
+    id: str
+    name: str | None = None
+    highlight: str | None = None
+    is_private: bool | None = None
+
+
+class InboxRef(BaseModel):
+    id: str
+    name: str | None = None
+    is_private: bool | None = None
+    is_public: bool | None = None
+
+
+class TeammateRef(BaseModel):
+    id: str
+    username: str | None = None
+    email: str | None = None
+    first_name: str | None = None
+    last_name: str | None = None
+    is_available: bool | None = None
+
+
+class RecentConversationRef(BaseModel):
+    id: str
+    subject: str | None = None
+    status: str | None = None
+    assignee_name: str | None = None
+    recipient: str | None = None
+    tags: list[str] = Field(default_factory=list)
+    is_private: bool | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+    waiting_since: str | None = None
+
+
+def _project(model: type[BaseModel], item: Any) -> dict[str, Any]:
+    """Validate an attrs model's ``to_dict()`` output through a Pydantic projection."""
+    return model.model_validate(item.to_dict()).model_dump(mode="json")
+
+
+def _dump(items: list[dict[str, Any]]) -> str:
+    """Serialize with stable key order so the 60s response-cache hits identical bytes."""
+    return json.dumps(items, sort_keys=True)
+
+
+async def _list_field_results(
+    context: Context,
+    list_fn: Callable[..., Any],
+    model: type[BaseModel],
+) -> str:
+    """Boilerplate for `field_results`-shaped list endpoints.
+
+    Three of the four reference resources (`tags`, `inboxes`, `teammates`)
+    follow the identical shape: call list_*.asyncio_detailed, unwrap field_results,
+    project each item through a Pydantic ref model, JSON-dump.
+    """
+    services = get_services(context)
+    response = await list_fn.asyncio_detailed(client=services.client)
+    parsed = unwrap(response)
+    results = getattr(parsed, "field_results", None) or []
+    return _dump([_project(model, item) for item in results])
+
+
+def _format_name(assignee: Any) -> str | None:
+    """First+last (joined and stripped), falling back to username."""
+    parts = [
+        getattr(assignee, "first_name", None),
+        getattr(assignee, "last_name", None),
+    ]
+    full = " ".join(p.strip() for p in parts if p and p.strip())
+    return full or getattr(assignee, "username", None)
+
+
+def register_resources(mcp: FastMCP) -> None:
+    """Register the workspace reference resources."""
+
+    @mcp.resource(
+        uri="frontapp://tags",
+        name="Tags",
+        description=(
+            "All workspace tags. Use to translate tag names ('urgent', 'vip') "
+            "into ids before passing to update_conversation."
+        ),
+        mime_type="application/json",
+    )
+    async def tags_resource(context: Context) -> str:
+        from frontapp_public_api_client.api.tags import list_tags
+
+        return await _list_field_results(context, list_tags, TagRef)
+
+    @mcp.resource(
+        uri="frontapp://inboxes",
+        name="Inboxes",
+        description=(
+            "All inboxes. Use to translate an inbox name ('Support', 'Sales') "
+            "into an id before listing or moving conversations."
+        ),
+        mime_type="application/json",
+    )
+    async def inboxes_resource(context: Context) -> str:
+        from frontapp_public_api_client.api.inboxes import list_inboxes
+
+        return await _list_field_results(context, list_inboxes, InboxRef)
+
+    @mcp.resource(
+        uri="frontapp://teammates",
+        name="Teammates",
+        description=(
+            "All teammates (human users). Use to translate a teammate name "
+            "or email into an id before assigning a conversation."
+        ),
+        mime_type="application/json",
+    )
+    async def teammates_resource(context: Context) -> str:
+        from frontapp_public_api_client.api.teammates import list_teammates
+
+        return await _list_field_results(context, list_teammates, TeammateRef)
+
+    @mcp.resource(
+        uri="frontapp://conversations/recent",
+        name="Recent conversations",
+        description=(
+            "The 20 most recent conversations as compact summaries. Use to orient "
+            "at the start of a session before drilling into a specific conversation "
+            "with get_conversation."
+        ),
+        mime_type="application/json",
+    )
+    async def recent_conversations_resource(context: Context) -> str:
+        # Goes through the helper (`client.conversations.list`) rather than the
+        # raw api module — the helper returns Pydantic domain models, so we
+        # re-project to the compact ref shape rather than calling _project.
+        services = get_services(context)
+        conversations = await services.client.conversations.list(limit=20)
+        return _dump(
+            [
+                RecentConversationRef(
+                    id=c.id,
+                    subject=c.subject,
+                    status=c.status,
+                    assignee_name=_format_name(c.assignee) if c.assignee else None,
+                    recipient=c.recipient.handle if c.recipient else None,
+                    tags=[t.name for t in c.tags if t.name],
+                    is_private=c.is_private,
+                    created_at=c.created_at.isoformat() if c.created_at else None,
+                    updated_at=c.updated_at.isoformat() if c.updated_at else None,
+                    waiting_since=(
+                        c.waiting_since.isoformat() if c.waiting_since else None
+                    ),
+                ).model_dump(mode="json")
+                for c in conversations
+            ]
+        )

--- a/frontapp_mcp_server/src/frontapp_mcp/server.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/server.py
@@ -225,6 +225,21 @@ All mutation tools use a two-step confirm:
 
 Front enforces per-endpoint rate limits; the client retries 429 responses
 automatically with exponential backoff. Expect ~60 req/min on most endpoints.
+
+## Resources (read these before mutating tools)
+
+  frontapp://help                  — full tool reference + workflow recipes
+  frontapp://tags                  — all workspace tags (translate name → id)
+  frontapp://inboxes               — all inboxes (translate name → id)
+  frontapp://teammates             — all teammates (translate name/email → id)
+  frontapp://conversations/recent  — 20 most recent conversations as summaries
+
+Resources are slow-changing reference data, cached for 60 seconds. Read
+them at session start to translate human-readable names ("Support" inbox,
+"Alice Cooper" assignee) into the `inb_*` / `tea_*` / `tag_*` ids that
+mutating tools require — instead of asking the user for ids or assuming
+list-* tools exist for those resources (the only list-* tools currently
+registered are for conversations).
 """,
 )
 


### PR DESCRIPTION
## Summary

Closes #3. **Stacked on #19 (Phase B)** which is itself stacked on #18 (Phase A); will rebase onto `main` once both predecessors merge.

Adds four read-only MCP **resources** that surface slow-changing workspace lookup data. Agents translate human-readable names ("Support" inbox, "Alice Cooper" assignee, "urgent" tag) into the `inb_*` / `tea_*` / `tag_*` ids that mutating tools require, without burning tool calls on `list_teammates` / `list_tags` every session.

| URI | Backed by | Projection |
| --- | --- | --- |
| `frontapp://tags` | `api.tags.list_tags` | `TagRef` (id, name, highlight, is_private) |
| `frontapp://inboxes` | `api.inboxes.list_inboxes` | `InboxRef` (id, name, is_private, is_public) |
| `frontapp://teammates` | `api.teammates.list_teammates` | `TeammateRef` (id, username, email, first_name, last_name, is_available) |
| `frontapp://conversations/recent` | `client.conversations.list(limit=20)` | `RecentConversationRef` (mirrors `ConversationSummary`) |

All four return JSON. The existing `ResponseCachingMiddleware` in `server.py` already caches read-resource results for 60s — no extra wiring needed.

## Verification

- `uv run poe check` green: 42 tests pass, prettier / ruff / ty all clean.
- Smoke-test confirms 5 resources register with correct mime types (1 existing `frontapp://help` + 4 new).

## Notes for reviewers

- Each resource takes `context: Context` — FastMCP injects it via `transform_context_annotations` (the `FunctionResource.from_function` path).
- The issue suggested cross-importing `ConversationSummary` from `tools/conversations.py`. I deliberately defined a sibling `RecentConversationRef` instead — same shape, but avoids `resources/` ← `tools/` coupling between two modules that are both leaves of the MCP server.
- **CLAUDE.md inaccuracy uncovered:** "Raw-array list (200): `/statuses`, `/teammates`" is wrong for `/teammates` — the generated `ListTeammatesResponse200` wraps results in `field_results`. Used the wrap-pattern accordingly. Worth a follow-up to correct CLAUDE.md and verify `/statuses` (the generated tree doesn't have a `list_statuses.py` at all; only `list_company_ticket_statuses` and `get_ticket_status_by_id` — likely the spec moved).

## Test plan
- [x] All static checks pass (`uv run poe check`)
- [x] Resource registration smoke-test (5 resources, correct mime types)
- [ ] **Real-world test:** start the MCP server with a real `FRONTAPP_API_KEY`, read each resource via an MCP host, confirm the JSON shape matches the projection
- [ ] **Real-world test:** confirm 60s caching by reading `frontapp://teammates` twice in quick succession and watching the upstream rate-limit headers

## Unblocks
- #2 (contacts vertical — agents resolve assignee/inbox names via these resources)
- #5 (tags + inboxes vertical — agents discover ids via these resources before mutating)
- #14 (drafts vertical — agents resolve `author_id` via `frontapp://teammates` before drafting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)