### PR TITLE
docs: refresh CLAUDE.md and AGENT_WORKFLOW.md to current harness state

### DIFF
--- a/AGENT_WORKFLOW.md
+++ b/AGENT_WORKFLOW.md
@@ -1,1148 +1,201 @@
 # Agent Workflow Guide
 
-This guide provides step-by-step instructions for AI agents working on the
-frontapp-openapi-client project. Follow these guidelines to work efficiently and safely
-in parallel with other agents.
+Step-by-step guide for AI agents (Claude Code, Copilot, others) developing this repo.
+Pairs with `CLAUDE.md` — that file is the cheat-sheet, this one is the walkthrough.
 
-## Quick Reference
-
-See CLAUDE.md "Essential Commands" for the full command table with timings.
-
-**Pre-commit Hooks:**
-
-- `.pre-commit-config-lite.yaml` - Fast iteration
-- `.pre-commit-config.yaml` - Full validation
+> **Quickest path:** read CLAUDE.md → check `docs/api-facts.yaml` for any
+> resource-specific question → invoke `vertical-planner` before coding a new resource →
+> use `/new-vertical` to scaffold → `/open-pr` when done.
 
 ---
 
-## Using Custom GitHub Copilot Agents
+## Knowledge sources, in priority order
 
-This project defines specialized GitHub Copilot agents for different development tasks.
-Each agent has domain-specific knowledge and follows project patterns.
+When you have a question about the codebase, consult these in order. Stop at the first
+one that answers your question:
 
-### Available Agents
-
-#### Specialist Agents
-
-- **`@agent-dev`** - Development agent for feature implementation and bug fixes
-  - Implements new features following established patterns
-  - Fixes bugs with proper error handling and logging
-  - Refactors code for consistency
-  - References ADRs for architectural decisions
-
-- **`@agent-plan`** - Planning agent for breaking down complex tasks
-  - Creates detailed implementation plans with phases
-  - Identifies dependencies and blockers
-  - Estimates effort (p1-high, p2-medium, p3-low)
-  - Writes comprehensive issues following templates
-
-- **`@agent-docs`** - Documentation agent for maintaining docs
-  - Creates and updates documentation
-  - Writes Architecture Decision Records (ADRs)
-  - Keeps guides current with code changes
-  - Ensures consistent markdown formatting
-
-- **`@agent-test`** - Testing agent for comprehensive test coverage
-  - Writes unit and integration tests
-  - Debugs test failures
-  - Maintains 87%+ coverage on core logic
-  - Implements reusable test fixtures
-
-- **`@agent-review`** - Review agent for thorough code reviews
-  - Checks adherence to project patterns
-  - Verifies type safety and error handling
-  - Identifies potential bugs and edge cases
-  - Suggests improvements with rationale
-
-#### Coordinator Agent
-
-- **`@agent-coordinator`** - Orchestrates multi-agent work and project management
-  - Monitors all open PRs and their status
-  - Routes tasks to appropriate specialist agents
-  - Ensures PRs meet merge criteria
-  - Tracks dependencies and blockers
-  - Maintains project velocity
-
-### Agent Workflow Patterns
-
-#### Single Agent (Direct Task)
-
-For straightforward tasks, use a specialist agent directly:
-
-```
-@agent-dev implement the search_conversations tool following the list_conversations pattern
-```
-
-```
-@agent-test write comprehensive tests for the orders helper functions
-```
-
-```
-@agent-docs create an ADR for the new Pydantic domain model architecture
-```
-
-#### Multi-Agent Coordination
-
-For complex tasks requiring multiple agents, use the coordinator:
-
-```
-@agent-coordinator get PR #125 ready to merge
-→ Analyzes PR status (review comments, CI failures, etc.)
-→ Delegates to @agent-dev for code fixes
-→ Delegates to @agent-test for test coverage
-→ Delegates to @agent-docs for documentation
-→ Verifies all criteria met
-→ Merges when ready
-```
-
-```
-@agent-coordinator complete the MCP v0.1.0 milestone
-→ Identifies all open issues and PRs
-→ Routes work to specialist agents
-→ Tracks progress across parallel workstreams
-→ Reports blockers and status
-→ Coordinates release when all work complete
-```
-
-#### Project-Level Coordination
-
-For ongoing project management:
-
-```
-@agent-coordinator check in on all open PRs
-→ Scans all PRs for status
-→ Identifies ready-to-merge PRs
-→ Assigns specialists to PRs needing work
-→ Reports blockers and stale PRs
-→ Provides project health summary
-```
-
-### Agent Definition Files
-
-All custom agents are defined in `.github/copilot/agents/`:
-
-- `agent-dev.yml` - Development agent configuration
-- `agent-plan.yml` - Planning agent configuration
-- `agent-docs.yml` - Documentation agent configuration
-- `agent-test.yml` - Testing agent configuration
-- `agent-review.yml` - Review agent configuration
-- `agent-coordinator.yml` - Coordinator agent configuration
-
-Each agent has:
-
-- Specialized instructions based on project patterns
-- References to key documentation (CLAUDE.md, ADRs)
-- Context about which files they work with
-- Examples of typical tasks and approaches
-
-### When to Use Which Agent
-
-**Use @agent-dev when:**
-
-- Implementing new features
-- Fixing bugs
-- Addressing review comments
-- Resolving merge conflicts
-- Refactoring code
-
-**Use @agent-plan when:**
-
-- Breaking down epic-level work
-- Creating implementation plans
-- Identifying dependencies
-- Estimating effort
-- Designing architecture
-
-**Use @agent-docs when:**
-
-- Writing new documentation
-- Updating existing docs
-- Creating ADRs
-- Adding examples to cookbook
-- Documenting APIs
-
-**Use @agent-test when:**
-
-- Writing new tests
-- Fixing test failures
-- Improving coverage
-- Debugging test issues
-- Creating test fixtures
-
-**Use @agent-review when:**
-
-- Reviewing pull requests
-- Checking code quality
-- Verifying patterns
-- Identifying bugs
-- Suggesting improvements
-
-**Use @agent-coordinator when:**
-
-- Managing multiple PRs
-- Coordinating agent work
-- Tracking project progress
-- Unblocking stalled work
-- Preparing releases
-
-### Example: Complete Feature Workflow
-
-Here's how multiple agents work together on a feature:
-
-1. **Planning Phase**
-
-   ```
-   @agent-plan break down "Add richer comment filtering" into implementation tasks
-   → Creates detailed plan with phases
-   → Identifies dependencies
-   → Creates individual issues
-   ```
-
-1. **Implementation Phase**
-
-   ```
-   @agent-dev implement a new tool for filtering by date range, following the list_conversations pattern
-   → Implements tool with proper patterns
-   → Adds error handling and logging
-   → Creates PR with changes
-   ```
-
-1. **Testing Phase**
-
-   ```
-   @agent-test write comprehensive tests for new tool
-   → Writes unit tests for all functions
-   → Tests success and error paths
-   → Verifies 90%+ coverage
-   ```
-
-1. **Documentation Phase**
-
-   ```
-   @agent-docs document the new tool
-   → Adds docstrings
-   → Updates README
-   → Adds cookbook example
-   ```
-
-1. **Review Phase**
-
-   ```
-   @agent-review review PR #123 for new tool
-   → Checks pattern adherence
-   → Verifies test coverage
-   → Validates documentation
-   → Suggests improvements
-   ```
-
-1. **Coordination Phase**
-
-   ```
-   @agent-coordinator get PR #123 merged
-   → Ensures all feedback addressed
-   → Verifies CI passing
-   → Confirms merge criteria met
-   → Merges PR
-   → Updates milestone
-   ```
-
-This coordinated workflow ensures high-quality, well-tested, documented features.
+1. **`docs/api-facts.yaml`** — generated, CI-validated index of every endpoint.
+   Pre-computed reverse indexes in `summary.*` answer most factual questions in one
+   grep. Cannot drift from the generated tree.
+2. **`CLAUDE.md`** — architecture, validation tiers, anti-patterns, file rules. The
+   cheat-sheet.
+3. **The canonical templates** — `frontapp_public_api_client/helpers/conversations.py`,
+   `frontapp_public_api_client/domain/conversation.py`,
+   `frontapp_mcp_server/src/frontapp_mcp/tools/conversations.py`. These are the patterns
+   every new vertical should mirror.
+4. **`docs/adr/`** — architecture decision records, slow-changing prose. Read when the
+   "why" of a pattern matters.
+5. **The OpenAPI spec** (`docs/frontapp-openapi.yaml`) — request body shapes, field
+   types, error responses. Read when the facts file doesn't have what you need.
+6. **Direct grep / file inspection** — last resort. If you find yourself here often for
+   the same question, the facts file or CLAUDE.md probably needs an update.
 
 ---
 
