### PR TITLE
chore(harness): Phase C of #17 — clean stale .github/agents/* files

### DIFF
--- a/.claude/agents/pr-preparer.md
+++ b/.claude/agents/pr-preparer.md
@@ -30,17 +30,25 @@ Review all commits on this branch (vs main) for:
 
 ### 3. Generated File Integrity
 
-- If generated files (`api/**/*.py`, `models/**/*.py`, `client.py`) appear in the diff,
-  verify they came from regeneration (spec change + `uv run poe regenerate-client`), not
-  manual edits
-- If `docs/frontapp-openapi.yaml` was modified, verify that client was regenerated AND
-  pydantic models were regenerated (`uv run poe generate-pydantic`)
+- If generated files (`api/**/*.py`, `models/**/*.py`, `client.py`, `client_types.py`,
+  `errors.py`) appear in the diff, verify they came from regeneration (spec change +
+  `uv run poe regenerate-client`), not manual edits. The PreToolUse hook normally blocks
+  these; if they're present, someone went around it.
+- If `docs/frontapp-openapi.yaml` was modified, verify the client was regenerated and
+  `docs/api-facts.yaml` is up to date (`uv run poe facts`). The full pipeline is
+  `uv run poe regenerate-all`.
 
 ### 4. Coverage Check
 
