### PR TITLE
perf(harness): use direct prettier binary instead of pnpm exec (#26)

### DIFF
--- a/.claude/hooks/format-on-edit.sh
+++ b/.claude/hooks/format-on-edit.sh
@@ -2,7 +2,7 @@
 # PostToolUse hook: silently format files after Edit/Write/MultiEdit succeeds.
 #
 # - *.py  → ruff check --fix && ruff format (one `uv run` to amortize startup)
-# - *.md  → pnpm exec prettier --write
+# - *.md  → ./node_modules/.bin/prettier --write (direct binary, skips pnpm shim)
 #
 # Zero-token on success. Never blocks (exit 0 even when the formatter exits
 # non-zero) — formatting failures must not undo a successful edit. PostToolUse
@@ -70,8 +70,10 @@ case "$file_path" in
     fi
     ;;
   *.md)
-    if command -v pnpm >/dev/null 2>&1; then
-      pnpm exec prettier --write --log-level=silent "$file_path" \
+    # Direct binary skips pnpm + node-shim startup (~250-400ms saved per edit).
+    # See issue #26.
+    if [[ -x ./node_modules/.bin/prettier ]]; then
+      ./node_modules/.bin/prettier --write --log-level=silent "$file_path" \
         >/dev/null 2>&1 || true
     fi
     ;;

--- a/docs/api-facts.yaml
+++ b/docs/api-facts.yaml
@@ -17,8 +17,8 @@
 #      domain wiring status, full path/method/response info).
 #
 schema_version: 1
-generated_at: '2026-04-26T04:57:14+00:00'
-generated_from_commit: fdcd666378fa8348c8bfde721c9e7d38cb34d16a
+generated_at: '2026-04-26T14:32:23+00:00'
+generated_from_commit: 83e48da725104198a3058ddf101704b2f9d27525
 summary:
   list_endpoints_with_field_results:
     - accounts.list_account_contacts
@@ -77,12 +77,6 @@ summary:
     - shifts.list_teammate_shifts
     - signatures.list_team_signatures
     - signatures.list_teammate_signatures
-    - tags.list_company_tags
-    - tags.list_tag_children
-    - tags.list_tagged_conversations
-    - tags.list_tags
-    - tags.list_team_tags
-    - tags.list_teammate_tags
     - teammate_groups.list_company_teammate_group_team_inboxes
     - teammate_groups.list_company_teammate_group_teammates
     - teammate_groups.list_company_teammate_group_teams
@@ -198,13 +192,6 @@ summary:
     - signatures.create_teammate_signature
     - signatures.delete_signature
     - signatures.update_signature
-    - tags.create_child_tag
-    - tags.create_company_tag
-    - tags.create_tag
-    - tags.create_team_tag
-    - tags.create_teammate_tag
-    - tags.delete_tag
-    - tags.update_a_tag
     - teammate_groups.add_company_teammate_group_team_inboxes
     - teammate_groups.add_company_teammate_group_teammates
     - teammate_groups.add_company_teammate_group_teams
@@ -238,7 +225,6 @@ summary:
     - knowledge_bases.get_a_knowledge_base_with_content_in_default_locale
     - knowledge_bases.get_a_knowledge_base_with_content_in_specified_locale
     - links.update_a_link
-    - tags.update_a_tag
     - teammate_groups.update_a_company_teammate_group
   tags_with_helper:
     - conversations
@@ -1725,104 +1711,6 @@ tags:
         response_type: Any
         list_shape: raw_array
         category: list