-## Step-by-Step Workflow
+## Sub-agents and skills
 
-### 1. Starting Work on an Issue
+The `.claude/` tree provides specialized agents and workflow skills.
 
-#### Check for Conflicts
+### Sub-agents (`.claude/agents/`)
 
-Before starting, ensure no other agent is working on the same code:
+Spawn these for delegated work during complex tasks. They have their own knowledge
+sources and tool restrictions baked in via frontmatter.
 
-```bash
-# Check if issue is already assigned
-gh issue view <issue-number>
+| Agent              | When to use                                                                     |
+| ------------------ | ------------------------------------------------------------------------------- |
+| `vertical-planner` | Before writing a new `client.<resource>` surface — produces a structured plan.  |
+| `domain-advisor`   | One-off factual questions ("does list_X use field_results?"). Read-only oracle. |
+| `code-modernizer`  | Refactoring hand-written code to current patterns (UNSET helpers, unwrap, etc.) |
+| `pr-preparer`      | Branch-readiness check before opening a PR                                      |
+| `spec-auditor`     | Audit the vendored spec against upstream for drift                              |
 
-# Check recent PRs touching same files
-gh pr list --search "is:open <keyword>"
+### Skills (`.claude/skills/`)
 
-# Look at current branch activity
-git branch -r | grep feature
-```
+Multi-step workflows. Invoked as `/skill-name`.
 
-#### Create Your Branch
+| Skill               | What it does                                                                                      |
+| ------------------- | ------------------------------------------------------------------------------------------------- |
+| `/new-vertical`     | End-to-end vertical scaffolding (helper + domain + MCP tools + tests + docs).                     |
+| `/vendor-and-regen` | Refresh the vendored OpenAPI spec from upstream and regenerate the client safely.                 |
+| `/open-pr`          | Open a PR — self-review, push, create, wait for CI, address feedback.                             |
+| `/review-pr`        | Address PR review comments — fetch, fix, validate, push, reply. Handles stacked PRs and Disagree. |
+| `/review`           | Structured code review of the current branch.                                                     |
+| `/techdebt`         | Scan for repo-specific anti-patterns.                                                             |
+| `/write-tests`      | Generate tests for target code (mock httpx transport, exercise unwrap helpers).                   |
+| `/generate-docs`    | Generate or update ADRs / cookbook entries.                                                       |
+| `/verify`           | Skeptical validation pass before considering work complete.                                       |
+| `/pre-commit`       | Quick pre-flight before committing.                                                               |
 
-Use consistent naming conventions:
+### Hooks (`.claude/hooks/`)
 
-```bash
-# Pattern: feature/{issue-number}-{short-description}
-git checkout -b feature/88-agent-workflow-doc
+Automatic safety net wired in via `.claude/settings.json`.
 
-# Alternative: agent/{agent-id}/{issue-number}-{description}
-git checkout -b agent/claude-1/88-agent-workflow-doc
-```
-
-**Branch Naming Rules:**
-
-- Use `feature/` for general work
-- Use `agent/` prefix if coordinating multiple agents
-- Always include issue number
-- Keep description short and kebab-case
-- Examples:
-  - `feature/92-release-concurrency`
-  - `feature/94-pytest-xdist`
-  - `agent/copilot-1/95-coverage-ratchet`
-
-#### Update Issue Status
-
-Comment on the issue to claim it:
-
-```bash
-gh issue comment <issue-number> --body "🤖 Starting work on this issue"
-```
+| Hook                       | When it fires                             | What it does                                                                                                                                                                                                                        |
+| -------------------------- | ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `block-generated-edits.sh` | PreToolUse on `Edit`/`Write`/`MultiEdit`  | Blocks edits to generated/vendored files under `frontapp_public_api_client/` (`api/**`, `models/**`, `client.py`, `client_types.py`, `errors.py`) and the two vendored YAMLs (`docs/frontapp-openapi.yaml`, `docs/api-facts.yaml`). |
+| `format-on-edit.sh`        | PostToolUse on `Edit`/`Write`/`MultiEdit` | Silently runs `ruff format`+`check --fix` on `*.py` and `prettier --write` on `*.md`.                                                                                                                                               |
 
 ---
 
