### PR TITLE
chore(harness): consolidate generated-file globs into shared lib (#25)

### DIFF
--- a/.claude/hooks/_lib/generated-paths.sh
+++ b/.claude/hooks/_lib/generated-paths.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Single source of truth for generated/vendored file globs.
+#
+# Sourced by .claude/hooks/block-generated-edits.sh (defense PreToolUse) and
+# .claude/hooks/format-on-edit.sh (no-op skip in PostToolUse). Adding a new
+# generated path means changing it once, here.
+#
+# Keep in sync with the "GENERATED — DO NOT EDIT" row of CLAUDE.md → File Rules.
+# CI itself doesn't enforce sync — the prose row is for humans, this list is
+# for hooks — but a stale CLAUDE.md row drifting from this list is the exact
+# problem this consolidation prevents going forward.
+
+# is_generated_path PATH
+# Returns 0 if PATH matches a generated or vendored file, 1 otherwise.
+is_generated_path() {
+  case "$1" in
+    */frontapp_public_api_client/api/*.py | \
+    */frontapp_public_api_client/api/*/*.py | \
+    */frontapp_public_api_client/models/*.py | \
+    */frontapp_public_api_client/client.py | \
+    */frontapp_public_api_client/client_types.py | \
+    */frontapp_public_api_client/errors.py | \
+    */docs/frontapp-openapi.yaml | \
+    */docs/api-facts.yaml | \
+    */packages/frontapp-client/src/generated/* | \
+    */packages/frontapp-client/src/generated/*/*)
+      return 0
+      ;;
+  esac
+  return 1
+}

--- a/.claude/hooks/block-generated-edits.sh
+++ b/.claude/hooks/block-generated-edits.sh
@@ -2,10 +2,14 @@
 # PreToolUse hook: block Edit/Write/MultiEdit on openapi-python-client generated files.
 #
 # Reads Claude Code's hook payload from stdin (JSON with tool_input.file_path),
-# matches against the generated-file globs from CLAUDE.md "File Rules", and exits
-# with status 2 to block the call. The stderr message is shown to the agent.
+# matches against the shared generated-path globs (.claude/hooks/_lib/generated-paths.sh),
+# and exits with status 2 to block the call. The stderr message is shown to the agent.
 
 set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_lib/generated-paths.sh
+source "${script_dir}/_lib/generated-paths.sh"
 
 input=$(cat)
 
@@ -22,16 +26,8 @@ if [[ -z "$file_path" ]]; then
   exit 0
 fi
 
-case "$file_path" in
-  */frontapp_public_api_client/api/*.py | \
-  */frontapp_public_api_client/api/*/*.py | \
-  */frontapp_public_api_client/models/*.py | \
-  */frontapp_public_api_client/client.py | \
-  */frontapp_public_api_client/client_types.py | \
-  */frontapp_public_api_client/errors.py | \
-  */docs/frontapp-openapi.yaml | \
-  */docs/api-facts.yaml)
-    cat >&2 <<EOF
+if is_generated_path "$file_path"; then
+  cat >&2 <<EOF
 STOP — "$file_path" is a generated or vendored file.
 
 Do not edit it directly. To change it, edit the source and regenerate:
@@ -45,6 +41,9 @@ Do not edit it directly. To change it, edit the source and regenerate:
                              (patch sanitization rules in scripts/vendor_spec.py)
   • docs/api-facts.yaml    ↳ machine-derived agent knowledge index
                              uv run poe facts
+  • packages/frontapp-client/src/generated/
+                           ↳ hey-api TypeScript client output
+                             pnpm --filter frontapp-client generate
 
 For ergonomic wrappers around generated endpoints, edit hand-written modules:
   frontapp_public_api_client/helpers/<resource>.py
@@ -53,8 +52,7 @@ For ergonomic wrappers around generated endpoints, edit hand-written modules:
 
 See CLAUDE.md → "Known Pitfalls" → "Editing generated files".
 EOF
-    exit 2
-    ;;
-esac
+  exit 2
+fi
 
 exit 0

--- a/.claude/hooks/format-on-edit.sh
+++ b/.claude/hooks/format-on-edit.sh
@@ -11,6 +11,10 @@
 
 set -uo pipefail
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_lib/generated-paths.sh
+source "${script_dir}/_lib/generated-paths.sh"
+
 input=$(cat)
 
 file_path=$(python3 -c '
@@ -35,14 +39,13 @@ fi
 
 # Don't try to format generated/vendored output (edits there are blocked
 # by block-generated-edits.sh anyway; defense in depth).
+if is_generated_path "$file_path"; then
+  exit 0
+fi
+
+# Build/cache directories — never format these (large, and not source).
 case "$file_path" in
-  */frontapp_public_api_client/api/* | \
-    */frontapp_public_api_client/models/* | \
-    */frontapp_public_api_client/client.py | \
-    */frontapp_public_api_client/client_types.py | \
-    */frontapp_public_api_client/errors.py | \
-    */docs/frontapp-openapi.yaml | \
-    */node_modules/* | \
+  */node_modules/* | \
     */.venv/* | \
     */dist/* | \
     */build/*)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,7 +215,9 @@ etc. Bearer auth on every endpoint.
 
 The `.claude/hooks/block-generated-edits.sh` PreToolUse hook enforces the generated-file
 boundary; an attempted Edit/Write/MultiEdit on any file in the "DO NOT EDIT" row exits 2
-with regen-flow guidance.
+with regen-flow guidance. The canonical glob list lives in
+`.claude/hooks/_lib/generated-paths.sh` and is shared with `format-on-edit.sh` — adding
+a new generated path means changing it once.
 
 | Regenerate                | Command                                | Time    |
 | ------------------------- | -------------------------------------- | ------- |


### PR DESCRIPTION
## Summary

- New `.claude/hooks/_lib/generated-paths.sh` exposes an `is_generated_path()` function — single source of truth for the generated/vendored glob list.
- `block-generated-edits.sh` and `format-on-edit.sh` both source it via `BASH_SOURCE`-relative path (works even when `CLAUDE_PROJECT_DIR` isn't set).
- `CLAUDE.md` "File Rules" now points at the shared script as the authoritative enforcement list.

## Drift caught while doing this

`packages/frontapp-client/src/generated/**` is listed in `CLAUDE.md` as generated but was **missing** from both hooks. Added to the shared list — TypeScript codegen output is now properly blocked from edits and skipped by the formatter, matching the documented contract.

## Test plan

- [x] `uv run poe check` — ruff format, prettier, ruff check, ty, yamllint, pytest, api-facts check all pass
- [x] Smoke-tested all four cases:
  - generated `.py` path → block exits 2 ✅
  - hand-written `.py` path → block exits 0 ✅
  - generated `.ts` path → block exits 2 ✅ (NEW)
  - generated `.py` path → format hook skips silently ✅
- [x] CI green

Closes #25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)