-  tags:
-    spec_tag: Tags
-    api_dir: frontapp_public_api_client/api/tags
-    helper:
-      built: false
-      path: null
-      class: null
-    domain:
-      built: false
-      path: null
-      class: null
-    endpoints:
-      - module: create_child_tag
-        method: POST
-        path: /tags/{tag_id}/children
-        response_type: TagResponse
-        list_shape: mutation
-        category: create
-      - module: create_company_tag
-        method: POST
-        path: /company/tags
-        response_type: TagResponse
-        list_shape: mutation
-        category: create
-      - module: create_tag
-        method: POST
-        path: /tags
-        response_type: TagResponse
-        list_shape: mutation
-        category: create
-      - module: create_team_tag
-        method: POST
-        path: /teams/{team_id}/tags
-        response_type: TagResponse
-        list_shape: mutation
-        category: create
-      - module: create_teammate_tag
-        method: POST
-        path: /teammates/{teammate_id}/tags
-        response_type: TagResponse
-        list_shape: mutation
-        category: create
-      - module: delete_tag
-        method: DELETE
-        path: /tags/{tag_id}
-        response_type: Any
-        list_shape: mutation
-        category: delete
-      - module: get_tag
-        method: GET
-        path: /tags/{tag_id}
-        response_type: TagResponse
-        list_shape: single
-        category: get
-      - module: list_company_tags
-        method: GET
-        path: /company/tags
-        response_type: ListCompanyTagsResponse200
-        list_shape: field_results
-        category: list
-      - module: list_tag_children
-        method: GET
-        path: /tags/{tag_id}/children
-        response_type: ListTagChildrenResponse200
-        list_shape: field_results
-        category: list
-      - module: list_tagged_conversations
-        method: GET
-        path: /tags/{tag_id}/conversations
-        response_type: ListTaggedConversationsResponse200
-        list_shape: field_results
-        category: list
-      - module: list_tags
-        method: GET
-        path: /tags
-        response_type: ListTagsResponse200
-        list_shape: field_results
-        category: list
-      - module: list_team_tags
-        method: GET
-        path: /teams/{team_id}/tags
-        response_type: ListTeamTagsResponse200
-        list_shape: field_results
-        category: list
-      - module: list_teammate_tags
-        method: GET
-        path: /teammates/{teammate_id}/tags
-        response_type: ListTeammateTagsResponse200
-        list_shape: field_results
-        category: list
-      - module: update_a_tag
-        method: PATCH
-        path: /tags/{tag_id}
-        response_type: Any
-        list_shape: mutation
-        category: update
-        quirks:
-          - _a_infix
   teammate_groups:
     spec_tag: Teammate Groups
     api_dir: frontapp_public_api_client/api/teammate_groups


### PR DESCRIPTION
## Summary

`.claude/hooks/format-on-edit.sh` ran `pnpm exec prettier --write` on every `*.md` edit, which paid pnpm's node-startup overhead (~310ms in this env) before prettier itself loaded. Switching to the direct `./node_modules/.bin/prettier` shim skips that.

This is **option 2** from #26 — the zero-infrastructure recommendation. Option 1 (prettierd) remains the path to <100ms but is out of scope here.

## Benchmark

Measured on darwin/arm64, formatting `frontapp_mcp_server/docs/LOGGING.md` through the full hook payload (`echo '{"tool_input":{"file_path":"…"}}' | bash .claude/hooks/format-on-edit.sh`), 5+ runs, best of:

| variant                            | wall time |
| ---------------------------------- | --------- |
| before (`pnpm exec prettier`)      | ~510ms    |
| after  (`./node_modules/.bin/prettier`) | ~200ms    |

Net: **~310ms saved per .md edit**. Doesn't hit the issue's <100ms target — node startup + prettier load itself is ~150ms here, which only prettierd can amortize. Closes the issue's intended scope (option 2 first; revisit prettierd if needed).

## Changes

- `.claude/hooks/format-on-edit.sh`: replace `pnpm exec prettier` with `./node_modules/.bin/prettier` and update the existing guard from `command -v pnpm` to `[[ -x ./node_modules/.bin/prettier ]]`. Preserve the `>/dev/null 2>&1 || true` semantics so a formatter failure never undoes a successful edit.
- `docs/api-facts.yaml`: regenerated. Was stale on `main` (drift after the tags vertical landed in #20). Required to get CI green on this PR.

## Test plan

- [x] Baseline: timed `pnpm exec` path 5+ runs through the actual hook payload, ~510ms best-case.
- [x] After change: timed direct-binary path 5+ runs, ~200ms best-case.
- [x] Smoke test: created `tmp_smoke_test.md` in the project tree with a long unwrapped line, ran the hook payload against it, prettier reflowed it at the configured 88-col `proseWrap: always` setting.
- [x] Idempotency: ran the hook against an already-formatted `LOGGING.md` — md5 unchanged, no spurious edits.
- [x] `uv run poe check` passes locally (format-check, lint, typecheck, yamllint, pytest, facts-check).

Closes #26.