-### 2. Development Workflow
+## The vertical-shipping workflow
 
-#### Fast Iteration Loop
+"Ship a new resource vertical" (drafts, contacts, messages, tags/inboxes, etc.) is the
+primary recurring unit of work. The harness encodes it as a five-step motion:
 
-During active development, use quick validation for fast feedback:
+1. **Plan** — `vertical-planner` reads `docs/api-facts.yaml` for the resource and
+   produces a structured plan (modules to wrap, response shapes, helper + domain wiring
+   status, MCP tools to register, files to create vs edit, risks). Output is reviewed
+   before any code is written.
+2. **Scaffold** — `/new-vertical` walks the 12-step STANDARD PATH (domain projection →
+   helper class → wire into `FrontappClient` → MCP tools → register → cache +
+   instructions → help.py → tests → README → validate). Mirrors
+   `frontapp_public_api_client/helpers/conversations.py` +
+   `frontapp_mcp_server/src/frontapp_mcp/tools/conversations.py` as the canonical
+   templates.
+3. **Validate** — `uv run poe full-check` (Tier 4) before requesting review. See
+   "Validation tiers" below.
+4. **Open PR** — `/open-pr` self-reviews, pushes, opens the PR, waits for CI.
+5. **Address feedback** — `/review-pr` handles review comments.
 
-```bash
-# Make changes to code
-vim src/file.py
-
-# Quick validation (5-10 seconds)
-uv run poe quick-check
-
-# If using pre-commit lite
-pre-commit run --config .pre-commit-config-lite.yaml --all-files
-
-# Continue iterating
-```
-
-**When to Use Quick Check:**
-
-- ✅ During active coding
-- ✅ Testing different approaches
-- ✅ Experimenting with solutions
-- ✅ Multiple iterations needed
-
-**When NOT to Use:**
-
-- ❌ Before committing (use agent-check)
-- ❌ Before opening PR (use check)
-- ❌ Before requesting review (use full-check)
-
-#### Before Committing
-
-Run more thorough validation:
-
-```bash
-# Agent-level validation (10-15 seconds)
-uv run poe agent-check
-
-# Or use pre-commit lite
-pre-commit run --config .pre-commit-config-lite.yaml --all-files
-
-# If all passes, commit
-git add <files>
-git commit -m "feat: your commit message"
-```
-
-**Commit Message Format:** Follow conventional commits:
-
-```
-<type>(<scope>): <description>
-
-[optional body]
-
-[optional footer]
-```
-
-**Types:**
-
-- `feat` - New feature (triggers release)
-- `fix` - Bug fix (triggers release)
-- `docs` - Documentation only
-- `test` - Test changes
-- `refactor` - Code refactoring
-- `chore` - Maintenance tasks
-- `ci` - CI/CD changes
-
-**Scopes (for monorepo):**
-
-- `client` - Releases frontapp-openapi-client
-- `mcp` - Releases frontapp-mcp-server
-- (no scope) - Releases frontapp-openapi-client (default)
-
-**Examples:**
-
-```bash
-git commit -m "feat(mcp): add status-history resource"
-git commit -m "fix(client): handle null status on orders"
-git commit -m "docs: update AGENT_WORKFLOW.md"
-git commit -m "test: add coverage for edge cases"
-```
+If something doesn't fit the canonical template (drafts inverts the two-step-confirm,
+reference-only resources go through `resources/` not `tools/`), the planner flags it
+under "Risks" — those become explicit decisions, not mid-implementation surprises.
 
 ---
 
-### 3. Before Opening a Pull Request
+## Validation tiers
 
-#### Run Full Validation
+Run the appropriate tier for your stage. Each is a poe task; see CLAUDE.md "Essential
+Commands" for timings.
 
-**CRITICAL:** PRs must be green with full validation. No skips, no excludes.
+| Tier | Task                     | When                                             |
+| ---- | ------------------------ | ------------------------------------------------ |
+| 1    | `uv run poe quick-check` | During development — fast format + lint feedback |
+| 2    | `uv run poe agent-check` | Before committing — adds typecheck + facts-check |
+| 3    | `uv run poe check`       | Before opening a PR — adds tests                 |
+| 4    | `uv run poe full-check`  | Before requesting review — adds docs-build       |
 
-```bash
-# Full validation (required before PR)
-uv run poe check
+`agent-check`, `check`, and `full-check` all include `facts-check`, so the generated
+`docs/api-facts.yaml` cannot drift from the api/ tree.
 
-# Or use full pre-commit
-pre-commit run --all-files
-
-# Expected time: ~40 seconds (or ~12-15s with parallel tests)
-```
-
-**What `check` does:**
-
-1. Format check (ruff, markdown)
-1. Linting (ruff, ty, yamllint)
-1. Tests (pytest with coverage, excluding slow docs tests)
-
-**If any checks fail:**
-
-- ❌ **DO NOT** add skips or excludes
-- ❌ **DO NOT** use `--no-verify` without justification
-- ✅ **FIX** the actual issue
-- ✅ **ASK** for help if blocked
-
-**Exception:** Only skip checks if:
-
-1. You document WHY in PR description
-1. You create a follow-up issue to fix properly
-1. The skip is temporary and necessary
-
-#### Push Your Branch
-
-```bash
-# Push to remote
-git push -u origin feature/88-agent-workflow-doc
-
-# If you need to force push (be careful!)
-git push --force-with-lease
-```
+If validation fails, fix at the source — never `noqa`, `type: ignore`, `--no-verify`, or
+skip a test. See CLAUDE.md "Zero Tolerance for Ignoring Errors".
 
 ---
 
-### 4. Opening the Pull Request
+## Common pitfalls
 
-#### Use GitHub CLI
+CLAUDE.md "Known Pitfalls" is the canonical list. Highlights an agent reading this file
+once should remember:
 