-- Run `uv run poe test-coverage` and verify core logic maintains 87%+ coverage
-- New code has test coverage for both success and error paths
-- No test files with only happy-path assertions
+- Run `uv run poe test-coverage` and verify there's no regression vs. the current
+  baseline on `main`. The project's test infrastructure is still ramping up — until a
+  fixed coverage floor is set in
+  [issue #7](https://github.com/dougborg/frontapp-openapi-client/issues/7), the gate is
+  "no regression," not a hardcoded percentage.
+- New code has test coverage for both success and error paths (including the
+  `unwrap`-helper exception classes: `AuthenticationError`, `ValidationError`,
+  `RateLimitError`, `ServerError`, `APIError`).
+- No test files with only happy-path assertions.
 
 ### 5. Documentation
 

--- a/.claude/agents/spec-auditor.md
+++ b/.claude/agents/spec-auditor.md
@@ -16,14 +16,21 @@ an upstream URL, update this file with the URL and switch to full drift-detectio
 
 ## Knowledge
 
-- Local spec lives at `docs/frontapp-openapi.yaml`
-- Generated files (`api/**/*.py`, `models/**/*.py`, `client.py`) are derived from the
-  spec via `uv run poe regenerate-client` followed by `uv run poe generate-pydantic`
-- Pydantic models inherit from `FrontappPydanticBase`, which uses `extra="forbid"`; the
-  attrs models tolerate unknown fields via `additional_properties`
-- Most list endpoints wrap data in `{"data": [...], "meta": {...}}` (page/per_page
-  pagination). Two endpoints return raw arrays: `GET /statuses` and
-  `GET /orders/{id}/viable-statuses`
+- **Upstream source**: `frontapp/front-api-specs` → `core-api/core-api.json`. Vendored
+  locally at `docs/frontapp-openapi.yaml` by `scripts/vendor_spec.py`, which sanitizes a
+  few quirks (`PATHS_TO_STRIP` for binary downloads, `PROPERTY_DEFAULTS_TO_STRIP` for
+  allOf-inheritance breakages, Unicode confusables) before writing.
+- **Generated files** (`api/**/*.py`, `models/**/*.py`, `client.py`, `client_types.py`,
+  `errors.py`) are produced by `uv run poe regenerate-client`. After regen, also run
+  `uv run poe facts` so `docs/api-facts.yaml` matches. The full pipeline is
+  `uv run poe regenerate-all`.
+- **Pagination shape**: Front uses cursor-based pagination. List responses wrap results
+  in `_results` (renamed by openapi-python-client to `field_results`) plus
+  `_pagination.next` (renamed `field_pagination`) containing the next-page URL with a
+  `page_token` query param. There is no `total` count.
+- **Per-endpoint shape**: which endpoints use `field_results` vs return raw arrays vs
+  return single objects is enumerated in `docs/api-facts.yaml` under
+  `summary.list_endpoints_*`. Read that file before making claims about response shape.
 
 ## Audit Process
 
@@ -58,7 +65,12 @@ For each endpoint with differences:
 
 ## Important
 
-- NEVER edit generated files directly — only modify `docs/frontapp-openapi.yaml`
-- After spec changes, the pipeline is: edit spec → `uv run poe regenerate-client` →
-  `uv run poe generate-pydantic` → `uv run poe agent-check`
+- NEVER edit generated files directly. The PreToolUse hook will block.
+- NEVER edit the vendored `docs/frontapp-openapi.yaml` directly either — patch the
+  sanitization rules in `scripts/vendor_spec.py` so the change survives the next
+  refresh.
+- After spec changes, the pipeline is: patch `scripts/vendor_spec.py` →
+  `uv run python scripts/vendor_spec.py` → `uv run poe regenerate-client` →
+  `uv run poe facts` → `uv run poe agent-check`. Or in one shot:
+  `uv run poe regenerate-all`.
 - Never include real user names or emails from API responses in reports or examples

--- a/.github/agents/ci-cd-specialist.agent.md
+++ b/.github/agents/ci-cd-specialist.agent.md
@@ -206,10 +206,12 @@ When you need detailed guidance, use the `read` tool:
 
 1. **Determine ownership**
 
-   - Lint failures → `@agent-dev` to fix formatting
-   - Test failures → `@agent-test` to fix tests
-   - Build failures → Handle yourself
-   - Security issues → `@agent-dev` to address vulnerabilities
+   - Lint failures → run `uv run poe fix` or hand off to `python-developer.agent.md` /
+     `code-modernizer`
+   - Test failures → hand off to `tdd-specialist.agent.md` (or `/write-tests`)
+   - Build failures → handle yourself
+   - Security issues → hand off to `python-developer.agent.md` for the fix;
+     `dependency-review` workflow output indicates the affected package
 
 1. **Fix and verify**
 
@@ -267,7 +269,7 @@ When you need detailed guidance, use the `read` tool:
 
    - Ensure `!` marker on breaking commits
    - Verify BREAKING CHANGE: footers
-   - Coordinate migration guide with `@agent-docs`
+   - Coordinate migration guide with `documentation-writer.agent.md`
    - Plan deprecation timeline
 
 1. **Rollback if needed**
@@ -300,19 +302,27 @@ Before considering infrastructure work complete:
 1. **Don't regenerate client without validation** - OpenAPI spec must be valid
 1. **Don't optimize workflows without measuring** - Know the baseline first
 
-## Agent Coordination
+## Coordinating with other agents
 
-### Delegate to Specialists
+For Claude Code sessions, point requesters at the appropriate specialist:
 
-- **`@agent-dev`** - Implementation fixes, code changes
-- **`@agent-test`** - Test failures, coverage improvements
-- **`@agent-docs`** - Documentation updates, migration guides
-- **`@agent-review`** - Code quality issues, pattern violations
-- **`@agent-coordinator`** - Multi-agent work orchestration
+- Code fix requested → `code-modernizer` agent or `/new-vertical` skill
+- Test coverage gap → `tdd-specialist.agent.md` (Copilot) or `/write-tests` skill
+- Documentation update → `documentation-writer.agent.md` (Copilot) or
+  `/generate-docs` skill
+- PR review-comment loop → `/review-pr` skill
 
-### Handle Yourself
+For Copilot sessions, the other `.github/agents/*.agent.md` files cover:
 
-- CI/CD configuration and optimization
+- `python-developer.agent.md` — Python implementation
+- `tdd-specialist.agent.md` — test-first development
+- `code-reviewer.agent.md` — structured code reviews
+- `documentation-writer.agent.md` — ADRs, MkDocs, cookbook
+- `task-planner.agent.md` — multi-phase implementation planning
+
+### Handle yourself (CI/CD scope)
+
+- CI/CD workflow configuration and optimization
 - Workflow debugging and fixes
 - Dependency updates and management
 - Release coordination and monitoring

--- a/.github/agents/code-reviewer.agent.md
+++ b/.github/agents/code-reviewer.agent.md
@@ -240,11 +240,15 @@ Verify documentation:
 
 ```markdown
 ❌ Bad: "This is inefficient"
-✅ Good: "This creates an N+1 query. Consider fetching all products
+✅ Good: "This creates an N+1 query. Consider fetching all conversations
           in a single call and filtering in memory:
 
-          products = await list_conversations.asyncio_detailed(client=client)
-          filtered = [p for p in products.parsed.data if p.is_sellable]
+          response = await list_conversations.asyncio_detailed(
+              client=client, q='status:open'
+          )
+          parsed = unwrap(response)
+          conversations = getattr(parsed, 'field_results', None) or []
+          urgent = [c for c in conversations if any(t.name == 'urgent' for t in c.tags)]
           "
 ```
 
@@ -275,7 +279,7 @@ Use emoji for clarity:
 **❌ Wrong: Wrapping API methods for retries**
 
 ```python
-async def get_products_with_retry():
+async def get_conversations_with_retry():
     for i in range(3):
         try:
             return await list_conversations.asyncio(...)
@@ -286,8 +290,9 @@ async def get_products_with_retry():
 **✅ Right: Use FrontappClient (transport-layer resilience)**
 
 ```python
-async with FrontappClient() as client:
-    # Retries handled automatically
+async with FrontappClient(api_key="...") as client:
+    # Retries + rate-limit awareness handled automatically by the
+    # ResilientAsyncTransport in FrontappClient.
     response = await list_conversations.asyncio_detailed(client=client)
 ```
 
@@ -296,17 +301,17 @@ async with FrontappClient() as client:
 **❌ Wrong: Missing type hints**
 
 ```python
-def process_product(product):
-    return product.name
+def process_conversation(conv):
+    return conv.subject
 ```
 
 **✅ Right: Full type annotations**
 
 ```python
-from frontapp_public_api_client.domain.product import Product
+from frontapp_public_api_client.domain import Conversation
 
-def process_product(product: Product) -> str:
-    return product.name
+def process_conversation(conv: Conversation) -> str | None:
+    return conv.subject
 ```
 
 ### Error Handling Issues
@@ -335,17 +340,20 @@ except SpecificError as e:
 **❌ Wrong: N+1 queries**
 
 ```python
-for product_id in product_ids:
-    product = await get_product(product_id)  # Multiple API calls
-    process(product)
+for conversation_id in conversation_ids:
+    conv = await client.conversations.get(conversation_id)  # Multiple API calls
+    process(conv)
 ```
 
-**✅ Right: Batch fetch**
+**✅ Right: Batch via the list endpoint with a query**
 
 ```python
-products = await list_conversations(ids=product_ids)  # Single call
-for product in products:
-    process(product)
+# Fetch the relevant set in one call via Front search syntax.
+conversations = await client.conversations.list(
+    q="status:open inbox:support", limit=100
+)
+for conv in conversations:
+    process(conv)
 ```
 
 ## Review Checklist
@@ -489,20 +497,20 @@ When a review reveals a recurring mistake or a pattern worth codifying:
 1. **Be specific** - Provide actionable feedback
 1. **Be constructive** - Suggest solutions, not just problems
 1. **Verify tests** - Always run test suite
-1. **Check coverage** - Must maintain 87%+ on core logic
+1. **Check coverage** - Watch for regression in test coverage; the project's
+   coverage baseline will firm up as the test infrastructure issue lands.
 1. **Reference ADRs** - Ensure architectural compliance
 1. **Security first** - Flag any security concerns
 1. **Performance matters** - Look for inefficient patterns
 1. **Documentation required** - Public APIs need docs
 1. **Improve the system** - Codify recurring findings into project docs
-1. **Coordinate with agents** - Request fixes from specialists
 
-## Agent Coordination
+## Coordinating with other agents
 
-Work with specialized agents:
+For Claude Code sessions, point requesters at the appropriate sub-agent or skill:
 
-- `@agent-dev` - Request code fixes for issues found
-- `@agent-test` - Request test coverage improvements
-- `@agent-docs` - Request documentation updates
-- `@agent-plan` - Verify implementation matches plan
-- `@agent-coordinator` - Report on PR readiness for merge
+- Code change needed → `code-modernizer` agent (refactor) or `/new-vertical` skill (new resource)
+- Test coverage gaps → `tdd-specialist.agent.md` (Copilot) or `/write-tests` skill
+- Documentation gaps → `documentation-writer.agent.md` (Copilot) or `/generate-docs` skill
+- Branch readiness check → `pr-preparer` agent or `/pre-commit` skill
+- PR review-comment loop → `/review-pr` skill

--- a/.github/agents/documentation-writer.agent.md
+++ b/.github/agents/documentation-writer.agent.md
@@ -517,12 +517,12 @@ Documentation should improve every time it's touched:
 1. **Fix what you find** - Improve existing docs alongside new ones
 1. **Coordinate with agents** - Get reviews from specialists
 
-## Agent Coordination
+## Coordinating with other agents
 
-Work with specialized agents:
+For Claude Code sessions:
 
-- `@agent-dev` - Request docs for new features
-- `@agent-plan` - Document architectural decisions from planning
-- `@agent-test` - Document testing patterns and coverage
-- `@agent-review` - Get doc reviews for accuracy
-- `@agent-coordinator` - Coordinate documentation releases
+- Code change for new feature → `vertical-planner` then `/new-vertical` skill
+- Test patterns to document → `tdd-specialist.agent.md` (Copilot)
+- ADR-driven planning → `task-planner.agent.md` (Copilot)
+- Doc review → `/review` skill or `code-reviewer.agent.md` (Copilot)
+- Cookbook entries / MkDocs builds → `/generate-docs` skill

--- a/.github/agents/project-coordinator.agent.md
+++ b/.github/agents/project-coordinator.agent.md
@@ -57,13 +57,17 @@ identifying blockers, and ensuring quality standards are met before merging.
 - Debugging test issues
 - Adding integration tests
 
-**Delegation Pattern:**
+**Delegation Pattern** (illustrative — uses an aspirational test file per
+[issue #7](https://github.com/dougborg/frontapp-openapi-client/issues/7);
+adapt to whatever exists today under `tests/` and
+`frontapp_mcp_server/tests/`):
 
 ```
-@tdd-specialist PR #125 has failing tests in test_inventory.py:
-- test_check_stock_empty_sku is failing
-- test_pagination needs update for new API response format
-Please fix these tests and verify coverage remains above 87%
+@tdd-specialist PR #125 has failing tests after the spec refresh:
+- the unwrap path is asserting on the old response shape
+- specifically broken on the conversations list endpoint after `field_results`
+  rename surfaced
+Please fix the test fixture and verify coverage doesn't regress vs main.
 ```
 
 ### @documentation-writer - Documentation
@@ -79,11 +83,12 @@ Please fix these tests and verify coverage remains above 87%
 **Delegation Pattern:**
 
 ```
-@documentation-writer PR #120 adds new sales_orders tool:
-- Add docstrings to all public functions
-- Update frontapp_mcp_server/README.md with new tool
-- Add usage example to docs/COOKBOOK.md
-- Create ADR if architectural decision made
+@documentation-writer PR #120 adds the drafts vertical:
+- Add docstrings to client.drafts.* helper methods
+- Update frontapp_mcp_server/src/frontapp_mcp/resources/help.py with the
+  new tools (it's hand-maintained, see CLAUDE.md "Help resource drift")
+- Update README.md "API Coverage" table row from ⏳ to ✅
+- Create ADR if the inverted-confirm pattern is worth recording
 ```
 
 ### @code-reviewer - Code Review
@@ -294,23 +299,26 @@ Manage multiple independent workstreams:
 ```markdown
 ## Parallel Workstreams
 
-**Stream 1: MCP v0.1.0 Release**
-- PR #130: Sales orders tool (@python-developer)
-- PR #131: Manufacturing orders tool (@python-developer)
-- PR #132: Documentation updates (@documentation-writer)
-- Dependency: 130 → 131 → 132
+**Stream 1: New verticals (MCP)**
+- PR #X: Drafts vertical (@python-developer)
+- PR #Y: Contacts vertical (@python-developer)
+- PR #Z: Tags/inboxes vertical (@python-developer)
+- Dependency: each vertical is independent of the others, but all assume
+  the harness PRs (#18, #19, #22) have landed
 
-**Stream 2: Client Enhancements**
-- PR #140: Domain model improvements (@python-developer)
-- PR #141: Helper utilities (@python-developer)
+**Stream 2: Test coverage ramp-up**
+- PR #A: Conversations test fixtures (@tdd-specialist)
+- PR #B: Helper test patterns (@tdd-specialist)
 - No dependencies, can merge independently
 
 **Stream 3: Infrastructure**
-- PR #150: CI/CD improvements (@ci-cd-specialist)
-- PR #151: Test coverage ratchet (@tdd-specialist)
+- PR #C: CI/CD improvements (@ci-cd-specialist)
+- PR #D: Documentation refresh (@documentation-writer)
 - No dependencies, can merge independently
 
-**Coordination**: Track each stream separately, merge when ready
+**Coordination**: Track each stream separately, merge when ready. For
+stacked PRs (one depends on another) follow the `/review-pr` skill's
+"Stacked PRs" section to avoid auto-close cascades.
 ```
 
 ### Sequential Execution Pattern
@@ -353,7 +361,7 @@ Before merging, verify:
 ### Quality Gates
 
 - [ ] `uv run poe check` passes
-- [ ] Test coverage maintained (87%+)
+- [ ] Test coverage doesn't regress vs `main` (the project's coverage baseline is still firming up — see [issue #7](https://github.com/dougborg/frontapp-openapi-client/issues/7))
 - [ ] No security vulnerabilities (CodeQL clean)
 - [ ] Documentation updated
 

--- a/.github/agents/python-developer.agent.md
+++ b/.github/agents/python-developer.agent.md
@@ -36,7 +36,7 @@ layer in `FrontappClient`, **not** in individual API methods. This means:
 - Rate limiting is handled transparently
 - Pagination is automatic when using FrontappClient
 
-**Read for details**: `docs/adr/0001-transport-layer-resilience.md`
+**Read for details**: `frontapp_public_api_client/docs/adr/0001-transport-layer-resilience.md`
 
 ### Pydantic Domain Models (ADR-011)
 
@@ -45,7 +45,7 @@ Use Pydantic domain models from `frontapp_public_api_client/domain/` for busines
 
 **Why**: Pydantic provides better validation, serialization, and developer experience.
 
-**Read for details**: `docs/adr/0011-pydantic-domain-models.md`
+**Read for details**: `frontapp_public_api_client/docs/adr/0011-pydantic-domain-models.md`
 
 ### UNSET Sentinel Pattern
 
@@ -109,17 +109,26 @@ async def archive_conversation(
     return {"preview": preview, "confirmed": True}
 ```
 
-### MCP Server Architecture (ADR-010)
+### MCP Server Architecture
 
 When working on `frontapp_mcp_server`:
 
-- **ServerContext Pattern**: Use `get_services()` to access FrontappClient
-- **Tool Organization**: Foundation tools in `foundation/`, workflows in `workflows/`
-- **Resource Management**: Use async context managers
-- **Type-Safe Parameters**: All tool parameters use Pydantic models
-- **Progress Reporting**: Report progress for long-running operations
+- **Services injection**: tools take `context: Context` and call
+  `get_services(context).client` to access the `FrontappClient`. See
+  `frontapp_mcp_server/src/frontapp_mcp/services/dependencies.py`.
+- **Tool organization**: one module per resource under
+  `frontapp_mcp_server/src/frontapp_mcp/tools/<resource>.py`. Each module
+  exports `register_tools(mcp)`. The canonical example is
+  `tools/conversations.py`.
+- **Reads vs mutations**: read-only tools are added to `_READ_ONLY_TOOLS` in
+  `server.py` and cached for 30s by the existing `ResponseCachingMiddleware`.
+  Mutations take `confirm: bool = False` and return a dict with `preview` and
+  `confirmed` keys (see Preview/Confirm Pattern above).
+- **Type-safe parameters**: tool parameters use `Annotated[<type>, Field(...)]`
+  for both validation and LLM-facing descriptions.
 
-**Read for details**: `docs/adr/0010-frontapp-mcp-server.md`
+**Read for details**: see `frontapp_mcp_server/docs/adr/` (the per-package ADR
+directory). A monorepo-level MCP-server ADR is tracked in a follow-up issue.
 
 ## Development Workflow
 
@@ -401,11 +410,23 @@ When you need detailed guidance, use the `read` tool:
 
 ### Architecture Decisions
 
-- `docs/adr/0001-transport-layer-resilience.md` - Resilience patterns
-- `docs/adr/0007-domain-helper-classes.md` - Domain model patterns
-- `docs/adr/0010-frontapp-mcp-server.md` - MCP server architecture
-- `docs/adr/0011-pydantic-domain-models.md` - Pydantic usage
-- `docs/adr/0012-validation-tiers-for-agent-workflows.md` - Validation workflow
+ADRs live per-package: `docs/adr/` is the monorepo level,
+`frontapp_public_api_client/docs/adr/` is the Python client, and
+`frontapp_mcp_server/docs/adr/` is the MCP server.
+
+Highlights:
+
+- `frontapp_public_api_client/docs/adr/0001-transport-layer-resilience.md` — resilience patterns
+- `frontapp_public_api_client/docs/adr/0006-response-unwrapping-utilities.md` — `unwrap_as` / `unwrap` helpers
+- `frontapp_public_api_client/docs/adr/0011-pydantic-domain-models.md` — Pydantic projection pattern
+- `frontapp_public_api_client/docs/adr/0012-validation-tiers-for-agent-workflows.md` — validation tier rationale
+- `frontapp_mcp_server/docs/adr/0016-tool-interface-pattern.md` — MCP tool shape
+- `frontapp_mcp_server/docs/adr/0017-automated-tool-documentation.md` — tool docs pattern
+- `docs/adr/0009-migrate-from-poetry-to-uv.md` — uv dependency manager
+- `docs/adr/0013-module-local-documentation.md` — per-package docs split
+- `docs/adr/0014-github-copilot-custom-agents.md` — Copilot agent format
+
+For the full list, see each `docs/adr/README.md`.
 
 ### Configuration & Tools
 
@@ -449,15 +470,24 @@ Before considering your work complete:
 1. **Preview before destroy** - Use confirm pattern for destructive ops
 1. **Log appropriately** - INFO for user actions, ERROR for failures
 1. **Use Pydantic domain models** - Not generated attrs models
-1. **Coordinate with other agents** - Tag @agent-test, @agent-docs as needed
 1. **Document as you go** - Update docstrings and comments
 
-## Agent Coordination
+## Coordinating with other agents
 
-Work with specialized agents:
+For Claude Code sessions, the harness in `.claude/agents/` and `.claude/skills/`
+provides specialized agents and workflows. Most-used:
 
-- `@agent-test` - Request comprehensive tests for new features
-- `@agent-docs` - Request documentation updates
-- `@agent-review` - Request code review
-- `@agent-plan` - Get implementation plans broken down
-- `@agent-coordinator` - Coordinate multi-agent workflows
+- `vertical-planner` - plan a new resource vertical before writing code
+- `domain-advisor` - one-off factual questions about Front's API surface
+- `code-modernizer` - refactor hand-written code to current patterns
+- `pr-preparer` - branch-readiness check before opening a PR
+- `/new-vertical` skill - end-to-end vertical scaffolding
+- `/review-pr` skill - address PR review comments
+
+For Copilot sessions in this repo, work alongside the other Copilot agent
+files in `.github/agents/` (each is a focused specialist):
+
+- `task-planner.agent.md` - planning and ADR-driven design
+- `tdd-specialist.agent.md` - test-first development with `httpx.MockTransport`
+- `code-reviewer.agent.md` - structured code reviews
+- `documentation-writer.agent.md` - ADRs, MkDocs, cookbook entries

--- a/.github/agents/task-planner.agent.md
+++ b/.github/agents/task-planner.agent.md
@@ -115,14 +115,25 @@ Use project priority labels based on time estimates:
 
 ### 8. Coordinate Agent Handoffs
 
-Specify which agents handle each phase:
+Specify which agent handles each phase. For **Copilot** sessions, the
+`.github/agents/*.agent.md` files are:
 
-- `@agent-dev` - Implementation, bug fixes, refactoring
-- `@agent-test` - Test coverage, debugging, validation
-- `@agent-docs` - Documentation, ADRs, examples
-- `@agent-review` - Code review, quality checks
-- `@agent-devops` - CI/CD, releases, dependencies
-- `@agent-coordinator` - Multi-agent orchestration
+- `python-developer.agent.md` - Implementation, bug fixes, refactoring
+- `tdd-specialist.agent.md` - Test coverage, debugging, validation
+- `documentation-writer.agent.md` - Documentation, ADRs, examples
+- `code-reviewer.agent.md` - Code review, quality checks
+- `ci-cd-specialist.agent.md` - CI/CD, releases, dependencies
+
+For **Claude Code** sessions, the `.claude/` harness provides:
+
+- `vertical-planner` (sub-agent) - Plan a new resource vertical
+- `domain-advisor` (sub-agent) - Read-only API factual oracle
+- `code-modernizer` (sub-agent) - Refactor to current patterns
+- `pr-preparer` (sub-agent) - Branch-readiness check
+- `/new-vertical` (skill) - End-to-end vertical scaffolding
+- `/vendor-and-regen` (skill) - Spec refresh + client regen
+- `/open-pr` / `/review-pr` (skills) - PR lifecycle
+- `/write-tests`, `/generate-docs`, `/review`, `/verify` (skills) - focused tasks
 
 ## Project Context
 
@@ -205,26 +216,36 @@ When you need detailed guidance, use the `read` tool to access:
 
 ## Planning Examples
 
-### Example 1: Sales Order MCP Tools
+### Example 1: Drafts MCP Vertical (issue #14)
 
-**Task**: Implement Sales Order domain tools for MCP server
+**Task**: Ship the drafts vertical — `client.drafts.{create,list,update,delete}`
+plus matching MCP tools.
 
 **Approach**:
 
-1. Review ADR-010 (MCP architecture) for server patterns
-1. Read `guides/plan/PLANNING_PROCESS.md` § "Creating Phased Plans"
-1. Study existing `frontapp_mcp_server/tools/purchase_orders.py` as pattern
+1. Read `frontapp_public_api_client/docs/adr/0011-pydantic-domain-models.md`
+   and `frontapp_mcp_server/docs/adr/0016-tool-interface-pattern.md` for
+   architectural baselines.
+1. Read the canonical templates: `frontapp_public_api_client/helpers/conversations.py`,
+   `frontapp_public_api_client/domain/conversation.py`,
+   `frontapp_mcp_server/src/frontapp_mcp/tools/conversations.py`.
+1. Invoke the `vertical-planner` Claude sub-agent (or do its job manually
+   here): consult `docs/api-facts.yaml` for `tags.drafts.endpoints[]`,
+   record list-shape (`field_results`), helper/domain wiring (`built: false`
+   today), and the inverted-confirm exception (drafts don't take a
+   `confirm` flag — the draft IS the review step).
 1. Create 4-phase plan:
-   - **Phase 1: Foundation** (p2-medium) - list_sales_orders, get_sales_order_details
-     tools
-   - **Phase 2: Core** (p1-high) - create_sales_order, update_sales_order operations
-   - **Phase 3: Enhancements** (p2-medium) - fulfill_order, cancel_order workflow
-     helpers
-   - **Phase 4: Documentation** (p3-low) - cookbook recipes, usage examples
-1. Use `guides/plan/EFFORT_ESTIMATION.md` for p1/p2/p3 labels
-1. Create issues with `guides/plan/ISSUE_TEMPLATES.md` templates
-1. Assign implementation phases to `@agent-dev`
-1. Assign testing to `@agent-test`, docs to `@agent-docs`
+   - **Phase 1: Foundation** (p2-medium) — `Draft` domain + `client.drafts.list/get`
+   - **Phase 2: Core** (p1-high) — `client.drafts.create/update/delete` + MCP tools
+   - **Phase 3: Attachments** (p1-high) — wire-format research (issue #12)
+     before helper code; multipart upload + binary download paths
+   - **Phase 4: Documentation** (p3-low) — cookbook recipe, README coverage row,
+     resources/help.py update
+1. Use `guides/plan/EFFORT_ESTIMATION.md` for p1/p2/p3 labels.
+1. Create issues with `guides/plan/ISSUE_TEMPLATES.md` templates.
+1. Hand the plan to `/new-vertical` (Claude skill) or `python-developer.agent.md`
+   (Copilot agent) for the implementation phases. Tests via `tdd-specialist.agent.md`
+   or `/write-tests`. Docs via `documentation-writer.agent.md` or `/generate-docs`.
 
 ### Example 2: Migration Strategy
 
@@ -246,7 +267,7 @@ When you need detailed guidance, use the `read` tool to access:
    - Type system complexity
    - Performance implications
 1. Create detailed issues with mitigation strategies for each risk
-1. Coordinate with `@agent-review` for migration checklist review
+1. Coordinate with `code-reviewer.agent.md` (or the `/review` skill) for migration checklist review
 
 ## Critical Reminders
 

--- a/.github/agents/tdd-specialist.agent.md
+++ b/.github/agents/tdd-specialist.agent.md
@@ -13,8 +13,8 @@ quality through test-driven development practices.
 
 ## Mission
 
-Write thorough, maintainable tests that verify both success and error paths, achieve
-high coverage (87%+ on core logic), and provide confidence in code correctness.
+Write thorough, maintainable tests that verify both success and error paths, avoid
+regressions in core-logic coverage, and provide confidence in code correctness.
 
 ## Your Expertise
 
@@ -115,29 +115,30 @@ uv run pytest tests/test_specific.py::test_function -v
 
 ### Directory Structure
 
+The test infrastructure is still ramping up
+([issue #7](https://github.com/dougborg/frontapp-openapi-client/issues/7)).
+
+**Today (April 2026):**
+
 ```
 tests/
-├── conftest.py                    # Shared fixtures
-├── test_frontapp_client.py          # Client tests
-├── test_pagination.py             # Pagination tests
-├── test_retry_logic.py            # Retry tests
-├── integration/                   # Integration tests (@pytest.mark.integration)
-│   ├── conftest.py
-│   └── test_api_integration.py
-├── unit/                          # Unit tests
-│   ├── test_domain_models.py
-│   └── test_helpers.py
-└── schema/                        # Schema validation
-    └── test_openapi_validation.py
+├── conftest.py
+└── test_documentation.py             # docs / link validation
 
 frontapp_mcp_server/tests/
 ├── conftest.py
-├── test_server.py
 ├── test_logging.py
-└── tools/
-    ├── test_inventory.py
-    └── test_purchase_orders.py
+├── test_observability_decorators.py
+├── test_package.py
+└── test_unpack.py
 ```
+
+**After #7 lands** the layout will fill out toward the canonical shape — a per-area
+file at the root (`test_unwrap_helpers.py`, `test_pagination.py`,
+`test_retry_logic.py`) plus a per-vertical file (`test_conversations.py`,
+`test_drafts.py`, etc.) and a `frontapp_mcp_server/tests/tools/` subdir mirroring
+`frontapp_mcp_server/src/frontapp_mcp/tools/`. Until then, new tests can land at
+the appropriate root and be reorganized when #7 ships.
 
 ### Test File Naming Conventions
 
@@ -150,37 +151,40 @@ frontapp_mcp_server/tests/
 
 ### AAA Pattern (Arrange-Act-Assert)
 
-```python
-def test_get_product_by_id():
-    # Arrange - Setup test data and conditions
-    client = FrontappClient(api_key="test-key")
-    product_id = "prod_123"
-    expected_name = "Test Product"
-
-    # Act - Execute the code under test
-    product = client.get_product(product_id)
-
-    # Assert - Verify the outcome
-    assert product.id == product_id
-    assert product.name == expected_name
-```
-
-### Async Tests
+Mock at the **httpx transport layer** (via `httpx.MockTransport`) so the
+response-helper logic (`unwrap_as`, status-code dispatch) is exercised
+end-to-end. Don't mock the helper methods directly.
 
 ```python
+import httpx
 import pytest
 
-@pytest.mark.asyncio
-async def test_async_get_products():
-    """Test async product fetching."""
-    async with FrontappClient() as client:
-        response = await list_conversations.asyncio_detailed(
-            client=client,
-            limit=10
-        )
+from frontapp_public_api_client import FrontappClient
 
-        assert response.status_code == 200
-        assert len(response.parsed.data) <= 10
+
+@pytest.mark.asyncio
+async def test_get_conversation_by_id() -> None:
+    # Arrange
+    expected_id = "cnv_abc123"
+    payload = {
+        "id": expected_id,
+        "subject": "Hello",
+        "status": "open",
+        "_links": {"self": f"https://api2.frontapp.com/conversations/{expected_id}"},
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path.endswith(f"/conversations/{expected_id}")
+        return httpx.Response(200, json=payload)
+
+    transport = httpx.MockTransport(handler)
+    async with FrontappClient(api_key="test", transport=transport) as client:
+        # Act
+        conv = await client.conversations.get(expected_id)
+
+        # Assert
+        assert conv.id == expected_id
+        assert conv.subject == "Hello"
 ```
 
 ### Parametrized Tests
@@ -188,83 +192,89 @@ async def test_async_get_products():
 Test multiple scenarios efficiently:
 
 ```python
-@pytest.mark.parametrize("input_sku,expected_valid", [
-    ("VALID-SKU", True),
-    ("invalid", False),
-    ("", False),
-    (None, False),
-])
-def test_sku_validation(input_sku, expected_valid):
-    """Test SKU validation with various inputs."""
-    result = validate_sku(input_sku)
-    assert result == expected_valid
+@pytest.mark.parametrize(
+    "query,expected_path_query",
+    [
+        ("status:open", "status%3Aopen"),
+        ("tag:urgent assignee:me", "tag%3Aurgent+assignee%3Ame"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_list_conversations_query(query, expected_path_query) -> None:
+    """Front search syntax round-trips into the q= parameter."""
+    seen_url: list[httpx.URL] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_url.append(request.url)
+        return httpx.Response(200, json={"_results": [], "_pagination": {}})
+
+    transport = httpx.MockTransport(handler)
+    async with FrontappClient(api_key="test", transport=transport) as client:
+        await client.conversations.list(q=query)
+
+    assert expected_path_query in str(seen_url[0])
 ```
 
 ### Mocking HTTP Requests
 
-Use `httpx.MockTransport` with fixtures from `tests/conftest.py`:
+Pass `transport=httpx.MockTransport(handler)` to the `FrontappClient`
+constructor. The transport replaces the resilient transport stack for the
+test, so calls go straight to your handler:
 
 ```python
+import httpx
+import pytest
+
+from frontapp_public_api_client import FrontappClient
+
+
 @pytest.mark.asyncio
-async def test_get_products_success(frontapp_client_with_mock_transport):
-    """Test successful product retrieval using the mock transport fixture."""
-    # Arrange - fixture provides FrontappClient with MockTransport pre-configured
-    client = frontapp_client_with_mock_transport
+async def test_list_conversations_success() -> None:
+    payload = {
+        "_results": [
+            {
+                "id": "cnv_1",
+                "subject": "Test",
+                "status": "open",
+                "_links": {"self": "https://api2.frontapp.com/conversations/cnv_1"},
+            }
+        ],
+        "_pagination": {},
+    }
 
-    # Act
-    response = await list_conversations.asyncio_detailed(client=client._client)
-
-    # Assert
-    assert response.status_code == 200
-    assert response.parsed is not None
-```
-
-For custom response handlers, create a handler and wire it into a FrontappClient:
-
-```python
-@pytest.mark.asyncio
-async def test_api_with_custom_handler(mock_api_credentials):
-    """Test with a custom mock transport handler."""
-    # Arrange - custom handler returning specific data
     def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, json={"data": [{"id": 1, "name": "Test"}]})
+        return httpx.Response(200, json=payload)
 
     transport = httpx.MockTransport(handler)
-    client = FrontappClient(**mock_api_credentials)
-    client._client._async_client = httpx.AsyncClient(
-        transport=transport, base_url=mock_api_credentials["base_url"]
-    )
+    async with FrontappClient(api_key="test", transport=transport) as client:
+        conversations = await client.conversations.list()
 
-    # Act
-    response = await list_conversations.asyncio_detailed(client=client._client)
-
-    # Assert
-    assert response.status_code == 200
+    assert len(conversations) == 1
+    assert conversations[0].id == "cnv_1"
 ```
 
 ### Testing Error Paths
 
-Always test error scenarios with complete examples:
+`unwrap()` raises typed exceptions on non-success responses. Test against
+the exception class rather than the status code directly:
 
 ```python
+import httpx
+import pytest
+
+from frontapp_public_api_client import FrontappClient
+from frontapp_public_api_client.utils import AuthenticationError
+
+
 @pytest.mark.asyncio
-async def test_api_unauthorized_error(mock_api_credentials):
-    """Test handling of 401 Unauthorized."""
-    # Arrange - handler returning 401
+async def test_get_conversation_unauthorized() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(401, json={"error": "Unauthorized"})
 
     transport = httpx.MockTransport(handler)
-    client = FrontappClient(**mock_api_credentials)
-    client._client._async_client = httpx.AsyncClient(
-        transport=transport, base_url=mock_api_credentials["base_url"]
-    )
-
-    # Act
-    response = await list_conversations.asyncio_detailed(client=client._client)
-
-    # Assert
-    assert response.status_code == 401
+    async with FrontappClient(api_key="bad", transport=transport) as client:
+        with pytest.raises(AuthenticationError):
+            await client.conversations.get("cnv_1")
 ```
 
 ### Testing Edge Cases
@@ -308,14 +318,14 @@ async def async_client():
         yield client
 
 @pytest.fixture
-def mock_product_data():
-    """Provide sample product data."""
+def mock_conversation_data():
+    """Sample conversation payload, shaped like Front's ConversationResponse."""
     return {
-        "id": "prod_123",
-        "name": "Test Product",
-        "sku": "TEST-001",
-        "price": 99.99,
-        "category": "Electronics"
+        "id": "cnv_abc123",
+        "subject": "Re: order question",
+        "status": "open",
+        "is_private": False,
+        "_links": {"self": "https://api2.frontapp.com/conversations/cnv_abc123"},
     }
 
 @pytest.fixture
@@ -331,12 +341,12 @@ def mock_error_response():
 ### Reusable Test Utilities
 
 ```python
-def assert_valid_product(product):
-    """Assert product has required fields with correct types."""
-    assert "id" in product
-    assert "name" in product
-    assert "sku" in product
-    assert isinstance(product.get("price"), (int, float))
+def assert_valid_conversation(conversation):
+    """Assert conversation has required fields per Front's schema."""
+    assert "id" in conversation
+    assert conversation["id"].startswith("cnv_")
+    assert "status" in conversation
+    assert conversation["status"] in {"open", "archived", "deleted", "spam"}
 
 def create_mock_handler(status_code: int, data: dict):
     """Create a mock transport handler returning the given response."""
@@ -349,10 +359,19 @@ def create_mock_handler(status_code: int, data: dict):
 
 ### Target Coverage
 
-- **Core logic**: 87%+ coverage (required)
-- **Helper functions**: 90%+ coverage
-- **Critical paths**: 95%+ coverage
-- **Error handling**: 80%+ coverage
+The project's test infrastructure is still ramping up
+([issue #7](https://github.com/dougborg/frontapp-openapi-client/issues/7)).
+Until that lands and a baseline is set, the coverage gate is **no regression
+vs. main**. Aim for these directional targets when writing new tests:
+
+- **Hand-written core paths** (`helpers/`, `domain/`, `utils.py`,
+  `frontapp_client.py`) — high coverage; touch every public method and the
+  error paths it can raise.
+- **Generated `api/`** — typically not unit-tested directly; covered
+  transitively through helper tests.
+- **Critical paths** (auth, retries, pagination) — exhaustive coverage of
+  success + every typed-exception branch (`AuthenticationError`,
+  `ValidationError`, `RateLimitError`, `ServerError`, `APIError`).
 
 ### Checking Coverage
 
@@ -606,21 +625,27 @@ Tests are often the first place you discover undocumented behavior:
 
 1. **Test before implementing** (TDD approach when possible)
 1. **One test at a time** - Focus on single behavior
-1. **Mock external dependencies** - Don't hit real APIs in unit tests
-1. **Test error paths** - Not just success scenarios
-1. **Achieve 87%+ coverage** - Required for core logic
-1. **Use parallel execution** - Default for speed
-1. **Mark integration tests** - Separate from unit tests
-1. **Provide helpful assertions** - Include failure messages
-1. **Keep tests fast** - Optimize slow tests or mark them
-1. **Improve the system** - Codify discoveries into project docs
+1. **Mock at the transport layer** (`httpx.MockTransport`) - exercises the
+   helper unwrap logic end-to-end; don't hit real APIs in unit tests
+1. **Test error paths** - assert the typed exceptions from `unwrap()`, not
+   just success
+1. **Use parallel execution** - `uv run poe test` runs `-n 4` by default
+1. **Mark integration tests** - separate from unit tests via `@pytest.mark.integration`
+1. **Provide helpful assertions** - include failure messages
+1. **Keep tests fast** - optimize slow tests or mark them
+1. **Improve the system** - codify discoveries into project docs
 
-## Agent Coordination
+## Coordinating with other agents
 
-Work with specialized agents:
+For Claude Code sessions:
 
-- `@agent-dev` - Request code changes to improve testability
-- `@agent-plan` - Get testing requirements in implementation plans
-- `@agent-docs` - Document testing patterns and coverage
-- `@agent-review` - Get test reviews for completeness
-- `@agent-coordinator` - Report on test coverage and CI failures
+- Code change required to make something testable → `code-modernizer` agent
+  or `/new-vertical` skill
+- Implementation plan needed → `vertical-planner` agent
+- Documentation of testing patterns → `/generate-docs` skill
+- Test review → `/review` skill or the `code-reviewer.agent.md` Copilot agent
+
+For Copilot sessions, see the other `.github/agents/*.agent.md` files
+(`python-developer.agent.md`, `code-reviewer.agent.md`,
+`documentation-writer.agent.md`, `task-planner.agent.md`,
+`ci-cd-specialist.agent.md`).


### PR DESCRIPTION
## Summary

Phase C of #17. Surgical cleanup of all six Copilot agent files in \`.github/agents/\` plus two Claude sub-agent files, removing StatusPro-template residue, phantom \`@agent-*\` references, and outdated coverage targets.

## Scope of cleanup

### Real bugs fixed

- **\`python-developer.agent.md\` ADR paths**: cited \`docs/adr/0001-...\`, \`docs/adr/0011-...\` but those ADRs live at \`frontapp_public_api_client/docs/adr/...\` (per the per-package split in ADR-0013). Two ADRs cited (\`0007-domain-helper-classes\`, \`0010-frontapp-mcp-server\`) don't exist at all — replaced the MCP-architecture section with concrete current-state guidance and filed a follow-up to write the missing ADRs.
- **\`spec-auditor.md\` pagination claim**: said list endpoints wrap data in \`{"data": [...], "meta": {...}}\` (page/per_page). That's StatusPro's pagination model. Front uses cursor-based with \`_results\` (renamed \`field_results\`) and \`_pagination.next\` URLs. Replaced with a pointer at \`docs/api-facts.yaml\` for the per-endpoint shape.
- **\`spec-auditor.md\` raw-array examples**: cited \`/statuses\` and \`/orders/{id}/viable-statuses\` — neither exists in Front's API. Removed.
- **All \`generate-pydantic\` references** (in \`spec-auditor.md\`, \`pr-preparer.md\`): the task doesn't exist. Dropped; replaced with the actual \`regenerate-all\` pipeline that chains \`vendor-spec → regenerate-client → facts\`.

### Stale content removed/updated

- **Phantom \`@agent-dev\`/\`@agent-test\`/\`@agent-docs\`/\`@agent-review\`/\`@agent-plan\`/\`@agent-coordinator\` references** in 5 files. None of these agents exist in this repo — they're inherited from the StatusPro template. Replaced with the actually-existing \`.claude/agents/\` sub-agents (\`vertical-planner\`, \`domain-advisor\`, \`code-modernizer\`, \`pr-preparer\`, \`spec-auditor\`), \`.claude/skills/\` workflows, and \`.github/agents/*.agent.md\` Copilot agent filenames (which correspond to real \`@\`-mentions: \`@python-developer\`, \`@tdd-specialist\`, etc.).
- **StatusPro example code** in \`code-reviewer\` (products, get_product, sales_orders), \`tdd-specialist\` (test_purchase_orders.py, get_products fixtures, mock_product_data, assert_valid_product), \`task-planner\` (Sales Order example) — replaced with Front domain equivalents (conversations, list + unwrap, drafts vertical example).
- **Hardcoded 87% coverage gate** in \`pr-preparer\`, \`tdd-specialist\`, \`project-coordinator\` — softened to "no regression vs \`main\`" until #7 ships real test infrastructure and a baseline.
- **\`tdd-specialist\` test patterns** updated: error path now asserts on \`AuthenticationError\` from \`unwrap()\` instead of \`response.status_code == 401\`. Mock-transport pattern uses \`FrontappClient(transport=httpx.MockTransport(...))\` instead of poking at \`client._client._async_client\` internals.

### Intentionally kept

\`@python-developer\`, \`@tdd-specialist\`, \`@code-reviewer\`, \`@documentation-writer\`, \`@task-planner\`, \`@ci-cd-specialist\`, \`@project-coordinator\` references in \`project-coordinator.agent.md\` — these correspond to actually-existing \`.github/agents/*.agent.md\` files and are valid Copilot \`@\`-mentions.

## Verification

- \`uv run poe agent-check\` green (format + ruff + ty + facts-check)
- All 9 files validated for prettier compliance
- No remaining \`@agent-dev|test|docs|review|plan|coordinator\` references in any Copilot agent file
- No remaining \`generate-pydantic\` references anywhere

## Stack

Independent of #29 (CLAUDE.md + AGENT_WORKFLOW cleanup). Both target \`main\`.

## Follow-up issues (filing separately)

- Write missing ADRs 0007 (domain helper classes) and 0010 (MCP server) — currently referenced from agent files but don't exist
- Deeper content rewrite for \`project-coordinator.agent.md\` and \`task-planner.agent.md\` — both still describe coordination patterns that don't quite match the current Claude+Copilot dual-harness reality. This PR removes the worst contamination but doesn't reshape the prose
- Audit \`domain/base.py\` — \`FrontappBaseModel\` is exported but not actually used by any domain class (\`Conversation\` doesn't extend it). Module docstring still describes the project as "Frontapp Manufacturing ERP" (StatusPro residue). Either use it, delete it, or fix the docstring

🤖 Generated with [Claude Code](https://claude.com/claude-code)