### PR TITLE
chore: sweep StatusPro residue from user-facing docs (#35)

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -107,7 +107,7 @@ All formatting is automated via `uv run poe format`.
    git commit -m "feat(client): add new domain helper"
 
    # For MCP server changes
-   git commit -m "feat(mcp): add inventory tool"
+   git commit -m "feat(mcp): add tags reference resource"
    ```
 
 1. **Push to your fork** and create a pull request
@@ -131,10 +131,10 @@ for monorepo versioning:
 
 ```bash
 # Release client package
-git commit -m "feat(client): add Products domain helper"
+git commit -m "feat(client): add Contacts domain helper"
 
 # Release MCP server package
-git commit -m "feat(mcp): implement check_inventory tool"
+git commit -m "feat(mcp): implement reply_to_conversation tool"
 
 # No release (documentation only)
 git commit -m "docs: update README with new examples"

--- a/docs/MONOREPO_SEMANTIC_RELEASE.md
+++ b/docs/MONOREPO_SEMANTIC_RELEASE.md
@@ -21,7 +21,7 @@ released:
 Commits affecting the main client:
 
 ```bash
-feat(client): add new Products helper methods
+feat(client): add Contacts helper methods
 fix(client): resolve pagination edge case
 perf(client): optimize retry backoff algorithm
 ```
@@ -38,8 +38,8 @@ fix: handle 429 rate limits correctly
 Commits affecting the MCP server:
 
 ```bash
-feat(mcp): add inventory tools
-fix(mcp): correct stock level calculation
+feat(mcp): add tags reference resource
+fix(mcp): correct two-step confirm for reply tool
 docs(mcp): update usage examples
 ```
 
@@ -195,15 +195,15 @@ git push origin mcp-v0.1.1
 ### Example 1: Release MCP Server Only
 
 ```bash
-# On branch: feature/add-inventory-tools
-git add frontapp_mcp_server/src/frontapp_mcp/tools/inventory.py
-git commit -m "feat(mcp): implement check_inventory tool
+# On branch: feature/add-tags-tools
+git add frontapp_mcp_server/src/frontapp_mcp/tools/tags.py
+git commit -m "feat(mcp): implement tags management tools
 
-- Add CheckInventoryRequest and StockInfo models
-- Implement tool using Products domain helper
+- Add create_tag and update_tag with two-step confirm
+- Wire elicitation for destructive operations
 - Add comprehensive unit tests"
 
-git push origin feature/add-inventory-tools
+git push origin feature/add-tags-tools
 # Create PR, merge to main
 # → Triggers MCP release (e.g., 0.1.0a1 → 0.2.0a1)
 ```
@@ -211,15 +211,15 @@ git push origin feature/add-inventory-tools
 ### Example 2: Release Client Only
 
 ```bash
-# On branch: feature/domain-helpers
-git add frontapp_public_api_client/helpers/products.py
-git commit -m "feat(client): add Products domain helper class
+# On branch: feature/contacts-helper
+git add frontapp_public_api_client/helpers/contacts.py
+git commit -m "feat(client): add Contacts domain helper class
 
-- Implement CRUD operations
-- Add search and filtering methods
+- Implement list/get/create/update operations
+- Add handle-lookup methods
 - Full test coverage"
 
-git push origin feature/domain-helpers
+git push origin feature/contacts-helper
 # Create PR, merge to main
 # → Triggers client release (e.g., 0.23.0 → 0.24.0)
 ```
@@ -228,14 +228,14 @@ git push origin feature/domain-helpers
 
 ```bash
 # First commit for client
-git add frontapp_public_api_client/helpers/inventory.py
-git commit -m "feat(client): add Inventory domain helper"
+git add frontapp_public_api_client/helpers/contacts.py
+git commit -m "feat(client): add Contacts domain helper"
 
 # Second commit for MCP
-git add frontapp_mcp_server/src/frontapp_mcp/tools/inventory.py
-git commit -m "feat(mcp): add inventory tools using new helper"
+git add frontapp_mcp_server/src/frontapp_mcp/tools/contacts.py
+git commit -m "feat(mcp): add contacts tools using new helper"
 
-git push origin feature/inventory-support
+git push origin feature/contacts-support
 # Create PR, merge to main
 # → Triggers BOTH releases independently
 ```

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -21,8 +21,8 @@ git commit -m "fix(client): resolve pagination edge case"
 ### For MCP Server Releases
 
 ```bash
-git commit -m "feat(mcp): add inventory tools"
-git commit -m "fix(mcp): correct stock level calculation"
+git commit -m "feat(mcp): add tags management tools"
+git commit -m "fix(mcp): correct two-step confirm for reply tool"
 ```
 
 ### No Release Needed
@@ -60,14 +60,14 @@ Both jobs run **in parallel** and are **completely independent**.
 
 ### Version Bumps
 
-| Commit Type                       | Example                         | Version Bump                   |
-| --------------------------------- | ------------------------------- | ------------------------------ |
-| `feat(scope):`                    | `feat(mcp): add search tool`    | MINOR (0.1.0 → 0.2.0)          |
-| `fix(scope):`                     | `fix(client): resolve auth bug` | PATCH (0.1.0 → 0.1.1)          |
-| `perf(scope):`                    | `perf(mcp): optimize queries`   | PATCH (0.1.0 → 0.1.1)          |
-| `feat(scope)!:` or Breaking       | `feat(client)!: redesign API`   | MAJOR (0.1.0 → 1.0.0)          |
-| Other (`docs:`, `chore:`, `test`) | `docs(mcp): update README`      | NO BUMP                        |
-| `feat:` (no scope)                | `feat: add pagination`          | Client MINOR (0.23.0 → 0.24.0) |
+| Commit Type                       | Example                                    | Version Bump                   |
+| --------------------------------- | ------------------------------------------ | ------------------------------ |
+| `feat(scope):`                    | `feat(mcp): add search_conversations tool` | MINOR (0.1.0 → 0.2.0)          |
+| `fix(scope):`                     | `fix(client): resolve auth bug`            | PATCH (0.1.0 → 0.1.1)          |
+| `perf(scope):`                    | `perf(mcp): optimize queries`              | PATCH (0.1.0 → 0.1.1)          |
+| `feat(scope)!:` or Breaking       | `feat(client)!: redesign API`              | MAJOR (0.1.0 → 1.0.0)          |
+| Other (`docs:`, `chore:`, `test`) | `docs(mcp): update README`                 | NO BUMP                        |
+| `feat:` (no scope)                | `feat: add pagination`                     | Client MINOR (0.23.0 → 0.24.0) |
 
 ## Commit Message Format
 
@@ -88,23 +88,23 @@ Follow [Conventional Commits](https://www.conventionalcommits.org/) with scopes:
 **Client Package Release:**
 
 ```bash
-feat(client): add Products domain helper class
+feat(client): add Contacts domain helper class
 
-- Implement CRUD operations
-- Add search and filtering methods
+- Implement list/get/create/update operations
+- Add handle-lookup methods
 - Full test coverage
 ```
 
 **MCP Server Release:**
 
 ```bash
-feat(mcp): implement check_inventory tool
+feat(mcp): implement reply_to_conversation tool
 
-- Add CheckInventoryRequest and StockInfo models
-- Implement tool using Products domain helper
+- Add ReplyRequest model with two-step confirm
+- Wire to ctx.elicit for explicit user approval
 - Add comprehensive unit tests
 
-Closes #35
+Closes #14
 ```
 
 **Breaking Change (Major Version):**

--- a/frontapp_mcp_server/docs/LOGGING.md
+++ b/frontapp_mcp_server/docs/LOGGING.md
@@ -8,8 +8,8 @@ capabilities.
 
 - **Structured JSON or text output** - Choose between JSON (for log aggregation) or
   human-readable text format
-- **Contextual information** - Every log includes relevant context (tool names, SKUs,
-  IDs, etc.)
+- **Contextual information** - Every log includes relevant context (tool names,
+  conversation IDs, recipient handles, etc.)
 - **Performance metrics** - Automatic duration tracking for all tool executions
 - **Trace IDs** - Support for request correlation across operations
 - **Security** - Automatic redaction of sensitive data (API keys, passwords,
@@ -50,13 +50,15 @@ frontapp-mcp-server
 
 ### JSON Format Example
 
+The `@observe_tool` decorator emits a paired `tool_invoked` / `tool_completed` event for
+every tool call (or `tool_failed` on exception). A successful completion looks like:
+
 ```json
 {
-  "event": "tool_executed",
-  "tool_name": "search_items",
-  "query": "widget",
-  "result_count": 15,
+  "event": "tool_completed",
+  "tool_name": "list_conversations",
   "duration_ms": 245.67,
+  "success": true,
   "timestamp": "2025-01-05T17:08:40.123456Z",
   "level": "info"
 }
@@ -65,7 +67,7 @@ frontapp-mcp-server
 ### Text Format Example
 
 ```
-2025-01-05 17:08:40 [info     ] tool_executed         tool_name=search_items query=widget result_count=15 duration_ms=245.67
+2025-01-05 17:08:40 [info     ] tool_completed         tool_name=list_conversations duration_ms=245.67 success=True
 ```
 
 ## Logged Events
@@ -107,41 +109,41 @@ frontapp-mcp-server
 
 ### Tool Execution
 
-**Inventory Check (Success):**
+**Get Conversation (Success):**
 
 ```json
 {
-  "event": "order_status_updated",
-  "sku": "WIDGET-001",
-  "product_name": "Widget Pro",
-  "available_stock": 100,
-  "committed": 30,
+  "event": "tool_completed",
+  "tool_name": "get_conversation",
+  "conversation_id": "cnv_abc123",
+  "status": "open",
   "duration_ms": 123.45,
   "level": "info"
 }
 ```
 
-**Search Items (Success):**
+**List Conversations (Success):**
 
 ```json
 {
-  "event": "item_search_completed",
-  "query": "widget",
+  "event": "tool_completed",
+  "tool_name": "list_conversations",
+  "query": "status:open tag:urgent",
   "result_count": 15,
   "duration_ms": 245.67,
   "level": "info"
 }
 ```
 
-**Create Item (Success):**
+**Reply to Conversation (Success):**
 
 ```json
 {
-  "event": "item_create_completed",
-  "item_type": "product",
-  "item_id": 123,
-  "name": "Widget Pro",
-  "sku": "WGT-PRO-001",
+  "event": "tool_completed",
+  "tool_name": "reply_to_conversation",
+  "conversation_id": "cnv_abc123",
+  "author_id": "tea_xyz",
+  "status_code": 202,
   "duration_ms": 567.89,
   "level": "info"
 }
@@ -153,10 +155,11 @@ frontapp-mcp-server
 
 ```json
 {
-  "event": "item_search_failed",
-  "query": "invalid",
+  "event": "tool_failed",
+  "tool_name": "list_conversations",
+  "query": "invalid:syntax",
   "error": "Invalid search query",
-  "error_type": "ValueError",
+  "error_type": "ValidationError",
   "duration_ms": 12.34,
   "level": "error",
   "exception": "Traceback (most recent call last)..."
@@ -214,16 +217,17 @@ All tool executions include performance metrics:
 
 - **`duration_ms`** - Time taken to execute the tool (in milliseconds)
 - **`result_count`** - Number of items returned (for search/list operations)
-- **`threshold`** - Configured threshold (for low stock checks)
+- **`limit`** - Page size requested (for paginated list operations)
 
 Example with metrics:
 
 ```json
 {
-  "event": "low_stock_search_completed",
-  "threshold": 10,
-  "total_count": 25,
-  "returned_count": 25,
+  "event": "tool_completed",
+  "tool_name": "search_conversations",
+  "query": "status:open assignee:me",
+  "limit": 25,
+  "result_count": 25,
   "duration_ms": 678.9,
   "level": "info"
 }

--- a/frontapp_mcp_server/docs/development.md
+++ b/frontapp_mcp_server/docs/development.md
@@ -331,7 +331,7 @@ uv run poe check         # Full validation (lint + test + format)
 # Good: Helps debug issues
 logger.info(f"Updating status for conversation {conversation_id}")
 logger.debug(f"Client config: base_url={client.base_url}, timeout={client.timeout}")
-logger.warning(f"SKU not found: {request.sku}, returning empty stock")
+logger.warning(f"Conversation not found: {conversation_id}, returning empty result")
 
 # Bad: Not helpful
 logger.info("Doing a thing")

--- a/frontapp_mcp_server/docs/docker.md
+++ b/frontapp_mcp_server/docs/docker.md
@@ -197,8 +197,10 @@ We recommend the **Docker-built** option because:
 
 ```yaml
 name: frontapp-mcp-server
-title: Frontapp Manufacturing ERP
-description: MCP server for interacting with Frontapp Manufacturing ERP API
+title: Frontapp MCP Server
+description:
+  MCP server for the Front customer-communication API (conversations, messages, tags,
+  inboxes, teammates)
 repository: https://github.com/dougborg/frontapp-openapi-client
 dockerfile_path: frontapp_mcp_server/Dockerfile
 version: 0.1.0
@@ -206,12 +208,12 @@ license: MIT
 author: Doug Borg
 tags:
   - conversations
-  - erp
-  - statuses
-  - conversations
+  - messaging
+  - customer-support
+  - shared-inbox
 categories:
   - business
-  - conversations
+  - communications
 build_type: docker-built # Docker will build and maintain
 ```
 

--- a/frontapp_mcp_server/src/frontapp_mcp/__main__.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/__main__.py
@@ -23,7 +23,10 @@ from frontapp_mcp.server import main
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description="Frontapp MCP Server - Manufacturing ERP tools for AI assistants"
+        description=(
+            "Frontapp MCP Server — Front API tools for AI assistants "
+            "(conversations, messages, tags, inboxes, teammates)"
+        )
     )
     parser.add_argument(
         "--transport",

--- a/frontapp_mcp_server/src/frontapp_mcp/logging.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/logging.py
@@ -19,7 +19,7 @@ Example Usage:
     from frontapp_mcp.logging import get_logger
 
     logger = get_logger()
-    logger.info("tool_executed", tool_name="search_items", result_count=15)
+    logger.info("tool_completed", tool_name="list_conversations", result_count=15)
 """
 
 from __future__ import annotations

--- a/packages/frontapp-client/tests/errors.test.ts
+++ b/packages/frontapp-client/tests/errors.test.ts
@@ -77,8 +77,8 @@ describe('Error Classes', () => {
 
     it('should store validation details', () => {
       const details = [
-        { field: 'name', message: 'Name is required' },
-        { field: 'sku', message: 'SKU must be unique', code: 'unique' },
+        { field: 'subject', message: 'Subject is required' },
+        { field: 'tags', message: 'Tag ID must be unique', code: 'unique' },
       ];
       const error = new ValidationError('Validation failed', { details });
       expect(error.details).toEqual(details);


### PR DESCRIPTION
## Summary

Triage the StatusPro-template grep across the codebase. Rewrote each match in user-facing surfaces to Front-domain framing/examples.

### Changes

- **`frontapp_mcp/__main__.py`** — argparse description was "Manufacturing ERP tools for AI assistants" → now describes Front API tool surface.
- **`mcp_server/docs/docker.md`** — Docker MCP submission YAML had `title: Frontapp Manufacturing ERP` + matching description and `erp`/`statuses` tags. Replaced with Front-correct title, description, and `customer-support` / `shared-inbox` tags.
- **`docs/CONTRIBUTING.md`, `docs/RELEASE.md`, `docs/MONOREPO_SEMANTIC_RELEASE.md`** — every commit-message and example referenced `inventory`/`Products`/`SKUs`/`manufacturing`; replaced with Front-domain examples (`tags`, `contacts`, `reply_to_conversation`, `search_conversations`).
- **`mcp_server/docs/LOGGING.md`** — every JSON log example was inventory-flavored. Replaced with conversation-flavored examples so readers learning the logging shape don't get confusing precedent.
- **`mcp_server/docs/development.md:334`** — "SKU not found" warning → "Conversation not found".
- **`packages/frontapp-client/tests/errors.test.ts`** — 422 validation-detail test used `field: 'sku'` as a generic name; switched to `subject` and `tags`.

### Out of scope (filed as #39)

`.github/agents/guides/`, `.github/instructions/`, `.github/prompts/`, parts of `.github/copilot-instructions.md` — inherited Copilot-style harness with extensive `@agent-X` / inventory / manufacturing residue. Several orders of magnitude larger than this sweep, and the keep-vs-delete decision is strategic. Tracked separately.

### Kept (legitimate Front-domain usage)

- `cookbook.md` examples showing "shipped from secondary warehouse" as a customer-service reply body — that's a realistic Front conversation, not StatusPro residue.
- `docs/FRONTAPP_API_ENDPOINTS.md` — "This inventory was imported..." uses "inventory" in the catalog sense, not StatusPro.
- `frontapp_public_api_client/domain/base.py` — already deleted in PR #36.

## Test plan

- [x] `uv run poe check` — ruff format, prettier, ruff check, ty, yamllint, pytest, api-facts check all pass
- [x] `pnpm test --run tests/errors.test.ts` — 21/21 pass
- [x] `git grep` shows no StatusPro framing in user-facing docs/READMEs (the remaining hits are in `.github/` per #39 or are legitimate Front-domain usage as noted above)
- [x] CI green

Closes #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)