-```bash
-# Create PR with template
-gh pr create --fill
-
-# Or specify details
-gh pr create \
-  --title "feat: add agent workflow documentation" \
-  --body "Closes #88
-
-## Description
-Adds comprehensive AGENT_WORKFLOW.md guide for AI agents.
-
-## Changes
-- Created AGENT_WORKFLOW.md with step-by-step workflow
-- Updated CLAUDE.md to link to new guide
-
-## Testing
-- Validated all commands work
-- Reviewed formatting and links"
-```
-
-#### PR Checklist
-
-Before requesting review, ensure:
-
-- [ ] All CI checks passing (green)
-- [ ] Full validation run locally (`uv run poe check`)
-- [ ] Tests added/updated for changes
-- [ ] Documentation updated if needed
-- [ ] Commit messages follow conventional commits
-- [ ] No test/lint skips or excludes (unless justified)
-- [ ] Issue number referenced in PR (e.g., "Closes #88")
-
-#### Request Review
-
-```bash
-# Self-assign
-gh pr edit --add-assignee @me
-
-# Add labels
-gh pr edit --add-label "documentation"
-
-# Mark ready for review (if draft)
-gh pr ready
-```
+- **Generated files** —
+  `frontapp_public_api_client/{api/**, models/**, client.py, client_types.py, errors.py}`
+  plus the vendored YAMLs `docs/frontapp-openapi.yaml` and `docs/api-facts.yaml`. Never
+  edit directly; the PreToolUse hook will reject. Regenerate via the appropriate
+  pipeline command (`uv run poe regenerate-client`, `uv run poe facts`, or
+  `uv run poe regenerate-all`).
+- **`field_results` vs raw arrays** — most list endpoints wrap results in
+  `field_results` (openapi-python-client renames Front's `_results`). A few return raw
+  arrays. Consult `docs/api-facts.yaml` `summary.*`; do not guess by tag name.
+- **`UNSET` sentinel** — attrs models use `UNSET` for unprovided fields, not `None`. Use
+  `unwrap_unset(field, default)` from `frontapp_public_api_client/domain/converters.py`,
+  not `isinstance` or `hasattr` checks. Use `to_unset(value)` when building request
+  bodies.
+- **MCP mutation pattern** — tools take `confirm: bool = False` and return a plain dict
+  with `preview` and `confirmed` keys. `ConfirmationResult` is the `StrEnum` returned by
+  `require_confirmation`, **not** the tool's return type.
+- **`/review-pr` on stacked PRs** — when merging a parent with `--delete-branch`, flip
+  every child's base to `main` first, otherwise GitHub auto-closes them (and they can't
+  be reopened). The `/review-pr` skill has a full section on this.
 
 ---
 
-### 5. Handling Review Feedback
+## Working with the LSP tool
 
-#### Make Changes
+For type/call-graph questions inside hand-written code, prefer LSP operations over
+`Read`+`Grep`. The full table is in CLAUDE.md "Using the LSP tool". Quick mapping:
 
-```bash
-# Make requested changes
-vim files.py
+- "What's this symbol's type?" → `LSP hover`
+- "Where is X defined?" → `LSP goToDefinition`
+- "Who calls X?" → `LSP findReferences` or `LSP incomingCalls`
 
-# Validate
-uv run poe check
-
-# Commit
-git add .
-git commit -m "fix: address review feedback"
-
-# Push
-git push
-```
-
-#### Respond to Comments
-
-```bash
-# Comment on PR
-gh pr comment <pr-number> --body "✅ Updated per your feedback"
-
-# Resolve conversations (on GitHub web UI)
-```
+For project-wide symbol search, fall back to `Grep` — pyright only indexes open files in
+this configuration.
 
 ---
 
-### 6. Before Merge
+## Multi-agent / parallel work
 
-#### Final Validation
+If multiple agents are working on the project simultaneously:
 
-**CRITICAL:** Before merging, run complete validation:
-
-```bash
-# Full check including docs
-uv run poe full-check
-
-# This includes:
-# - Format check
-# - Linting (ruff, ty, yamllint)
-# - All tests (including docs tests)
-# - Coverage check
-
-# Expected time: ~50 seconds
-```
-
-#### Ensure CI is Green
-
-Check GitHub UI or:
-
-```bash
-gh pr checks
-
-# Should show all checks passing
-```
-
-#### Merge
-
-```bash
-# Squash and merge (recommended)
-gh pr merge --squash
-
-# Or merge commit
-gh pr merge --merge
-
-# Or rebase (be careful!)
-gh pr merge --rebase
-```
+1. Each takes their own branch (`feat/<resource>-vertical`, `chore/<area>-cleanup`).
+2. The PreToolUse hook + `facts-check` CI gate prevent the most common collision modes
+   (generated-file edits, stale fact index).
+3. For overlapping changes, the second-to-merge rebases via `/review-pr`'s stacked-PR
+   section.
+4. `/babysit-prs` (TODO — see open issues) would automate the "watch CI on N open PRs"
+   coordination loop. Until then, manual `gh pr list --state open`.
 
 ---
 
-## Validation Tiers Reference
+## Detailed references
 
-See CLAUDE.md "Essential Commands" for the authoritative command table with timings.
-
-### Quick Check
-
-**Command:** `uv run poe quick-check` | **Use during development**
-
-Runs ruff format check and linting. Skips type checking and tests.
-
-### Agent Check
-
-**Command:** `uv run poe agent-check` | **Use before committing**
-
-Runs format check, linting, and ty type checking. Skips tests.
-
-### Check
-
-**Command:** `uv run poe check` | **Required before opening PR**
-
-Runs format check (ruff, markdown), linting (ruff, ty, yamllint), and tests (pytest,
-excluding docs). **This is the standard for "PR ready."**
-
-### Full Check
-
-**Command:** `uv run poe full-check` | **Use before requesting review**
-
-Runs everything in `check` plus documentation build. **This is the gold standard.**
+- `CLAUDE.md` — quick-reference cheat-sheet; **read this first**
+- `docs/api-facts.yaml` — generated, machine-readable index of every endpoint
+- `docs/adr/README.md` — architecture decision records
+- `frontapp_public_api_client/docs/guide.md` — Python client guide
+- `frontapp_mcp_server/docs/README.md` — MCP server docs
+- `packages/frontapp-client/README.md` — TypeScript client
+- `.github/agents/guides/shared/VALIDATION_TIERS.md` — fuller tier rationale
+- `.github/agents/guides/shared/COMMIT_STANDARDS.md` — semantic commit format
+- `.github/agents/guides/shared/FILE_ORGANIZATION.md` — what goes where
 
 ---
 
-## Conflict Resolution
-
-### Detecting Conflicts
-
-#### Before Starting Work
-
-```bash
-# Check who's working on what
-gh issue list --assignee @me
-gh pr list --author @me
-
-# Check file history
-git log --oneline --follow <file>
-
-# Check open PRs touching same files
-gh pr list --search "is:open"
-```
-
-#### During Work
-
-```bash
-# Keep your branch updated
-git fetch origin
-git rebase origin/main
-
-# Check for conflicts
-git status
-```
-
-### Resolving Conflicts
-
-#### Simple Rebase
-
-```bash
-# Update main
-git checkout main
-git pull
-
-# Rebase your branch
-git checkout feature/your-branch
-git rebase main
-
-# If conflicts, resolve them
-# Edit conflicting files
-git add <resolved-files>
-git rebase --continue
-
-# Force push (safe with --force-with-lease)
-git push --force-with-lease
-```
-
-#### Complex Conflicts
-
-If you encounter complex conflicts:
-
-1. **Communicate in the issue:**
-
-   ```bash
-   gh issue comment <issue-number> --body "Encountered conflicts with #<other-issue>. Coordinating resolution."
-   ```
-
-1. **Check with other agent (if parallel work):**
-   - Review the other PR
-   - Determine which changes take precedence
-   - Coordinate in issue comments
-
-1. **If blocked:**
-   - Comment on issue explaining blockage
-   - Provide details on conflict
-   - Wait for guidance or coordinate with other agent
-
----
-
-## Common Pitfalls & Solutions
-
-### ❌ Pitfall: Skipping Validation
-
-**Problem:** Using `--no-verify` or skipping checks to speed up workflow
-
-**Solution:**
-
-- Use tiered validation (quick-check, agent-check, check)
-- Only full validation required before PR
-- Fast iteration OK during development
-
----
-
-### ❌ Pitfall: Committing with Failures
-
-**Problem:** Committing when tests or linting fail
-
-**Solution:**
-
-- Always run `uv run poe agent-check` before committing
-- Fix issues, don't skip them
-- If blocked, ask for help in issue comments
-
----
-
-### ❌ Pitfall: Adding Test/Lint Skips
-
-**Problem:** Adding `# type: ignore`, `# noqa`, or pytest skips to pass CI
-
-**Solution:**
-
-- Fix the actual issue
-- Only skip if absolutely necessary AND document why in PR
-- Create follow-up issue to remove skip
-
----
-
-### ❌ Pitfall: Force Pushing Without Care
-
-**Problem:** Using `git push --force` and overwriting others' work
-
-**Solution:**
-
-- Use `git push --force-with-lease` (safer)
-- Check if anyone else is on your branch
-- Communicate before force pushing shared branches
-
----
-
-### ❌ Pitfall: Not Updating Branch
-
-**Problem:** Working on stale branch, causing conflicts
-
-**Solution:**
-
-```bash
-# Update regularly
-git fetch origin
-git rebase origin/main
-
-# Or merge if preferred
-git merge origin/main
-```
-
----
-
-### ❌ Pitfall: Unclear Commit Messages
-
-**Problem:** Vague commits like "fix stuff" or "update code"
-
-**Solution:**
-
-- Follow conventional commits format
-- Be specific: "fix(client): handle empty viable-statuses response"
-- Include context: "refactor: extract helper for order status mapping"
-
----
-
-## Pre-commit Hook Usage
-
-### Lite Config (Fast Iteration)
-
-**File:** `.pre-commit-config-lite.yaml`
-
-**Usage:**
-
-```bash
-# Run lite hooks
-pre-commit run --config .pre-commit-config-lite.yaml --all-files
-
-# Install as default
-pre-commit install --config .pre-commit-config-lite.yaml
-```
-
-**When to Use:**
-
-- During development
-- Fast feedback loop
-- Experimenting
-
----
-
-### Full Config (Complete Validation)
-
-**File:** `.pre-commit-config.yaml`
-
-**Usage:**
-
-```bash
-# Run full hooks (includes tests)
-pre-commit run --all-files
-
-# Install as default
-pre-commit install
-```
-
-**When to Use:**
-
-- Before opening PR
-- Before requesting review
-- Final validation
-
-**Note:** With pytest-xdist (parallel tests), this is now ~12-15 seconds instead of ~27
-seconds.
-
----
-
-## Working with Multiple Agents
-
-When multiple AI agents work on the same codebase in parallel, coordination is essential
-to avoid conflicts and wasted effort. Follow these patterns for smooth parallel
-development.
-
-### Coordination Strategies
-
-#### 1. Claim Issues Early
-
-**Always** comment on an issue as soon as you start working on it:
-
-```bash
-# As soon as you start
-gh issue comment <issue-number> --body "🤖 Starting work on this issue"
-
-# Self-assign if possible
-gh issue edit <issue-number> --add-assignee "@me"
-```
-
-**Why:** Other agents can see someone is already working on it.
-
-#### 2. Check for Conflicts BEFORE Starting
-
-**Critical:** Before starting work, check if anyone else is already working on similar
-changes:
-
-```bash
-# 1. Check open PRs that might overlap
-gh pr list --state open
-
-# 2. Check issues assigned to others
-gh issue list --state open --assignee "@others"
-
-# 3. Check recent activity on files you'll touch
-git log --oneline -10 --follow <file-path>
-
-# 4. Check open branches
-git branch -r | grep feature
-```
-
-**Decision tree:**
-
-- **No conflicts?** → Start work, claim issue
-- **Similar work in progress?** → Comment on issue, coordinate with other agent
-- **Depends on other PR?** → Wait for that PR to merge, or coordinate merge order
-
-#### 3. Communicate Progress in Issue Comments
-
-Keep issue comments updated so other agents know your status:
-
-```bash
-# Update progress
-gh issue comment <issue-number> --body "✅ Completed X, working on Y"
-
-# Signal blocks
-gh issue comment <issue-number> --body "⚠️ Blocked by #<other-issue>, waiting for resolution"
-
-# Ask for coordination
-gh issue comment <issue-number> --body "📋 This may conflict with #<other-issue>. Coordinating..."
-
-# Signal completion
-gh issue comment <issue-number> --body "✅ PR #<pr-number> ready for review"
-```
-
-#### 4. Branch Naming for Clarity
-
-**Standard pattern:** `feature/<issue-number>-<description>`
-
-```bash
-git checkout -b feature/88-agent-workflow
-```
-
-**Agent-specific pattern** (if coordinating multiple agents on same project):
-
-```bash
-# Agent 1
-git checkout -b agent/claude-1/88-agent-workflow
-
-# Agent 2
-git checkout -b agent/copilot-1/89-update-instructions
-```
-
-**Why agent-specific branches help:**
-
-- Clearly shows which agent owns which work
-- Prevents accidental branch name collisions
-- Makes it easy to see parallel work in `git branch -r`
-
-#### 5. File-Level Conflict Detection
-
-Before starting, identify which files you'll modify and check for conflicts:
-
-```bash
-# Check who else recently touched these files
-git log --oneline -10 -- path/to/file.py
-
-# Check open PRs touching same files
-gh pr list --json number,title,files --jq '.[] | select(.files[].path == "path/to/file.py") | {number, title}'
-
-# Check for unmerged branches touching same files
-git branch -r --contains <commit> | grep -v "$(git rev-parse --abbrev-ref HEAD)"
-```
-
-**If conflicts detected:**
-
-1. **Same file, different sections** → Can work in parallel, coordinate merge order
-1. **Same file, same sections** → One agent should wait or pick different issue
-1. **Dependencies** → Work sequentially, file issue dependencies
-
-#### 6. Merge Order Coordination
-
-When multiple PRs will conflict, coordinate merge order:
-
-```bash
-# Option A: Sequential (safest)
-# Agent 1: Open PR #100, merge
-# Agent 2: Wait for #100 to merge, rebase, then open PR #101
-
-# Option B: Parallel with coordination (faster)
-# Agent 1: Open PR #100 (touches file A)
-# Agent 2: Open PR #101 (touches file B, no conflicts)
-# Both can merge independently
-
-# Option C: Stacked PRs (for dependencies)
-# Agent 1: Open PR #100 (foundation)
-# Agent 2: Branch from PR #100, open PR #101 (depends on #100)
-# Merge #100 first, then #101 rebases and merges
-```
-
-#### 7. Self-Coordination Strategies
-
-**Pattern 1: Claim and Complete**
-
-```bash
-# 1. Check issue list, pick unclaimed issue
-gh issue list --no-assignee
-
-# 2. Claim it
-gh issue edit <issue-number> --add-assignee "@me"
-gh issue comment <issue-number> --body "🤖 Starting work"
-
-# 3. Complete end-to-end (no partial work)
-# 4. Open PR, get it merged
-# 5. Move to next issue
-```
-
-**Pattern 2: Avoid Overlap**
-
-```bash
-# Before starting, check if files overlap with open PRs
-ISSUE=92
-FILES="path/to/file.py path/to/other.py"
-
-for FILE in $FILES; do
-  echo "Checking $FILE..."
-  gh pr list --json number,files --jq ".[] | select(.files[].path == \"$FILE\") | .number"
-done
-
-# If overlap found, choose different issue or coordinate
-```
-
-**Pattern 3: Phase-Based Work**
-
-Work on issues grouped by phase to minimize conflicts:
-
-```bash
-# Agent 1: Works on Phase 1 issues (#88, #89, #90)
-# Agent 2: Works on Phase 2 issues (#92, #93)
-# Agent 3: Works on Phase 3 issues (#94, #95)
-
-# Check your assigned phase
-gh issue list --label "phase-1"
-```
-
-#### 8. Rebase Frequently
-
-If working on a long-running branch, rebase frequently to stay current:
-
-```bash
-# Every few hours or before opening PR
-git fetch origin
-git rebase origin/main
-
-# If conflicts, resolve them immediately
-git status
-# Fix conflicts, then:
-git add .
-git rebase --continue
-```
-
-#### 9. Use GitHub Projects for Visibility
-
-If available, use GitHub Projects to show what each agent is working on:
-
-```bash
-# View project status
-gh project list
-
-# See what's in progress
-gh project item-list <project-number> --format json | jq '.[] | select(.status == "In Progress")'
-```
-
-#### 10. Coordinate Breaking Changes
-
-If your change will break other agents' work, coordinate explicitly:
-
-```bash
-# Announce in main issue
-gh issue comment <tracking-issue> --body "⚠️ PR #<number> will rename function X → Y. Other agents should wait for this to merge."
-
-# Or create tracking issue
-gh issue create --title "Coordination: Breaking change in PR #<number>" --body "..."
-```
-
----
-
-## Troubleshooting
-
-### Tests Failing Locally
-
-```bash
-# Run tests with verbose output
-uv run pytest -v
-
-# Run specific test
-uv run pytest tests/test_specific.py::test_function
-
-# Run with coverage
-uv run poe test-coverage
-
-# Check test markers
-uv run pytest --markers
-```
-
-### Linting Errors
-
-```bash
-# See all linting issues
-uv run poe lint
-
-# Auto-fix what's possible
-uv run poe fix
-
-# Check specific file
-uv run ruff check path/to/file.py
-```
-
-### Type Checking Errors
-
-```bash
-# Run ty type checker
-uv run poe typecheck
-
-# Or run ty directly
-uv run ty check
-
-# See ty config
-# Check [tool.ty] in pyproject.toml
-
-# Note: ty is pre-alpha and may report false positives
-# Uses --exit-zero to prevent CI failures during early adoption
-```
-
-### Pre-commit Hook Timeouts
-
-If pre-commit hooks timeout (e.g., in network-restricted environments):
-
-```bash
-# Use lite config
-pre-commit run --config .pre-commit-config-lite.yaml --all-files
-
-# Or skip hooks temporarily
-git commit --no-verify
-
-# But then run full validation manually
-uv run poe check
-```
-
-### Coverage Failures
-
-```bash
-# Run tests with coverage report
-uv run poe test-coverage
-
-# View HTML coverage report
-open htmlcov/index.html
-
-# Check coverage for specific files
-uv run pytest --cov=frontapp_public_api_client --cov-report=term-missing
-```
-
----
-
-## Additional Resources
-
-- **[CLAUDE.md](CLAUDE.md)** - Project overview and quick start
-- **[docs/CONTRIBUTING.md](docs/CONTRIBUTING.md)** - Contribution guidelines
-- **[.github/copilot-instructions.md](.github/copilot-instructions.md)** - Detailed
-  instructions for GitHub Copilot
-- **[pyproject.toml](pyproject.toml)** - See all poe tasks and configurations
-- **[GitHub Project](https://github.com/users/dougborg/projects/4)** - Automation &
-  Agent Infrastructure roadmap
-
----
-
-## Using Git Worktrees for Parallel Sessions
-
-Git worktrees let you run multiple Claude Code sessions on the same repository without
-conflicts. Each worktree is an isolated copy of the repo with its own working directory
-and branch.
-
-### When to Use Worktrees
-
-- Running multiple Claude Code sessions in parallel on different tasks
-- Working on a feature while keeping main clean for reviews
-- Testing changes in isolation without stashing or committing
-
-### Quick Setup
-
-```bash
-# Create a worktree for a specific task
-git worktree add ../frontapp-feature-123 -b feature/123-my-task
-
-# Work in the worktree (each Claude Code session gets its own)
-cd ../frontapp-feature-123
-
-# When done, clean up
-git worktree remove ../frontapp-feature-123
-```
-
-### Tips
-
-- Each worktree has its own `.venv` - run `uv sync --all-extras` in new worktrees
-- Worktrees share the same `.git` history - commits in one are visible in all
-- Don't have two worktrees on the same branch (causes confusion)
-- Clean up worktrees when done: `git worktree list` to see all, `git worktree prune` to
-  remove stale entries
-
----
-
-## Summary: The Golden Rules
-
-1. ✅ **Use tiered validation** - quick-check during dev, check before PR, full-check
-   before review
-1. ✅ **PRs must be green** - No skips, no excludes, no failures
-1. ✅ **Communicate early** - Claim issues, update progress, signal blocks
-1. ✅ **Follow conventions** - Branch naming, commit messages, PR format
-1. ✅ **Coordinate conflicts** - Check before starting, rebase regularly, resolve
-   proactively
-1. ✅ **Ask for help** - If blocked, ask in issue comments
-1. ✅ **Document exceptions** - If you must skip/exclude, document why in PR
-
-Happy coding! 🤖
+## Self-improvement
+
+If you discover something that should be in this guide, CLAUDE.md, or one of the skill
+prompts, update it as part of your current work. Stale agent guidance is more harmful
+than no guidance — see CLAUDE.md "Continuous Improvement". The session that documented
+an anti-pattern as the canonical example wasted three later sessions before it was
+caught.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,13 @@ Common mistakes to avoid:
   `field_` when they'd otherwise collide with Python (leading-underscore names). So
   `_results` becomes `field_results`, `_pagination` becomes `field_pagination`. Always
   use `getattr(parsed, "field_results", None) or []` when unwrapping list responses.
+  Which list endpoints use `field_results` vs return raw arrays is enumerated in
+  `docs/api-facts.yaml` under `summary.list_endpoints_with_field_results` and
+  `summary.list_endpoints_returning_raw_array` — read that file rather than guessing by
+  tag name. Notably `/teammates` and `/tags` use `field_results` (despite older
+  intuition); the raw-array set is small and includes some conversation sub-resource
+  lists plus `statuses.list_company_ticket_statuses` — see the facts file for the
+  current authoritative list.
 - **Front error responses have no single schema** — Front doesn't define a canonical
   `ErrorResponse` type; each endpoint models errors inline. `utils.unwrap()` dispatches
   on HTTP status code, not on parsed-type `isinstance` checks. Don't try to import an
@@ -201,12 +208,21 @@ etc. Bearer auth on every endpoint.
 
 ## File Rules
 
-| Category      | Files                                         | Action          |
-| ------------- | --------------------------------------------- | --------------- |
-| **EDITABLE**  | `frontapp_client.py`, tests/, scripts/, docs/ | Can modify      |
-| **GENERATED** | `api/**/*.py`, `models/**/*.py`, `client.py`  | **DO NOT EDIT** |
+| Category                    | Files                                                                                                                                                                                                                                                                                                                                                                              | Action          |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- |
+| **EDITABLE**                | `frontapp_public_api_client/{frontapp_client.py, helpers/**, domain/**, utils.py, api_wrapper/**}`, `frontapp_mcp_server/src/**`, `packages/frontapp-client/src/**`, `tests/**`, `frontapp_mcp_server/tests/**`, `scripts/**`, `docs/**` (except the YAMLs below), `.claude/**`, `.github/**`                                                                                      | Can modify      |
+| **GENERATED — DO NOT EDIT** | `frontapp_public_api_client/api/**/*.py`, `frontapp_public_api_client/models/**/*.py`, `frontapp_public_api_client/client.py`, `frontapp_public_api_client/client_types.py`, `frontapp_public_api_client/errors.py`, `docs/frontapp-openapi.yaml` (vendored from upstream), `docs/api-facts.yaml` (generated from the api/ tree), `packages/frontapp-client/src/generated/**` (TS) | **DO NOT EDIT** |
 
-Regenerate client: `uv run poe regenerate-client` (2+ min)
+The `.claude/hooks/block-generated-edits.sh` PreToolUse hook enforces the generated-file
+boundary; an attempted Edit/Write/MultiEdit on any file in the "DO NOT EDIT" row exits 2
+with regen-flow guidance.
+
+| Regenerate                | Command                                | Time    |
+| ------------------------- | -------------------------------------- | ------- |
+| Python client             | `uv run poe regenerate-client`         | ~1-2min |
+| Vendored OpenAPI spec     | `uv run python scripts/vendor_spec.py` | ~3s     |
+| API facts index           | `uv run poe facts`                     | ~3s     |
+| Full pipeline (all three) | `uv run poe regenerate-all`            | ~1-2min |
 
 ## Commit Standards
 
@@ -247,14 +263,20 @@ tags = unwrap_unset(conv.tags, [])  # Returns [] if UNSET
 
 ### When to Use Each Pattern
 
-| Scenario                       | Pattern                                            | Example                       |
-| ------------------------------ | -------------------------------------------------- | ----------------------------- |
-| Single object (200)            | `unwrap_as(response, Type)`                        | Get/update by id              |
-| Paginated list (200)           | `unwrap(response)` + `getattr(…, "field_results")` | List conversations/messages/… |
-| Raw-array list (200)           | `unwrap(response)` (parsed is a `list` directly)   | `/statuses`, `/teammates`     |
-| Create (201)                   | `is_success(response)`                             | POST with no body             |
-| Accepted (202) / Deleted (204) | `is_success(response)`                             | Replies, archives             |
-| attrs UNSET field              | `unwrap_unset(field, default)`                     | Optional API fields           |
+| Scenario                       | Pattern                                            | Example                                                       |
+| ------------------------------ | -------------------------------------------------- | ------------------------------------------------------------- |
+| Single object (200)            | `unwrap_as(response, Type)`                        | Get/update by id                                              |
+| Paginated list (200)           | `unwrap(response)` + `getattr(…, "field_results")` | Most list endpoints (see `docs/api-facts.yaml` summary block) |
+| Raw-array list (200)           | `unwrap(response)` (parsed is a `list` directly)   | A handful of conversation sub-resource lists; see facts file  |
+| Create (201)                   | `is_success(response)`                             | POST with no body                                             |
+| Accepted (202) / Deleted (204) | `is_success(response)`                             | Replies, archives                                             |
+| attrs UNSET field              | `unwrap_unset(field, default)`                     | Optional API fields                                           |
+
+For the authoritative per-endpoint shape (which list returns `field_results` vs a raw
+array vs a single object), consult `docs/api-facts.yaml` —
+`summary.list_endpoints_with_field_results`,
+`summary.list_endpoints_returning_raw_array`, and
+`tags.<resource>.endpoints[].list_shape` are CI-validated and cannot drift.
 
 ### Anti-Patterns to Avoid
 
@@ -292,27 +314,35 @@ status = unwrap_unset(conv.status, None)
 
 Project slash commands in `.claude/commands/` and skills in `.claude/skills/`:
 
-| Command          | Purpose                                      |
-| ---------------- | -------------------------------------------- |
-| `/techdebt`      | Scan for tech debt and anti-patterns         |
-| `/review`        | Structured code review of current branch     |
-| `/write-tests`   | Write comprehensive tests for target code    |
-| `/generate-docs` | Generate or update documentation             |
-| `/verify`        | Skeptically validate implementation quality  |
-| `/pre-commit`    | Quick pre-flight check before committing     |
-| `/review-pr`     | Address PR review comments, fix, push, reply |
-| `/open-pr`       | Open PR with self-review, CI wait, feedback  |
+| Command             | Purpose                                                                                |
+| ------------------- | -------------------------------------------------------------------------------------- |
+| `/new-vertical`     | Scaffold a new resource vertical (helper + domain + MCP tools + tests + docs)          |
+| `/vendor-and-regen` | Refresh the vendored Front OpenAPI spec from upstream and regenerate the client safely |
+| `/review-pr`        | Address PR review comments — fetch, fix, validate, push, reply                         |
+| `/open-pr`          | Open PR with self-review, CI wait, feedback                                            |
+| `/review`           | Structured code review of current branch                                               |
+| `/techdebt`         | Scan for tech debt and anti-patterns                                                   |
+| `/write-tests`      | Write comprehensive tests for target code                                              |
+| `/generate-docs`    | Generate or update documentation                                                       |
+| `/verify`           | Skeptically validate implementation quality                                            |
+| `/pre-commit`       | Quick pre-flight check before committing                                               |
 
 ## Claude Code Agents
 
 Sub-agents in `.claude/agents/` that can be spawned for delegated work during complex
 tasks:
 
-| Agent             | Purpose                                              |
-| ----------------- | ---------------------------------------------------- |
-| `spec-auditor`    | Audit local OpenAPI spec against upstream for drift  |
-| `code-modernizer` | Simplify code using repo-specific patterns and rules |
-| `pr-preparer`     | Validate branch readiness for pull request           |
+| Agent              | Purpose                                                                                                                          |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| `vertical-planner` | Plan a new resource vertical (helper + domain + MCP tools) BEFORE any code is written. Sonnet, Read+Bash+Grep+Glob.              |
+| `domain-advisor`   | Read-only oracle for Front API factual questions (response shape, module names, helper status). Haiku, Read+Grep+Glob (no Bash). |
+| `code-modernizer`  | Simplify code using repo-specific patterns (UNSET helpers, response unwrap, etc.)                                                |
+| `pr-preparer`      | Validate branch readiness for pull request                                                                                       |
+| `spec-auditor`     | Audit local OpenAPI spec against upstream for drift                                                                              |
+
+The `vertical-planner` and `domain-advisor` both consult `docs/api-facts.yaml` as their
+primary knowledge source. When you have a one-off factual question about the API surface
+mid-task, prefer `domain-advisor` over grep+ls.
 
 ## Detailed Documentation
 


### PR DESCRIPTION
## Summary

Two stale-doc cleanups so future agent sessions don't get misled.

### `CLAUDE.md`

- **File Rules**: GENERATED row was missing `client_types.py`, `errors.py`, `docs/frontapp-openapi.yaml`, `docs/api-facts.yaml` — now matches the PreToolUse hook's actual block list. Added a regenerate-command table including the new \`poe facts\` and \`poe regenerate-all\`.
- **API Response Handling table**: dropped the \`/statuses, /teammates\` examples from the "Raw-array list" row — both wrong. \`teammates\` uses \`field_results\` (verified against generated code). \`statuses\` has no list endpoint at all (only \`list_company_ticket_statuses\`). Replaced with a pointer at \`docs/api-facts.yaml\` as the CI-validated source of truth.
- **Known Pitfalls**: the "Generated list-response field names" entry now points at \`docs/api-facts.yaml: summary.list_endpoints_with_field_results\` rather than re-stating the rule a fourth time.
- **Claude Code Commands / Agents tables**: added the new pieces shipped in #19 — \`/new-vertical\`, \`/vendor-and-regen\` skills; \`vertical-planner\`, \`domain-advisor\` agents.

### \`AGENT_WORKFLOW.md\`

Full rewrite. The previous 1148-line version referenced six phantom \`@agent-*\` names that never existed (\`@agent-dev\`, \`@agent-plan\`, \`@agent-docs\`, \`@agent-test\`, \`@agent-review\`, \`@agent-coordinator\`) and used StatusPro domain examples. Replaced with a focused ~180-line current-harness guide covering knowledge sources in priority order, sub-agents + skills as they actually exist today, hooks, the vertical-shipping workflow, validation tiers, common pitfalls, and the LSP tool.

## Test plan
- [x] \`uv run poe agent-check\` green (format, prettier, ruff, ty, facts-check)
- [ ] Reviewer sanity check that the new doc accurately describes what's on \`main\` after #18-#21

## Related
This is the first half of the "session learnings" cleanup. PR B (Phase C of #17) addresses the remaining stale files in \`.github/agents/\`. Follow-up issues for aspirational features (e.g. \`/babysit-prs\`) filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)