### PR TITLE
feat(client,mcp): drafts vertical — drafts-first outbound (#14)

### DIFF
--- a/.claude/agents/vertical-planner.md
+++ b/.claude/agents/vertical-planner.md
@@ -12,8 +12,9 @@ Produce a concrete, repo-grounded implementation plan for a new resource vertica
 vertical has highly stereotyped structure, but the resource-specific details (generated
 module names, list-response shape, presence of sub-resources) must be discovered
 up-front from the spec and the generated `api/` tree. Without this, mid-implementation
-surprises like the `reply_to_conversation` → `create_message_reply` module-name mismatch
-or `AddComment` → `CreateComment` model rename cost a full debug cycle.
+surprises like the `edit_draft` path being `/drafts/{message_id}/` (note: `message_id`
+not `draft_id`, and a trailing slash) or `AddComment` → `CreateComment` model rename
+cost a full debug cycle.
 
 You do **not** write code. Your output is a plan the human reviews before invoking
 `/new-vertical` or any code-writing agent.

--- a/.claude/skills/new-vertical/SKILL.md
+++ b/.claude/skills/new-vertical/SKILL.md
@@ -118,11 +118,12 @@ future `client.<resource>` surface.
      tool, decorated with `@mcp.tool(name=..., description=...)`.
    - Reads return a `list[<Resource>Summary]`. Mutations take
      `confirm: bool = False` and return a plain dict with `preview` and
-     `confirmed` keys (matching `tools/conversations.py:reply_to_conversation`).
-     Note: `ConfirmationResult` is a `StrEnum` (`CONFIRMED`/`CANCELLED`/
-     `DECLINED`) — it's the **return value of `require_confirmation`**, not
-     the tool's return type. Drafts (#14) invert this — `create_draft` has no
-     `confirm` parameter; the draft IS the review step.
+     `confirmed` keys (matching `tools/conversations.py:update_conversation`
+     or `tools/drafts.py:create_draft_reply`). Note: `ConfirmationResult` is
+     a `StrEnum` (`CONFIRMED`/`CANCELLED`/`DECLINED`) — it's the **return
+     value of `require_confirmation`**, not the tool's return type.
+     Customer-facing outbound mutations always go through the drafts
+     vertical; there is no direct-send pattern.
    - Tools call `get_services(context).client.<resource>.<method>(...)`. Never
      reach into the generated `api/` modules from a tool.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,9 +199,12 @@ etc. Bearer auth on every endpoint.
   `from frontapp_public_api_client.api.<tag> import <operation>` access to every
   generated endpoint, plus hand-written `client.<resource>.…` facades that return
   Pydantic domain models for the most-used resources.
-- **Two-step confirm on MCP mutations** — tools like `reply_to_conversation` take a
-  `confirm: bool = False` parameter; `confirm=False` returns a preview, `confirm=True`
-  both executes and elicits explicit user approval via `ctx.elicit`.
+- **Two-step confirm on MCP mutations** — tools like `update_conversation` and
+  `create_draft_reply` take a `confirm: bool = False` parameter; `confirm=False` returns
+  a preview, `confirm=True` both executes and elicits explicit user approval via
+  `ctx.elicit`. Outbound replies always go through the drafts vertical
+  (`create_draft_reply`, `create_draft_on_channel`, etc.) — there is no direct-send
+  tool. See ADR-0016 → "Drafts-first outbound".
 - **Spec sanitization at vendor time** — Front's upstream OpenAPI spec has a few quirks
   that break openapi-python-client (`example` values on required path params,
   allOf-inherited defaults, binary `*/*` attachment downloads). `scripts/vendor_spec.py`

--- a/README.md
+++ b/README.md
@@ -134,13 +134,14 @@ channels, rules, custom fields, drafts, message templates, analytics, and more. 
 Hand-written ergonomic helpers (Python `client.<resource>.…`) and MCP tools wrap the
 highest-value subset. Current status:
 
-| Resource                 | Python helper (`client.X.…`) | MCP tools                                                                          |
-| ------------------------ | ---------------------------- | ---------------------------------------------------------------------------------- |
-| Conversations            | ✅ `.conversations`          | list / get / search / list_messages / list_comments / reply / update / add_comment |
-| Contacts                 | ⏳ planned                   | ⏳ planned                                                                         |
-| Messages                 | ⏳ planned                   | ⏳ planned                                                                         |
-| Tags, Inboxes, Teammates | ⏳ planned                   | ⏳ planned (also as `frontapp://` resources)                                       |
-| Analytics                | ⏳ planned                   | ⏳ planned (create→poll recipe)                                                    |
+| Resource                 | Python helper (`client.X.…`) | MCP tools                                                                                           |
+| ------------------------ | ---------------------------- | --------------------------------------------------------------------------------------------------- |
+| Conversations            | ✅ `.conversations`          | list / get / search / list_messages / list_comments / update / add_comment                          |
+| Drafts                   | ✅ `.drafts`                 | list_conversation_drafts / create_draft_on_channel / create_draft_reply / edit_draft / delete_draft |
+| Contacts                 | ⏳ planned                   | ⏳ planned                                                                                          |
+| Messages                 | ⏳ planned                   | ⏳ planned                                                                                          |
+| Tags, Inboxes, Teammates | ⏳ planned                   | ⏳ planned (also as `frontapp://` resources)                                                        |
+| Analytics                | ⏳ planned                   | ⏳ planned (create→poll recipe)                                                                     |
 
 See the [issue tracker](https://github.com/dougborg/frontapp-openapi-client/issues) for
 the roadmap. The full generated surface is usable today via direct imports from
@@ -164,10 +165,14 @@ Conversation list/search endpoints accept Front's `q=` search syntax:
 
 Combine with `AND` / `OR`: `status:open AND tag:urgent`.
 
-## MCP Tools (conversations vertical)
+## MCP Tools
 
 Mutations use a two-step confirm pattern — call with `confirm=false` for a preview, then
 `confirm=true` to apply (which also elicits explicit user approval via `ctx.elicit`).
+Customer-facing replies always go through the drafts vertical: agents draft, humans
+send.
+
+### Conversations
 
 | Tool                         | Mutation? | Description                                              |
 | ---------------------------- | --------- | -------------------------------------------------------- |
@@ -176,9 +181,21 @@ Mutations use a two-step confirm pattern — call with `confirm=false` for a pre
 | `search_conversations`       | no        | Full Front search syntax as the primary filter           |
 | `list_conversation_messages` | no        | Messages inside a conversation (most recent first)       |
 | `list_conversation_comments` | no        | Internal teammate comments on a conversation             |
-| `reply_to_conversation`      | yes       | Send an outbound reply (uses the conversation's channel) |
 | `update_conversation`        | yes       | Archive/reopen, reassign, retag, move inbox              |
 | `add_conversation_comment`   | yes       | Add a teammate-only comment (never reaches the customer) |
+
+### Drafts (drafts-first outbound)
+
+| Tool                       | Mutation? | Description                                        |
+| -------------------------- | --------- | -------------------------------------------------- |
+| `list_conversation_drafts` | no        | Existing drafts on a conversation                  |
+| `create_draft_on_channel`  | yes       | Brand-new outbound draft on a channel              |
+| `create_draft_reply`       | yes       | Draft a reply on an existing conversation          |
+| `edit_draft`               | yes       | Full-replacement edit (body + channel_id required) |
+| `delete_draft`             | yes       | Discard a draft                                    |
+
+Front exposes no programmatic `send_draft` — drafts are reviewed and sent by a human in
+Front's UI. There is intentionally no `reply_to_conversation` tool.
 
 Reads are cached for 30s via `ResponseCachingMiddleware`.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -134,7 +134,7 @@ for monorepo versioning:
 git commit -m "feat(client): add Contacts domain helper"
 
 # Release MCP server package
-git commit -m "feat(mcp): implement reply_to_conversation tool"
+git commit -m "feat(mcp): implement create_draft_reply tool"
 
 # No release (documentation only)
 git commit -m "docs: update README with new examples"

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -98,7 +98,7 @@ feat(client): add Contacts domain helper class
 **MCP Server Release:**
 
 ```bash
-feat(mcp): implement reply_to_conversation tool
+feat(mcp): implement create_draft_reply tool
 
 - Add ReplyRequest model with two-step confirm
 - Wire to ctx.elicit for explicit user approval

--- a/docs/api-facts.yaml
+++ b/docs/api-facts.yaml
@@ -17,8 +17,8 @@
 #      domain wiring status, full path/method/response info).
 #
 schema_version: 1
-generated_at: '2026-04-26T14:36:09+00:00'
-generated_from_commit: 83e48da725104198a3058ddf101704b2f9d27525
+generated_at: '2026-04-26T16:02:33+00:00'
+generated_from_commit: f321651f4a668bab94a0b8e1bd23ad774e3a65c3
 summary:
   list_endpoints_with_field_results:
     - accounts.list_account_contacts
@@ -242,8 +242,10 @@ summary:
     - teammate_groups.update_a_company_teammate_group
   tags_with_helper:
     - conversations
+    - drafts
   tags_with_domain:
     - conversations
+    - drafts
 tags:
   accounts:
     spec_tag: Accounts
@@ -915,13 +917,13 @@ tags:
     spec_tag: Drafts
     api_dir: frontapp_public_api_client/api/drafts
     helper:
-      built: false
-      path: null
-      class: null
+      built: true
+      path: frontapp_public_api_client/helpers/drafts.py
+      class: Drafts
     domain:
-      built: false
-      path: null
-      class: null
+      built: true
+      path: frontapp_public_api_client/domain/draft.py
+      class: Draft
     endpoints:
       - module: create_draft
         method: POST

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,7 +48,9 @@ stack rather than as per-method decorators. This means:
 On top of the generated API, hand-written **domain helpers** wrap the most-used
 resources with ergonomic signatures and Pydantic domain models:
 
-- `client.conversations.{list, get, search, update, reply, …}` — ✅ available today
+- `client.conversations.{list, get, search, update, …}` — ✅ available today
+- `client.drafts.{create_on_channel, create_reply, edit, delete, list_for_conversation}`
+  — ✅ available today (drafts-first outbound)
 - `client.contacts.…` — ⏳ planned (see issues)
 - `client.messages.…` — ⏳ planned
 - `client.tags.…`, `client.inboxes.…`, `client.teammates.…` — ⏳ planned

--- a/frontapp_mcp_server/README.md
+++ b/frontapp_mcp_server/README.md
@@ -120,6 +120,8 @@ frontapp-mcp-server
 Mutations use a two-step confirm pattern: call with `confirm=false` first to get a
 preview, then `confirm=true` to execute.
 
+### Conversations
+
 | Tool                         | Mutation? | Endpoint                            | Purpose                                                 |
 | ---------------------------- | --------- | ----------------------------------- | ------------------------------------------------------- |
 | `list_conversations`         | no        | `GET /conversations`                | Cursor-paginated list; supports Front `q=` syntax       |
@@ -127,14 +129,26 @@ preview, then `confirm=true` to execute.
 | `search_conversations`       | no        | `GET /conversations/search/{query}` | Front search syntax as the primary filter               |
 | `list_conversation_messages` | no        | `GET /conversations/{id}/messages`  | Messages inside a conversation                          |
 | `list_conversation_comments` | no        | `GET /conversations/{id}/comments`  | Internal teammate comments                              |
-| `reply_to_conversation`      | yes       | `POST /conversations/{id}/messages` | Send outbound reply on the conversation's channel       |
 | `update_conversation`        | yes       | `PATCH /conversations/{id}`         | Archive/reopen, reassign, retag, move inbox             |
 | `add_conversation_comment`   | yes       | `POST /conversations/{id}/comments` | Internal note (teammates only — never reaches customer) |
+
+### Drafts (drafts-first outbound)
+
+There is no direct "send a reply" tool — outbound replies always go through drafts.
+Agents draft, humans review and click send in Front's UI.
+
+| Tool                       | Mutation? | Endpoint                             | Purpose                                          |
+| -------------------------- | --------- | ------------------------------------ | ------------------------------------------------ |
+| `list_conversation_drafts` | no        | `GET /conversations/{id}/drafts`     | Existing drafts on a conversation                |
+| `create_draft_on_channel`  | yes       | `POST /channels/{channel_id}/drafts` | New outbound draft on a channel                  |
+| `create_draft_reply`       | yes       | `POST /conversations/{id}/drafts`    | Draft a reply on an existing conversation        |
+| `edit_draft`               | yes       | `PATCH /drafts/{id}/`                | Full-replacement edit (body + channel_id needed) |
+| `delete_draft`             | yes       | `DELETE /drafts/{id}`                | Discard a draft                                  |
 
 More verticals (contacts, tags, inboxes, teammates, messages, analytics) are tracked as
 open issues on the repo.
 
-### Example: find, read, and reply to a conversation
+### Example: find, read, and draft a reply to a conversation
 
 ```
 list_conversations(q="status:open tag:urgent", limit=10)
@@ -143,13 +157,17 @@ list_conversations(q="status:open tag:urgent", limit=10)
 list_conversation_messages(conversation_id="cnv_abc")
   → [{body: "Hi, my order hasn't arrived…", author: …}, …]
 
-reply_to_conversation(
+create_draft_reply(
   conversation_id="cnv_abc",
   body="Thanks for reaching out — we're tracking it down now.",
+  channel_id="cha_xyz",
   confirm=False
 )
-  → Preview: reply on cnv_abc (body previewed, no send)
-  → ...confirm=true to send
+  → Preview: draft reply on cnv_abc (body previewed, no draft created)
+  → ...confirm=true to create the draft
+
+# The human reviews the draft in Front and clicks send. There is no
+# programmatic send_draft.
 ```
 
 ### Front search syntax

--- a/frontapp_mcp_server/docs/LOGGING.md
+++ b/frontapp_mcp_server/docs/LOGGING.md
@@ -135,12 +135,12 @@ every tool call (or `tool_failed` on exception). A successful completion looks l
 }
 ```
 
-**Reply to Conversation (Success):**
+**Create Draft Reply (Success):**
 
 ```json
 {
   "event": "tool_completed",
-  "tool_name": "reply_to_conversation",
+  "tool_name": "create_draft_reply",
   "conversation_id": "cnv_abc123",
   "author_id": "tea_xyz",
   "status_code": 202,

--- a/frontapp_mcp_server/docs/adr/0016-tool-interface-pattern.md
+++ b/frontapp_mcp_server/docs/adr/0016-tool-interface-pattern.md
@@ -34,26 +34,29 @@ option for future tools with wide or deeply-nested request bodies.
 
 ```python
 @mcp.tool(
-    name="reply_to_conversation",
+    name="create_draft_reply",
     description=(
-        "Send an outbound reply on an existing conversation. Uses the "
-        "channel the conversation was opened on. Two-step confirm."
+        "Create a draft reply on an existing conversation. The human reviews "
+        "the draft in Front and clicks send. Two-step confirm."
     ),
 )
-async def reply_to_conversation(
+async def create_draft_reply(
     context: Context,
     conversation_id: str,
     body: Annotated[str, Field(description="Reply body (HTML or plain text)")],
+    channel_id: Annotated[
+        str, Field(description="Channel to send through, e.g. 'cha_xyz'")
+    ],
     author_id: Annotated[
         str | None,
-        Field(description="Teammate id to send as; defaults to token owner"),
+        Field(description="Teammate id to author as; defaults to token owner"),
     ] = None,
     subject: Annotated[str | None, Field(description="Override subject")] = None,
     to: Annotated[list[str] | None, Field(description="Override To recipients")] = None,
     cc: Annotated[list[str] | None, Field(description="CC recipients")] = None,
     bcc: Annotated[list[str] | None, Field(description="BCC recipients")] = None,
     confirm: Annotated[
-        bool, Field(description="Must be true to send the reply")
+        bool, Field(description="Must be true to create the draft")
     ] = False,
 ) -> dict[str, Any]:
     ...
@@ -97,7 +100,7 @@ with a consistent shape:
 # confirm=False (preview)
 {
     "preview": {
-        "action": "reply_to_conversation",
+        "action": "create_draft_reply",
         "conversation_id": "cnv_abc",
         "body_preview": "Hi there…",
         ...
@@ -153,7 +156,28 @@ The pattern has two independent safety gates:
 2. **Host elicitation**: `ctx.elicit` prompts the user even once the LLM has set
    `confirm=True`, so a misaligned LLM can't unilaterally apply changes.
 
-#### 5. Shared schemas
+#### 5. Drafts-first outbound
+
+For customer-facing replies there is a **third** gate beyond preview + elicitation: the
+agent never sends, it only drafts. The Frontapp drafts vertical (`create_draft_reply`,
+`create_draft_on_channel`, `edit_draft`, `delete_draft`) exposes the full reply surface,
+but Front's API has no programmatic `send_draft` — the human reviews the draft in
+Front's UI and clicks send themselves.
+
+The earlier `reply_to_conversation` tool (which sent immediately on `confirm=True`) was
+removed in the drafts vertical PR. Even a misaligned LLM that gets past elicitation
+cannot send to a customer; the strongest action it can take is creating a draft that a
+human still has to approve and dispatch.
+
+This also matches Front's product model — every outbound message in Front flows through
+a draft state, even when teammates type-and-send by hand. The agent surface just keeps
+that behavior explicit.
+
+Mutation tools that don't reach the customer (`update_conversation`,
+`add_conversation_comment`) keep the standard two-gate pattern only. The drafts-first
+rule is specifically for outbound messaging.
+
+#### 6. Shared schemas
 
 Common schemas live in `frontapp_mcp/tools/schemas.py`:
 
@@ -224,7 +248,7 @@ elicitation flow stays consistent.
 ### Flat untyped parameters
 
 ```python
-async def reply_to_conversation(
+async def create_draft_reply(
     conversation_id: str,
     body: str,
     author_id: str | None,    # ❌ no Field description
@@ -240,7 +264,7 @@ to keep tools consistent.
 ### Dictionary-based
 
 ```python
-async def reply_to_conversation(
+async def create_draft_reply(
     params: dict,    # ❌ no type safety
     context: Context,
 ) -> dict:
@@ -252,7 +276,7 @@ async def reply_to_conversation(
 ### Response-field confirmation (no elicitation)
 
 ```python
-async def reply_to_conversation(...) -> dict:
+async def create_draft_reply(...) -> dict:
     if not confirmed:
         return {"status": "pending", "confirmation_required": True}
     # else apply
@@ -271,11 +295,13 @@ the intended action before committing, without requiring a speculative API call.
 
 ## Implementation examples
 
-Live today in the conversations vertical (`tools/conversations.py`):
+Live today across the conversations and drafts verticals:
 
 **Mutations** (two-step confirm + elicitation):
 
-- `reply_to_conversation` — customer-facing outbound message
+- `create_draft_reply` / `create_draft_on_channel` / `edit_draft` / `delete_draft` — the
+  drafts vertical (`tools/drafts.py`); customer-facing outbound always goes through
+  drafts
 - `update_conversation` — archive/reopen, reassign, retag, move inbox
 - `add_conversation_comment` — internal teammate note
 

--- a/frontapp_mcp_server/docs/adr/0017-automated-tool-documentation.md
+++ b/frontapp_mcp_server/docs/adr/0017-automated-tool-documentation.md
@@ -32,11 +32,12 @@ truth, with automated extraction for discovery and reference documentation.
 Every tool carries a Google-style docstring:
 
 ```python
-@mcp.tool(name="reply_to_conversation", description="...")
-async def reply_to_conversation(
+@mcp.tool(name="create_draft_reply", description="...")
+async def create_draft_reply(
     context: Context,
     conversation_id: str,
     body: str,
+    channel_id: str,
     author_id: str | None = None,
     subject: str | None = None,
     to: list[str] | None = None,
@@ -44,22 +45,25 @@ async def reply_to_conversation(
     bcc: list[str] | None = None,
     confirm: bool = False,
 ) -> dict[str, Any]:
-    """Send an outbound reply on an existing Front conversation.
+    """Create a draft reply on an existing Front conversation.
 
-    🔴 HIGH-RISK OPERATION: customer-facing message. Requires two-step
+    🟡 MEDIUM-RISK OPERATION: creates Front-side state, but the human
+    reviews the draft and clicks send themselves. Requires two-step
     confirmation via ``ctx.elicit``.
 
     **Workflow**:
-    1. Call with ``confirm=False`` — returns a preview of what would be
-       sent (body, recipients, subject). No side effects.
+    1. Call with ``confirm=False`` — returns a preview of the draft. No
+       side effects.
     2. Call with ``confirm=True`` — elicits explicit user approval, then
-       POSTs to ``/conversations/{id}/messages``. Front replies 202 Accepted;
-       the message is enqueued for delivery on the conversation's channel.
+       POSTs to ``/conversations/{id}/drafts``. The draft appears in Front
+       for the human to review and send. There is no programmatic
+       ``send_draft``.
 
     **Related tools**:
+    - ``edit_draft`` — full-replacement edit of an existing draft
+    - ``delete_draft`` — discard a draft
     - ``add_conversation_comment`` — internal teammate note (never reaches
       the customer)
-    - ``update_conversation`` — archive/reassign without sending a reply
 
     **Related resources**:
     - ``frontapp://teammates`` — look up ``author_id`` values
@@ -69,11 +73,13 @@ async def reply_to_conversation(
         context: FastMCP context for services + elicitation
         conversation_id: Front conversation id, e.g. ``"cnv_abc123"``
         body: Reply body (HTML or plain text)
-        author_id: Teammate id to send as; defaults to the token owner
+        channel_id: Channel to send through, e.g. ``"cha_xyz"`` (required
+            so Front knows which channel the eventual send goes through)
+        author_id: Teammate id to author as; defaults to the token owner
         subject: Override subject (rarely needed)
         to / cc / bcc: Override recipients; defaults to the conversation's
             existing participants
-        confirm: Must be True to actually send
+        confirm: Must be True to create the draft
 
     Returns:
         dict with ``confirmed``, ``status_code``, and a ``preview`` on the
@@ -81,9 +87,9 @@ async def reply_to_conversation(
 
     Example:
         Preview:
-            {"conversation_id": "cnv_abc", "body": "Thanks!", "confirm": false}
-        Send:
-            {"conversation_id": "cnv_abc", "body": "Thanks!", "confirm": true}
+            {"conversation_id": "cnv_abc", "body": "Thanks!", "channel_id": "cha_xyz", "confirm": false}
+        Create draft:
+            {"conversation_id": "cnv_abc", "body": "Thanks!", "channel_id": "cha_xyz", "confirm": true}
     """
 ```
 
@@ -262,7 +268,7 @@ tool responses are small JSON objects and a Pydantic projection model
 - Example query using Front search syntax
 - Cursor pagination explained
 
-**Destructive tool** (`reply_to_conversation`):
+**Destructive tool** (`create_draft_reply`):
 
 - 🔴 indicator (customer-facing mutation)
 - Two-step confirm workflow documented

--- a/frontapp_mcp_server/docs/docker.md
+++ b/frontapp_mcp_server/docs/docker.md
@@ -153,8 +153,8 @@ ensuring the tools list stays synchronized with actual implementations.
     "description": "Archive, reassign, or retag a conversation (two-step confirm)."
   },
   {
-    "name": "reply_to_conversation",
-    "description": "Send an outbound reply to the customer (two-step confirm)."
+    "name": "create_draft_reply",
+    "description": "Draft a reply on an existing conversation; the human reviews and sends in Front (two-step confirm)."
   }
 ]
 ```

--- a/frontapp_mcp_server/docs/examples.md
+++ b/frontapp_mcp_server/docs/examples.md
@@ -42,27 +42,32 @@ Model:
   → [ConversationSummary(…), …]
 ```
 
-## Replying to a customer (two-step confirm)
+## Drafting a reply to a customer (drafts-first, two-step confirm)
+
+There is no direct-send tool — outbound replies always go through drafts. The agent
+drafts; the human reviews the draft in Front's UI and clicks send.
 
 ```
 User: "Let the customer on cnv_abc know we've shipped their replacement"
 
 Model:
-  # 1. Preview — confirm=False, no send.
-  reply_to_conversation(
+  # 1. Preview — confirm=False, no draft created.
+  create_draft_reply(
     conversation_id="cnv_abc",
     body="Hi! We've shipped your replacement — tracking 1Z999AA10123456784.",
+    channel_id="cha_xyz",
     confirm=False,
   )
-  → {"preview": {"action": "reply_to_conversation", "body_preview": "…"}, "confirmed": False}
+  → {"preview": {"action": "create_draft_reply", "body_preview": "…"}, "confirmed": False}
 
-  # 2. Send — confirm=True triggers ctx.elicit to ask the user to approve.
-  reply_to_conversation(
+  # 2. Create draft — confirm=True triggers ctx.elicit to ask the user to approve.
+  create_draft_reply(
     conversation_id="cnv_abc",
     body="Hi! We've shipped your replacement — tracking 1Z999AA10123456784.",
+    channel_id="cha_xyz",
     confirm=True,
   )
-  → {"confirmed": True, "status_code": 202, "note": "…message enqueued."}
+  → {"confirmed": True, "status_code": 202, "note": "Draft created. The human reviews in Front and clicks send."}
 ```
 
 ## Reassigning and re-tagging

--- a/frontapp_mcp_server/src/frontapp_mcp/projections.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/projections.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from pydantic import BaseModel, Field
 
-from frontapp_public_api_client.domain import Conversation
+from frontapp_public_api_client.domain import Conversation, Draft
 
 
 class ConversationSummary(BaseModel):
@@ -53,4 +53,51 @@ def to_summary(conv: Conversation) -> ConversationSummary:
     )
 
 
-__all__ = ["ConversationSummary", "to_summary"]
+class DraftSummary(BaseModel):
+    """Compact projection of a draft for LLM responses.
+
+    Strips the heavy ``MessageResponse`` shape down to what an LLM cares about
+    when reviewing a draft it just created or edited: id, subject, body,
+    recipient handles, version (for clobber-free re-edits), and timestamps.
+    """
+
+    id: str
+    subject: str | None = None
+    body: str | None = None
+    blurb: str | None = None
+    draft_mode: str | None = None
+    error_type: str | None = None
+    version: str | None = None
+    author_name: str | None = None
+    recipients: list[str] = Field(default_factory=list)
+    attachment_filenames: list[str] = Field(default_factory=list)
+    created_at: str | None = None
+
+
+def to_draft_summary(draft: Draft) -> DraftSummary:
+    """Project a ``Draft`` domain model to a ``DraftSummary``."""
+    author_name: str | None = None
+    if draft.author:
+        parts = [draft.author.first_name, draft.author.last_name]
+        author_name = " ".join(p for p in parts if p) or draft.author.username
+    return DraftSummary(
+        id=draft.id,
+        subject=draft.subject,
+        body=draft.body,
+        blurb=draft.blurb,
+        draft_mode=draft.draft_mode,
+        error_type=draft.error_type,
+        version=draft.version,
+        author_name=author_name,
+        recipients=[r.handle for r in draft.recipients if r.handle],
+        attachment_filenames=[a.filename for a in draft.attachments if a.filename],
+        created_at=draft.created_at.isoformat() if draft.created_at else None,
+    )
+
+
+__all__ = [
+    "ConversationSummary",
+    "DraftSummary",
+    "to_draft_summary",
+    "to_summary",
+]

--- a/frontapp_mcp_server/src/frontapp_mcp/resources/help.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/resources/help.py
@@ -32,9 +32,25 @@ resources.)
 | `search_conversations` | `GET /conversations/search/{query}` | Front search syntax as the primary filter. |
 | `list_conversation_messages` | `GET /conversations/{id}/messages` | Messages in a conversation (most recent first). |
 | `list_conversation_comments` | `GET /conversations/{id}/comments` | Internal teammate comments on a conversation. |
-| `reply_to_conversation` | `POST /conversations/{id}/messages` | Send outbound reply on the conversation's channel. Two-step confirm. |
 | `update_conversation` | `PATCH /conversations/{id}` | Archive/reopen, reassign, retag, move inbox. Two-step confirm. |
 | `add_conversation_comment` | `POST /conversations/{id}/comments` | Teammate-only internal note. Two-step confirm. |
+
+There is intentionally no direct "send a reply" tool — outbound replies go
+through the drafts vertical below. Agents draft, humans send.
+
+## Drafts (drafts-first outbound)
+
+Drafts are the safe-by-default outbound path. An agent creates a draft, the
+human reviews it in Front's UI, and the human clicks send. Front exposes no
+programmatic ``send_draft``.
+
+| Tool | Endpoint | Purpose |
+| ---- | -------- | ------- |
+| `list_conversation_drafts` | `GET /conversations/{id}/drafts` | Existing drafts on a conversation. |
+| `create_draft_on_channel` | `POST /channels/{channel_id}/drafts` | Brand-new outbound draft on a channel. Two-step confirm. |
+| `create_draft_reply` | `POST /conversations/{id}/drafts` | Draft a reply on an existing conversation (`channel_id` required). Two-step confirm. |
+| `edit_draft` | `PATCH /drafts/{id}/` | Full-replacement edit of an existing draft (`body` + `channel_id` required). Two-step confirm. |
+| `delete_draft` | `DELETE /drafts/{id}` | Discard a draft. Two-step confirm. |
 
 ## Front search syntax (`q=` parameter)
 
@@ -51,7 +67,7 @@ resources.)
 
 Combine with `AND` / `OR`: `status:open AND tag:urgent`.
 
-## Recommended workflow: triaging and replying
+## Recommended workflow: triaging and drafting a reply
 
 ```
 list_conversations(q="status:open is:unassigned", limit=25)
@@ -63,12 +79,14 @@ list_conversation_messages(conversation_id="cnv_abc")
 update_conversation(conversation_id="cnv_abc", assignee_id="tea_xyz", confirm=True)
   → assign it to a teammate (two-step confirm)
 
-reply_to_conversation(
+create_draft_reply(
     conversation_id="cnv_abc",
     body="Thanks for reaching out…",
+    channel_id="cha_xyz",
     confirm=False,   # preview
 )
-reply_to_conversation(..., confirm=True)   # actually send
+create_draft_reply(..., confirm=True)
+  → draft is created in Front; tell the user to review and click send
 ```
 
 ## Mutations are always two-step

--- a/frontapp_mcp_server/src/frontapp_mcp/server.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/server.py
@@ -200,12 +200,22 @@ Frontapp MCP Server — Read and act on Front customer-communication data.
   get_conversation (full detail by id)
 
 **Reading inside a conversation:**
-  list_conversation_messages | list_conversation_comments
+  list_conversation_messages | list_conversation_comments |
+  list_conversation_drafts (unsent drafts awaiting human send)
 
-**Responding (all use two-step confirm):**
-  reply_to_conversation — outbound message to the customer
-  add_conversation_comment — internal note, teammates only
+**Responding to the customer (drafts-first — human still clicks send):**
+  create_draft_reply — draft a reply on an existing conversation
+  create_draft_on_channel — draft a brand-new outbound message
+  edit_draft — full-replacement edit of an existing draft (clobbers)
+  delete_draft — discard a draft
+
+**Internal-only updates:**
+  add_conversation_comment — teammate-only note (NOT sent to customer)
   update_conversation — archive/reopen, reassign, retag, move inbox
+
+There is no programmatic "send a reply now" tool. By design — agents draft;
+humans send. To respond to a customer, call create_draft_reply, then tell
+the user to review and send the draft in Front's UI.
 
 ## Front Search Syntax (q parameter)
 
@@ -250,6 +260,7 @@ _READ_ONLY_TOOLS = [
     "search_conversations",
     "list_conversation_messages",
     "list_conversation_comments",
+    "list_conversation_drafts",
 ]
 
 mcp.add_middleware(

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/__init__.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/__init__.py
@@ -11,8 +11,10 @@ from fastmcp import FastMCP
 def register_all_tools(mcp: FastMCP) -> None:
     """Register every tool module with the FastMCP instance."""
     from .conversations import register_tools as register_conversations_tools
+    from .drafts import register_tools as register_drafts_tools
 
     register_conversations_tools(mcp)
+    register_drafts_tools(mcp)
 
 
 __all__ = ["register_all_tools"]

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/conversations.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/conversations.py
@@ -1,10 +1,12 @@
 """MCP tools for Frontapp conversations.
 
-Exposes 8 tools covering the common read paths and the three mutations that
-matter for agent workflows (reply, update status/assignee/tags, add internal
-comment). Mutations use the two-step confirm pattern: call with
-``confirm=False`` to preview, ``confirm=True`` to execute (which also elicits
-explicit user approval via ``ctx.elicit``).
+Exposes 7 tools: 5 read-side (list / get / search / list_messages /
+list_comments) and 2 internal-only mutations (update_conversation,
+add_conversation_comment) using the standard two-step confirm pattern.
+
+There is no direct ``reply_to_conversation`` tool — outbound replies happen
+via the drafts vertical (``create_draft_reply`` etc.). Agents draft, humans
+send. See ADR-0016 → "Drafts-first outbound" for the rationale.
 """
 
 from __future__ import annotations
@@ -127,70 +129,11 @@ def register_tools(mcp: FastMCP) -> None:
         return [c.to_dict() for c in comments]
 
     # -- mutations (two-step confirm) ---------------------------------------
-
-    @mcp.tool(
-        name="reply_to_conversation",
-        description=(
-            "Send an outbound reply on an existing conversation. Uses the "
-            "channel the conversation was opened on. Two-step confirm: "
-            "confirm=False returns a preview; confirm=True executes."
-        ),
-    )
-    async def reply_to_conversation(
-        context: Context,
-        conversation_id: str,
-        body: Annotated[str, Field(description="Reply body (HTML or plain text)")],
-        author_id: Annotated[
-            str | None,
-            Field(description="Teammate id to send as; defaults to token owner"),
-        ] = None,
-        subject: Annotated[
-            str | None, Field(description="Override subject (rarely needed)")
-        ] = None,
-        to: Annotated[
-            list[str] | None, Field(description="Override To recipients")
-        ] = None,
-        cc: Annotated[list[str] | None, Field(description="CC recipients")] = None,
-        bcc: Annotated[list[str] | None, Field(description="BCC recipients")] = None,
-        confirm: Annotated[
-            bool, Field(description="Must be true to send the reply")
-        ] = False,
-    ) -> dict[str, Any]:
-        services = get_services(context)
-
-        preview = {
-            "action": "reply_to_conversation",
-            "conversation_id": conversation_id,
-            "body_preview": body[:200] + ("…" if len(body) > 200 else ""),
-            "author_id": author_id,
-            "subject": subject,
-            "to": to,
-            "cc": cc,
-            "bcc": bcc,
-        }
-        if not confirm:
-            return {"preview": preview, "confirmed": False}
-
-        result = await require_confirmation(
-            context, f"Send reply to conversation {conversation_id}?"
-        )
-        if result is not ConfirmationResult.CONFIRMED:
-            return {"preview": preview, "confirmed": False, "result": result.value}
-
-        response = await services.client.conversations.reply(
-            conversation_id,
-            body=body,
-            author_id=author_id,
-            subject=subject,
-            to=to,
-            cc=cc,
-            bcc=bcc,
-        )
-        return {
-            "confirmed": True,
-            "status_code": response.status_code,
-            "note": "Front returns 202 Accepted; the message is enqueued for delivery.",
-        }
+    #
+    # Outbound replies are NOT exposed here — the conversations vertical has
+    # no direct-send tool. Use ``create_draft_reply`` (in the drafts vertical)
+    # to draft a reply that the human reviews and sends in Front's UI. See
+    # ADR-0016 → "Drafts-first outbound" for the rationale.
 
     @mcp.tool(
         name="update_conversation",

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/drafts.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/drafts.py
@@ -1,0 +1,294 @@
+"""MCP tools for Frontapp drafts.
+
+Drafts are the safe-by-default outbound path: an agent creates a draft, the
+human reviews it in Front's UI, and the human clicks send. There is no
+programmatic ``send_draft`` — sending is always human-in-the-loop.
+
+All four mutation tools (create-on-channel, create-reply, edit, delete) use
+the standard two-step confirm pattern: call with ``confirm=False`` for a
+preview, ``confirm=True`` to execute (which also elicits explicit user
+approval via ``ctx.elicit``).
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any, Literal
+
+from fastmcp import Context, FastMCP
+from pydantic import Field
+
+from frontapp_mcp.projections import DraftSummary, to_draft_summary
+from frontapp_mcp.services import get_services
+from frontapp_mcp.tools.schemas import ConfirmationResult, require_confirmation
+
+
+def _preview_body(body: str) -> str:
+    return body[:200] + ("…" if len(body) > 200 else "")
+
+
+def register_tools(mcp: FastMCP) -> None:
+    """Register draft-related tools with the FastMCP server."""
+
+    # -- reads --------------------------------------------------------------
+
+    @mcp.tool(
+        name="list_conversation_drafts",
+        description=(
+            "List drafts on a conversation. Drafts are unsent messages "
+            "awaiting human review in Front's UI."
+        ),
+    )
+    async def list_conversation_drafts(
+        context: Context,
+        conversation_id: Annotated[
+            str, Field(description="Conversation id, e.g. 'cnv_abc123'")
+        ],
+    ) -> list[dict[str, Any]]:
+        services = get_services(context)
+        drafts = await services.client.drafts.list_for_conversation(conversation_id)
+        # Drafts list is raw_array of attrs MessageResponse — to_dict for JSON safety.
+        return [d.to_dict() for d in drafts]
+
+    # -- mutations (two-step confirm) ---------------------------------------
+
+    @mcp.tool(
+        name="create_draft_on_channel",
+        description=(
+            "Create a draft message on a channel (no existing conversation). "
+            "Returns a DraftSummary so the LLM can verify what was created. "
+            "Two-step confirm: confirm=False returns a preview; confirm=True "
+            "creates the draft (human still has to click send in Front)."
+        ),
+    )
+    async def create_draft_on_channel(
+        context: Context,
+        channel_id: Annotated[str, Field(description="Channel id, e.g. 'cha_abc123'")],
+        body: Annotated[str, Field(description="Draft body (HTML or plain text)")],
+        author_id: Annotated[
+            str | None,
+            Field(description="Teammate id to author as; defaults to token owner"),
+        ] = None,
+        subject: Annotated[str | None, Field(description="Subject line")] = None,
+        to: Annotated[
+            list[str] | None, Field(description="To recipients (handles)")
+        ] = None,
+        cc: Annotated[list[str] | None, Field(description="CC recipients")] = None,
+        bcc: Annotated[list[str] | None, Field(description="BCC recipients")] = None,
+        mode: Annotated[
+            Literal["private", "shared"] | None,
+            Field(description="'private' (author-only) or 'shared' (all teammates)"),
+        ] = None,
+        confirm: Annotated[
+            bool, Field(description="Must be true to create the draft")
+        ] = False,
+    ) -> dict[str, Any]:
+        services = get_services(context)
+        preview = {
+            "action": "create_draft_on_channel",
+            "channel_id": channel_id,
+            "subject": subject,
+            "body_preview": _preview_body(body),
+            "to": to,
+            "cc": cc,
+            "bcc": bcc,
+            "mode": mode,
+        }
+        if not confirm:
+            return {"preview": preview, "confirmed": False}
+
+        result = await require_confirmation(
+            context, f"Create draft on channel {channel_id}?"
+        )
+        if result is not ConfirmationResult.CONFIRMED:
+            return {"preview": preview, "confirmed": False, "result": result.value}
+
+        draft = await services.client.drafts.create_on_channel(
+            channel_id,
+            body=body,
+            author_id=author_id,
+            subject=subject,
+            to=to,
+            cc=cc,
+            bcc=bcc,
+            mode=mode,
+        )
+        return {"confirmed": True, "draft": to_draft_summary(draft).model_dump()}
+
+    @mcp.tool(
+        name="create_draft_reply",
+        description=(
+            "Create a draft reply on an existing conversation. The draft "
+            "appears in Front for human review and send. channel_id is "
+            "required so Front knows which channel the reply will go through. "
+            "Two-step confirm: confirm=False returns a preview; confirm=True "
+            "creates the draft."
+        ),
+    )
+    async def create_draft_reply(
+        context: Context,
+        conversation_id: Annotated[
+            str, Field(description="Conversation id, e.g. 'cnv_abc123'")
+        ],
+        body: Annotated[str, Field(description="Reply body (HTML or plain text)")],
+        channel_id: Annotated[
+            str,
+            Field(description="Channel to send through, e.g. 'cha_abc123'"),
+        ],
+        author_id: Annotated[
+            str | None, Field(description="Teammate id to author as")
+        ] = None,
+        subject: Annotated[
+            str | None, Field(description="Override subject (rarely needed)")
+        ] = None,
+        to: Annotated[
+            list[str] | None, Field(description="Override To recipients")
+        ] = None,
+        cc: Annotated[list[str] | None, Field(description="CC recipients")] = None,
+        bcc: Annotated[list[str] | None, Field(description="BCC recipients")] = None,
+        mode: Annotated[
+            Literal["private", "shared"] | None,
+            Field(description="'private' or 'shared'"),
+        ] = None,
+        confirm: Annotated[
+            bool, Field(description="Must be true to create the draft")
+        ] = False,
+    ) -> dict[str, Any]:
+        services = get_services(context)
+        preview = {
+            "action": "create_draft_reply",
+            "conversation_id": conversation_id,
+            "channel_id": channel_id,
+            "body_preview": _preview_body(body),
+            "to": to,
+            "cc": cc,
+            "bcc": bcc,
+            "mode": mode,
+        }
+        if not confirm:
+            return {"preview": preview, "confirmed": False}
+
+        result = await require_confirmation(
+            context, f"Create draft reply on conversation {conversation_id}?"
+        )
+        if result is not ConfirmationResult.CONFIRMED:
+            return {"preview": preview, "confirmed": False, "result": result.value}
+
+        response = await services.client.drafts.create_reply(
+            conversation_id,
+            body=body,
+            channel_id=channel_id,
+            author_id=author_id,
+            subject=subject,
+            to=to,
+            cc=cc,
+            bcc=bcc,
+            mode=mode,
+        )
+        return {
+            "confirmed": True,
+            "status_code": response.status_code,
+            "note": (
+                "Draft created. The human reviews in Front and clicks send; "
+                "there is no programmatic send_draft."
+            ),
+        }
+
+    @mcp.tool(
+        name="edit_draft",
+        description=(
+            "Edit an existing draft. Front's PATCH /drafts/{id}/ is a "
+            "full-replacement — body and channel_id are required even when "
+            "only changing metadata. Pass version (from a prior draft fetch) "
+            "to avoid clobbering concurrent edits. Two-step confirm."
+        ),
+    )
+    async def edit_draft(
+        context: Context,
+        draft_id: Annotated[
+            str, Field(description="Draft id, e.g. 'msg_abc123' or 'dft_abc123'")
+        ],
+        body: Annotated[str, Field(description="Full draft body (replaces existing)")],
+        channel_id: Annotated[
+            str, Field(description="Channel id, required by Front's edit shape")
+        ],
+        author_id: Annotated[
+            str | None, Field(description="Teammate id to author as")
+        ] = None,
+        subject: Annotated[str | None, Field(description="Subject line")] = None,
+        to: Annotated[list[str] | None, Field(description="To recipients")] = None,
+        cc: Annotated[list[str] | None, Field(description="CC recipients")] = None,
+        bcc: Annotated[list[str] | None, Field(description="BCC recipients")] = None,
+        mode: Annotated[
+            Literal["shared"] | None,
+            Field(description="Only 'shared' is accepted on edit"),
+        ] = None,
+        version: Annotated[
+            str | None,
+            Field(description="Version token from a prior draft to avoid clobbers"),
+        ] = None,
+        confirm: Annotated[
+            bool, Field(description="Must be true to apply the edit")
+        ] = False,
+    ) -> dict[str, Any]:
+        services = get_services(context)
+        preview = {
+            "action": "edit_draft",
+            "draft_id": draft_id,
+            "channel_id": channel_id,
+            "subject": subject,
+            "body_preview": _preview_body(body),
+            "to": to,
+            "cc": cc,
+            "bcc": bcc,
+            "mode": mode,
+            "version": version,
+        }
+        if not confirm:
+            return {"preview": preview, "confirmed": False}
+
+        result = await require_confirmation(
+            context, f"Edit draft {draft_id}? This replaces the current draft body."
+        )
+        if result is not ConfirmationResult.CONFIRMED:
+            return {"preview": preview, "confirmed": False, "result": result.value}
+
+        draft = await services.client.drafts.edit(
+            draft_id,
+            body=body,
+            channel_id=channel_id,
+            author_id=author_id,
+            subject=subject,
+            to=to,
+            cc=cc,
+            bcc=bcc,
+            mode=mode,
+            version=version,
+        )
+        return {"confirmed": True, "draft": to_draft_summary(draft).model_dump()}
+
+    @mcp.tool(
+        name="delete_draft",
+        description=(
+            "Delete a draft by id. Two-step confirm — deleting clobbers any "
+            "in-progress edits in Front."
+        ),
+    )
+    async def delete_draft(
+        context: Context,
+        draft_id: Annotated[str, Field(description="Draft id to delete")],
+        confirm: Annotated[bool, Field(description="Must be true to delete")] = False,
+    ) -> dict[str, Any]:
+        services = get_services(context)
+        preview = {"action": "delete_draft", "draft_id": draft_id}
+        if not confirm:
+            return {"preview": preview, "confirmed": False}
+
+        result = await require_confirmation(context, f"Delete draft {draft_id}?")
+        if result is not ConfirmationResult.CONFIRMED:
+            return {"preview": preview, "confirmed": False, "result": result.value}
+
+        success = await services.client.drafts.delete(draft_id)
+        return {"confirmed": True, "deleted": success}
+
+
+__all__ = ["DraftSummary", "register_tools"]

--- a/frontapp_mcp_server/tests/test_drafts_tools.py
+++ b/frontapp_mcp_server/tests/test_drafts_tools.py
@@ -1,0 +1,254 @@
+"""Tests for MCP draft tools — preview-vs-execute confirm flow.
+
+These tests verify the two-step confirm pattern works as documented in
+ADR-0016 → "Drafts-first outbound": every mutation tool returns a preview on
+``confirm=False`` without making any API calls, and only attempts the API
+call after both the explicit ``confirm=True`` AND a successful elicitation.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from frontapp_mcp.projections import DraftSummary, to_draft_summary
+from frontapp_mcp.tools.drafts import register_tools
+
+from frontapp_public_api_client.domain import Draft
+
+from .conftest import create_mock_context
+
+
+def _make_mcp() -> tuple[object, dict]:
+    """Build a fake FastMCP that captures registered tool functions by name."""
+    captured: dict[str, object] = {}
+
+    class FakeMCP:
+        def tool(self, **kwargs: object):
+            name = kwargs["name"]
+
+            def decorator(fn):
+                captured[name] = fn
+                return fn
+
+            return decorator
+
+    return FakeMCP(), captured
+
+
+@pytest.fixture
+def drafts_tools() -> dict[str, object]:
+    """Register all draft tools and return the captured function dict."""
+    mcp, captured = _make_mcp()
+    register_tools(mcp)  # type: ignore[arg-type]
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# Two-step confirm — preview path (no API call expected)
+# ---------------------------------------------------------------------------
+
+
+class TestPreviewPath:
+    """``confirm=False`` should return a preview dict and never call the client."""
+
+    async def test_create_draft_on_channel_preview(self, drafts_tools):
+        context, lifespan = create_mock_context()
+        # Crash the test if any client method is invoked during preview.
+        lifespan.client = AsyncMock(
+            side_effect=AssertionError("client invoked on preview path")
+        )
+
+        result = await drafts_tools["create_draft_on_channel"](
+            context, channel_id="cha_abc", body="Hi there", confirm=False
+        )
+
+        assert result == {
+            "preview": {
+                "action": "create_draft_on_channel",
+                "channel_id": "cha_abc",
+                "subject": None,
+                "body_preview": "Hi there",
+                "to": None,
+                "cc": None,
+                "bcc": None,
+                "mode": None,
+            },
+            "confirmed": False,
+        }
+        # elicit() is never invoked on the preview path.
+        context.elicit.assert_not_called()
+
+    async def test_create_draft_reply_preview(self, drafts_tools):
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock(
+            side_effect=AssertionError("client invoked on preview path")
+        )
+
+        result = await drafts_tools["create_draft_reply"](
+            context,
+            conversation_id="cnv_abc",
+            body="Reply",
+            channel_id="cha_xyz",
+            confirm=False,
+        )
+
+        assert result["confirmed"] is False
+        assert result["preview"]["action"] == "create_draft_reply"
+        assert result["preview"]["channel_id"] == "cha_xyz"
+
+    async def test_edit_draft_preview(self, drafts_tools):
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock(
+            side_effect=AssertionError("client invoked on preview path")
+        )
+
+        result = await drafts_tools["edit_draft"](
+            context,
+            draft_id="msg_abc",
+            body="Updated body",
+            channel_id="cha_xyz",
+            confirm=False,
+        )
+
+        assert result["confirmed"] is False
+        assert result["preview"]["action"] == "edit_draft"
+        assert result["preview"]["draft_id"] == "msg_abc"
+
+    async def test_delete_draft_preview(self, drafts_tools):
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock(
+            side_effect=AssertionError("client invoked on preview path")
+        )
+
+        result = await drafts_tools["delete_draft"](
+            context, draft_id="msg_abc", confirm=False
+        )
+
+        assert result == {
+            "preview": {"action": "delete_draft", "draft_id": "msg_abc"},
+            "confirmed": False,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Two-step confirm — declined elicitation
+# ---------------------------------------------------------------------------
+
+
+class TestDeclinedElicitation:
+    """When the user declines elicitation, the tool must NOT call the API."""
+
+    async def test_delete_draft_declined(self, drafts_tools):
+        context, lifespan = create_mock_context(elicit_confirm=False)
+        lifespan.client = AsyncMock(
+            side_effect=AssertionError("client invoked after decline")
+        )
+
+        result = await drafts_tools["delete_draft"](
+            context, draft_id="msg_abc", confirm=True
+        )
+
+        assert result["confirmed"] is False
+        assert result["result"] == "cancelled"
+        # Elicitation WAS invoked (unlike the preview path).
+        context.elicit.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Confirmed path — verify the API call shape is correct
+# ---------------------------------------------------------------------------
+
+
+class TestConfirmedExecution:
+    """``confirm=True`` + accepted elicitation should reach the helper."""
+
+    async def test_create_draft_on_channel_calls_helper(self, drafts_tools):
+        context, lifespan = create_mock_context()
+        # Build a Draft return value the helper would produce.
+        returned_draft = Draft.model_validate(
+            {"id": "msg_new", "subject": "Hello", "draft_mode": "shared"}
+        )
+        lifespan.client = AsyncMock()
+        lifespan.client.drafts.create_on_channel = AsyncMock(
+            return_value=returned_draft
+        )
+
+        result = await drafts_tools["create_draft_on_channel"](
+            context,
+            channel_id="cha_abc",
+            body="Hi there",
+            subject="Hello",
+            mode="shared",
+            confirm=True,
+        )
+
+        lifespan.client.drafts.create_on_channel.assert_awaited_once_with(
+            "cha_abc",
+            body="Hi there",
+            author_id=None,
+            subject="Hello",
+            to=None,
+            cc=None,
+            bcc=None,
+            mode="shared",
+        )
+        assert result["confirmed"] is True
+        assert result["draft"]["id"] == "msg_new"
+        assert result["draft"]["draft_mode"] == "shared"
+
+    async def test_delete_draft_calls_helper(self, drafts_tools):
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock()
+        lifespan.client.drafts.delete = AsyncMock(return_value=True)
+
+        result = await drafts_tools["delete_draft"](
+            context, draft_id="msg_abc", confirm=True
+        )
+
+        lifespan.client.drafts.delete.assert_awaited_once_with("msg_abc")
+        assert result == {"confirmed": True, "deleted": True}
+
+
+# ---------------------------------------------------------------------------
+# DraftSummary projection
+# ---------------------------------------------------------------------------
+
+
+class TestDraftSummary:
+    def test_to_draft_summary_projects_author_name_from_first_last(self):
+        from frontapp_public_api_client.domain import (
+            RecipientSummary,
+            TeammateSummary,
+        )
+
+        draft = Draft.model_validate(
+            {
+                "id": "msg_abc",
+                "subject": "Hi",
+                "body": "<p>hi</p>",
+                "draft_mode": "shared",
+            }
+        )
+        # Re-construct with author and recipients for projection.
+        author = TeammateSummary(first_name="Ada", last_name="Lovelace")
+        recipient = RecipientSummary(handle="customer@example.com", role="to")
+        draft = draft.model_copy(update={"author": author, "recipients": [recipient]})
+
+        summary = to_draft_summary(draft)
+
+        assert isinstance(summary, DraftSummary)
+        assert summary.id == "msg_abc"
+        assert summary.author_name == "Ada Lovelace"
+        assert summary.recipients == ["customer@example.com"]
+        assert summary.draft_mode == "shared"
+
+    def test_to_draft_summary_falls_back_to_username(self):
+        from frontapp_public_api_client.domain import TeammateSummary
+
+        draft = Draft.model_validate({"id": "msg_abc"})
+        author = TeammateSummary(username="ada", first_name=None, last_name=None)
+        draft = draft.model_copy(update={"author": author})
+
+        summary = to_draft_summary(draft)
+        assert summary.author_name == "ada"

--- a/frontapp_public_api_client/docs/guide.md
+++ b/frontapp_public_api_client/docs/guide.md
@@ -60,14 +60,20 @@ async with FrontappClient() as client:
 
 ## Available helpers today
 
-| Helper                 | Status     | Covers                                                               |
-| ---------------------- | ---------- | -------------------------------------------------------------------- |
-| `client.conversations` | ✅ shipped | list/get/search/update/reply/list_messages/list_comments/add_comment |
-| `client.contacts`      | ⏳ planned | See issue tracker                                                    |
-| `client.messages`      | ⏳ planned | See issue tracker                                                    |
-| `client.tags`          | ⏳ planned | See issue tracker                                                    |
-| `client.inboxes`       | ⏳ planned | See issue tracker                                                    |
-| `client.teammates`     | ⏳ planned | See issue tracker                                                    |
+| Helper                 | Status     | Covers                                                           |
+| ---------------------- | ---------- | ---------------------------------------------------------------- |
+| `client.conversations` | ✅ shipped | list/get/search/update/list_messages/list_comments/add_comment   |
+| `client.drafts`        | ✅ shipped | list_for_conversation/create_on_channel/create_reply/edit/delete |
+| `client.contacts`      | ⏳ planned | See issue tracker                                                |
+| `client.messages`      | ⏳ planned | See issue tracker                                                |
+| `client.tags`          | ⏳ planned | See issue tracker                                                |
+| `client.inboxes`       | ⏳ planned | See issue tracker                                                |
+| `client.teammates`     | ⏳ planned | See issue tracker                                                |
+
+Outbound replies go through `client.drafts.create_reply(...)` rather than
+`client.conversations.reply(...)` — the latter still exists at the helper level for
+direct API access, but the recommended path is drafts-first: agents draft, humans review
+and send in Front's UI. Front has no programmatic `send_draft`.
 
 Anything without a helper is still fully usable via the generated API layer.
 

--- a/frontapp_public_api_client/domain/__init__.py
+++ b/frontapp_public_api_client/domain/__init__.py
@@ -23,10 +23,13 @@ from .conversation import (
     TeammateSummary,
 )
 from .converters import to_unset, unwrap_unset
+from .draft import AttachmentSummary, Draft
 
 __all__ = [
+    "AttachmentSummary",
     "Conversation",
     "ConversationPageCursor",
+    "Draft",
     "RecipientSummary",
     "TagSummary",
     "TeammateSummary",

--- a/frontapp_public_api_client/domain/draft.py
+++ b/frontapp_public_api_client/domain/draft.py
@@ -1,0 +1,83 @@
+"""Domain model for Frontapp drafts.
+
+A draft is an unsent message in Front (``msg_`` or ``dft_`` prefixed id). Drafts
+are the safe-by-default outbound path: an agent creates a draft, the human
+reviews it in Front's UI, and the human clicks send. There is no programmatic
+``send_draft`` endpoint in Front's spec — sending is always human-in-the-loop.
+
+The ``Draft`` projection mirrors Front's ``MessageResponse`` (the same shape
+``create_draft`` and ``edit_draft`` return), reusing ``TeammateSummary`` and
+``RecipientSummary`` from the conversations domain.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, field_validator
+
+from .conversation import RecipientSummary, TeammateSummary, _Frozen, _unix_to_datetime
+
+
+class AttachmentSummary(_Frozen):
+    """Subset of Front's ``Attachment`` schema surfaced on a Draft.
+
+    Drafts created without attachments expose an empty list. The actual upload
+    mechanism is unresolved upstream and tracked in #12; for now, drafts can
+    reference attachments that were uploaded through the Front UI.
+    """
+
+    id: str | None = Field(None, description="Attachment id, e.g. 'fil_abc123'")
+    filename: str | None = None
+    url: str | None = None
+    content_type: str | None = None
+    size: int | None = None
+
+
+class Draft(BaseModel):
+    """A Front draft message returned by ``create_draft`` / ``edit_draft``.
+
+    Front returns the full ``MessageResponse`` shape; this projection keeps
+    the fields callers actually use. ``draft_mode`` is one of ``'private'``
+    (visible to the author only) or ``'shared'`` (visible to all teammates
+    with access to the conversation).
+    """
+
+    id: str
+    message_uid: str | None = Field(
+        None, description="Front's secondary message UID for idempotency / dedup"
+    )
+    type_: str | None = Field(None, alias="type")
+    is_inbound: bool | None = None
+    draft_mode: Literal["private", "shared"] | None = None
+    error_type: str | None = Field(
+        None,
+        description="Populated when a previous send attempt failed (e.g. 'no_inbox')",
+    )
+    version: str | None = Field(
+        None,
+        description="Opaque version token; pass to edit_draft to avoid clobbering",
+    )
+    created_at: AwareDatetime | None = None
+    subject: str | None = None
+    blurb: str | None = Field(None, description="Plaintext preview of the body")
+    body: str | None = None
+    text: str | None = None
+    author: TeammateSummary | None = None
+    recipients: list[RecipientSummary] = Field(default_factory=list)
+    attachments: list[AttachmentSummary] = Field(default_factory=list)
+
+    model_config = ConfigDict(
+        frozen=True,
+        str_strip_whitespace=True,
+        extra="ignore",
+        populate_by_name=True,
+    )
+
+    @field_validator("created_at", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: Any) -> Any:
+        return _unix_to_datetime(value)
+
+
+__all__ = ["AttachmentSummary", "Draft"]

--- a/frontapp_public_api_client/frontapp_client.py
+++ b/frontapp_public_api_client/frontapp_client.py
@@ -19,6 +19,7 @@ from urllib.parse import parse_qs, quote, urlencode, urlparse, urlunparse
 
 if TYPE_CHECKING:
     from .helpers.conversations import Conversations
+    from .helpers.drafts import Drafts
 
 import httpx
 from dotenv import load_dotenv
@@ -1024,6 +1025,7 @@ class FrontappClient(AuthenticatedClient):
 
         # Domain helper instances (lazy-loaded via properties)
         self._conversations: Conversations | None = None
+        self._drafts: Drafts | None = None
 
         # Extract client-level parameters that shouldn't go to the transport
         # Event hooks for observability - start with our defaults
@@ -1101,6 +1103,20 @@ class FrontappClient(AuthenticatedClient):
         if self._conversations is None:
             self._conversations = Conversations(self)
         return self._conversations
+
+    @property
+    def drafts(self) -> "Drafts":
+        """Ergonomic operations over Frontapp's draft endpoints.
+
+        Drafts are the safe-by-default outbound path: an agent creates the
+        draft, the human reviews in Front, and the human clicks send. There
+        is no programmatic ``send_draft`` — sending is human-in-the-loop.
+        """
+        from .helpers.drafts import Drafts
+
+        if self._drafts is None:
+            self._drafts = Drafts(self)
+        return self._drafts
 
     # Event hooks for observability
     async def _capture_pagination_metadata(self, response: httpx.Response) -> None:

--- a/frontapp_public_api_client/helpers/drafts.py
+++ b/frontapp_public_api_client/helpers/drafts.py
@@ -1,0 +1,277 @@
+"""Drafts helper facade — ergonomic wrappers around generated draft endpoints.
+
+Exposes ``client.drafts.{list_for_conversation, create_on_channel, create_reply,
+edit, delete}`` with domain-model returns where Front returns a body. Drafts are
+the safe-by-default outbound path: an agent creates a draft, the human reviews
+it in Front's UI, and the human clicks send. There is no programmatic
+``send_draft`` endpoint — sending is always human-in-the-loop.
+
+Notes:
+
+- ``edit`` and ``create_reply`` build ``EditDraft`` / ``ReplyDraft`` models which
+  require both ``body`` AND ``channel_id``. Front treats PATCH /drafts/{id}/ as a
+  full replacement, so callers must re-supply the body even when only changing
+  metadata.
+- ``list_for_conversation`` returns raw attrs ``MessageResponse`` items pulled
+  out of the standard ``field_results`` wrapper. (``api-facts.yaml`` classifies
+  this endpoint as ``raw_array`` due to an "Any takes precedence" quirk in the
+  classifier, but the runtime parsed type is
+  ``ListConversationDraftsResponse200`` with ``field_results: list[MessageResponse]``
+  — same shape as every other Front list endpoint.)
+- ``attachments`` is accepted as a typed pass-through (``list[File] | None``)
+  on all three mutation helpers; the actual upload mechanism is unresolved
+  upstream and tracked in #12. Callers who already have ``File`` objects (e.g.
+  from ``models.attachment``) can pass them through; the MCP tool surface
+  doesn't expose attachments yet because the upload flow needs to land first.
+"""
+
+from __future__ import annotations
+
+import builtins
+from typing import TYPE_CHECKING, Any, Literal
+
+from frontapp_public_api_client.helpers.base import Base
+
+if TYPE_CHECKING:
+    from frontapp_public_api_client.domain import Draft
+    from frontapp_public_api_client.models.message_response import MessageResponse
+
+
+class Drafts(Base):
+    """Ergonomic operations over Frontapp's drafts endpoints."""
+
+    # -- reads --------------------------------------------------------------
+
+    async def list_for_conversation(
+        self, conversation_id: str
+    ) -> builtins.list[MessageResponse]:
+        """List drafts on a conversation. Returns raw attrs ``MessageResponse``s.
+
+        Despite api-facts.yaml's ``raw_array`` classification (a known
+        classifier quirk where ``Any`` takes precedence over the real wrapper
+        in the union), the runtime parsed type is
+        ``ListConversationDraftsResponse200`` with the standard ``field_results``
+        wrapper. Callers wanting a domain projection should
+        ``Draft.model_validate(item.to_dict())`` per item.
+        """
+        from frontapp_public_api_client.api.drafts import list_conversation_drafts
+        from frontapp_public_api_client.utils import unwrap
+
+        response = await list_conversation_drafts.asyncio_detailed(
+            conversation_id=conversation_id, client=self._client
+        )
+        parsed = unwrap(response)
+        return list(getattr(parsed, "field_results", None) or [])
+
+    # -- mutations ----------------------------------------------------------
+
+    async def create_on_channel(
+        self,
+        channel_id: str,
+        *,
+        body: str,
+        author_id: str | None = None,
+        subject: str | None = None,
+        to: builtins.list[str] | None = None,
+        cc: builtins.list[str] | None = None,
+        bcc: builtins.list[str] | None = None,
+        quote_body: str | None = None,
+        attachments: builtins.list[Any] | None = None,
+        mode: Literal["private", "shared"] | None = None,
+        signature_id: str | None = None,
+        should_add_default_signature: bool | None = None,
+    ) -> Draft:
+        """Create a new draft on a channel (no existing conversation).
+
+        Returns the created ``Draft``. The human reviews it in Front and sends.
+        ``attachments`` accepts ``list[File]`` from ``models.attachment``;
+        upload mechanism is tracked in #12.
+        """
+        from frontapp_public_api_client.api.drafts import create_draft
+        from frontapp_public_api_client.domain import Draft
+        from frontapp_public_api_client.models.create_draft import CreateDraft
+        from frontapp_public_api_client.models.create_draft_mode import (
+            CreateDraftMode,
+        )
+        from frontapp_public_api_client.models.message_response import MessageResponse
+        from frontapp_public_api_client.utils import unwrap_as
+
+        payload_kwargs: dict[str, Any] = {"body": body}
+        if author_id is not None:
+            payload_kwargs["author_id"] = author_id
+        if subject is not None:
+            payload_kwargs["subject"] = subject
+        if to is not None:
+            payload_kwargs["to"] = to
+        if cc is not None:
+            payload_kwargs["cc"] = cc
+        if bcc is not None:
+            payload_kwargs["bcc"] = bcc
+        if quote_body is not None:
+            payload_kwargs["quote_body"] = quote_body
+        if attachments is not None:
+            payload_kwargs["attachments"] = attachments
+        if mode is not None:
+            payload_kwargs["mode"] = CreateDraftMode(mode)
+        if signature_id is not None:
+            payload_kwargs["signature_id"] = signature_id
+        if should_add_default_signature is not None:
+            payload_kwargs["should_add_default_signature"] = (
+                should_add_default_signature
+            )
+
+        draft_body = CreateDraft(**payload_kwargs)
+        response = await create_draft.asyncio_detailed(
+            channel_id=channel_id, client=self._client, body=draft_body
+        )
+        message = unwrap_as(response, MessageResponse)
+        return Draft.model_validate(message.to_dict())
+
+    async def create_reply(
+        self,
+        conversation_id: str,
+        *,
+        body: str,
+        channel_id: str,
+        author_id: str | None = None,
+        subject: str | None = None,
+        to: builtins.list[str] | None = None,
+        cc: builtins.list[str] | None = None,
+        bcc: builtins.list[str] | None = None,
+        quote_body: str | None = None,
+        attachments: builtins.list[Any] | None = None,
+        mode: Literal["private", "shared"] | None = None,
+        signature_id: str | None = None,
+        should_add_default_signature: bool | None = None,
+    ) -> Draft:
+        """Create a draft reply on an existing conversation.
+
+        ``channel_id`` is required — Front uses it to pick which channel the
+        outbound reply will eventually send through. Returns the created
+        ``Draft`` (Front's ``_parse_response`` parses ``MessageResponse`` on
+        200 — the spec's ``Any`` arm covers redirects only).
+        """
+        from frontapp_public_api_client.api.drafts import create_draft_reply
+        from frontapp_public_api_client.domain import Draft
+        from frontapp_public_api_client.models.create_draft_mode import (
+            CreateDraftMode,
+        )
+        from frontapp_public_api_client.models.message_response import MessageResponse
+        from frontapp_public_api_client.models.reply_draft import ReplyDraft
+        from frontapp_public_api_client.utils import unwrap_as
+
+        payload_kwargs: dict[str, Any] = {"body": body, "channel_id": channel_id}
+        if author_id is not None:
+            payload_kwargs["author_id"] = author_id
+        if subject is not None:
+            payload_kwargs["subject"] = subject
+        if to is not None:
+            payload_kwargs["to"] = to
+        if cc is not None:
+            payload_kwargs["cc"] = cc
+        if bcc is not None:
+            payload_kwargs["bcc"] = bcc
+        if quote_body is not None:
+            payload_kwargs["quote_body"] = quote_body
+        if attachments is not None:
+            payload_kwargs["attachments"] = attachments
+        if mode is not None:
+            payload_kwargs["mode"] = CreateDraftMode(mode)
+        if signature_id is not None:
+            payload_kwargs["signature_id"] = signature_id
+        if should_add_default_signature is not None:
+            payload_kwargs["should_add_default_signature"] = (
+                should_add_default_signature
+            )
+
+        reply = ReplyDraft(**payload_kwargs)
+        response = await create_draft_reply.asyncio_detailed(
+            conversation_id=conversation_id, client=self._client, body=reply
+        )
+        message = unwrap_as(response, MessageResponse)
+        return Draft.model_validate(message.to_dict())
+
+    async def edit(
+        self,
+        draft_id: str,
+        *,
+        body: str,
+        channel_id: str,
+        author_id: str | None = None,
+        subject: str | None = None,
+        to: builtins.list[str] | None = None,
+        cc: builtins.list[str] | None = None,
+        bcc: builtins.list[str] | None = None,
+        quote_body: str | None = None,
+        attachments: builtins.list[Any] | None = None,
+        mode: Literal["shared"] | None = None,
+        signature_id: str | None = None,
+        should_add_default_signature: bool | None = None,
+        version: str | None = None,
+    ) -> Draft:
+        """Edit a draft (full-replacement PATCH).
+
+        Front's PATCH /drafts/{id}/ replaces the draft body — ``body`` and
+        ``channel_id`` are both required even if you're only changing
+        metadata. Pass ``version`` (from a prior ``Draft.version`` token) to
+        avoid clobbering concurrent edits.
+
+        ``mode`` only accepts ``'shared'`` here (Front narrows the enum on
+        edit; private drafts can't be re-shared via this endpoint).
+
+        The endpoint path is ``/drafts/{message_id}/`` — note the trailing
+        slash and the parameter rename. The helper accepts ``draft_id`` and
+        passes it through as ``message_id`` to the generated module.
+        """
+        from frontapp_public_api_client.api.drafts import edit_draft
+        from frontapp_public_api_client.domain import Draft
+        from frontapp_public_api_client.models.edit_draft import EditDraft
+        from frontapp_public_api_client.models.edit_draft_mode import EditDraftMode
+        from frontapp_public_api_client.models.message_response import MessageResponse
+        from frontapp_public_api_client.utils import unwrap_as
+
+        payload_kwargs: dict[str, Any] = {"body": body, "channel_id": channel_id}
+        if author_id is not None:
+            payload_kwargs["author_id"] = author_id
+        if subject is not None:
+            payload_kwargs["subject"] = subject
+        if to is not None:
+            payload_kwargs["to"] = to
+        if cc is not None:
+            payload_kwargs["cc"] = cc
+        if bcc is not None:
+            payload_kwargs["bcc"] = bcc
+        if quote_body is not None:
+            payload_kwargs["quote_body"] = quote_body
+        if attachments is not None:
+            payload_kwargs["attachments"] = attachments
+        if mode is not None:
+            payload_kwargs["mode"] = EditDraftMode(mode)
+        if signature_id is not None:
+            payload_kwargs["signature_id"] = signature_id
+        if should_add_default_signature is not None:
+            payload_kwargs["should_add_default_signature"] = (
+                should_add_default_signature
+            )
+        if version is not None:
+            payload_kwargs["version"] = version
+
+        edit_body = EditDraft(**payload_kwargs)
+        response = await edit_draft.asyncio_detailed(
+            message_id=draft_id, client=self._client, body=edit_body
+        )
+        message = unwrap_as(response, MessageResponse)
+        return Draft.model_validate(message.to_dict())
+
+    async def delete(self, draft_id: str) -> bool:
+        """Delete a draft by id. Returns ``True`` on success (204 No Content)."""
+        from frontapp_public_api_client.api.drafts import delete_draft
+        from frontapp_public_api_client.utils import is_success
+
+        response = await delete_draft.asyncio_detailed(
+            draft_id=draft_id, client=self._client
+        )
+        return is_success(response)
+
+
+__all__ = ["Drafts"]

--- a/tests/test_drafts.py
+++ b/tests/test_drafts.py
@@ -1,0 +1,230 @@
+"""Tests for the drafts vertical: Draft domain model + Drafts helper."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import httpx
+import pydantic
+import pytest
+
+from frontapp_public_api_client.domain import AttachmentSummary, Draft
+
+# ---------------------------------------------------------------------------
+# Domain model: Draft
+# ---------------------------------------------------------------------------
+
+
+class TestDraftDomain:
+    """Pydantic-level validation of the Draft projection."""
+
+    def test_minimal_payload_validates(self):
+        """A draft with only an id should validate (everything else is optional)."""
+        d = Draft.model_validate({"id": "msg_abc"})
+        assert d.id == "msg_abc"
+        assert d.subject is None
+        assert d.recipients == []
+        assert d.attachments == []
+
+    def test_unix_timestamp_converts_to_aware_datetime(self):
+        """Front sends created_at as unix-seconds float; the validator converts."""
+        d = Draft.model_validate({"id": "msg_abc", "created_at": 1701292639})
+        assert isinstance(d.created_at, datetime)
+        assert d.created_at == datetime.fromtimestamp(1701292639, tz=UTC)
+
+    def test_iso_string_timestamp_passes_through(self):
+        """An already-parsed datetime string should be accepted as-is."""
+        d = Draft.model_validate(
+            {"id": "msg_abc", "created_at": "2024-01-01T12:00:00+00:00"}
+        )
+        assert d.created_at == datetime(2024, 1, 1, 12, 0, tzinfo=UTC)
+
+    def test_extra_fields_ignored(self):
+        """Front's MessageResponse carries fields the projection doesn't surface."""
+        d = Draft.model_validate(
+            {
+                "id": "msg_abc",
+                "_links": {"self": "https://api2.frontapp.com/drafts/msg_abc"},
+                "metadata": {"headers": {}},
+                "signature": {"id": "sig_abc"},
+            }
+        )
+        assert d.id == "msg_abc"
+        # Should not raise; extras silently ignored.
+
+    def test_draft_mode_literal_accepts_valid_values(self):
+        for mode in ("private", "shared"):
+            d = Draft.model_validate({"id": "msg_abc", "draft_mode": mode})
+            assert d.draft_mode == mode
+
+    def test_draft_mode_literal_rejects_unknown(self):
+        with pytest.raises(pydantic.ValidationError):
+            Draft.model_validate({"id": "msg_abc", "draft_mode": "broadcast"})
+
+    def test_attachment_summary_projects(self):
+        d = Draft.model_validate(
+            {
+                "id": "msg_abc",
+                "attachments": [
+                    {
+                        "id": "fil_1",
+                        "filename": "invoice.pdf",
+                        "url": "https://...",
+                        "content_type": "application/pdf",
+                        "size": 1024,
+                    }
+                ],
+            }
+        )
+        assert len(d.attachments) == 1
+        assert isinstance(d.attachments[0], AttachmentSummary)
+        assert d.attachments[0].filename == "invoice.pdf"
+
+    def test_frozen(self):
+        """Draft is immutable per ConfigDict(frozen=True)."""
+        d = Draft.model_validate({"id": "msg_abc"})
+        with pytest.raises(pydantic.ValidationError):
+            d.id = "msg_xyz"  # type: ignore[misc]
+
+    def test_type_alias_field(self):
+        """``type`` is a Python keyword; the field uses an alias."""
+        d = Draft.model_validate({"id": "msg_abc", "type": "email"})
+        assert d.type_ == "email"
+
+
+# ---------------------------------------------------------------------------
+# Helper: client.drafts.list_for_conversation (raw_array unwrap)
+# ---------------------------------------------------------------------------
+
+
+class TestDraftsHelper:
+    """Helper-level integration via httpx.MockTransport.
+
+    The drafts vertical is the first to add helper tests under tests/; the
+    conversations vertical landed without unit tests. Future verticals should
+    follow this pattern.
+    """
+
+    def _mock_response(
+        self, payload: list[dict] | dict, status: int = 200
+    ) -> httpx.MockTransport:
+        """Build a MockTransport that returns ``payload`` for every request."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(status, json=payload)
+
+        return httpx.MockTransport(handler)
+
+    @pytest.fixture
+    def drafts_client(self, mock_api_credentials):
+        """A FrontappClient whose transport will be patched per test."""
+        from frontapp_public_api_client import FrontappClient
+
+        return FrontappClient(**mock_api_credentials)
+
+    async def test_list_for_conversation_unwraps_field_results(
+        self, mock_api_credentials
+    ):
+        """list_conversation_drafts returns the standard field_results wrapper.
+
+        Despite api-facts.yaml's raw_array classification (a known classifier
+        quirk), the runtime parsed type is ListConversationDraftsResponse200
+        with the field_results wrapper.
+        """
+        from frontapp_public_api_client import FrontappClient
+
+        client = FrontappClient(**mock_api_credentials)
+        client.set_async_httpx_client(
+            httpx.AsyncClient(
+                transport=self._mock_response(
+                    {
+                        "_results": [
+                            {"id": "msg_1", "type": "email", "is_inbound": False},
+                            {"id": "msg_2", "type": "email", "is_inbound": False},
+                        ],
+                        "_pagination": {},
+                        "_links": {},
+                    }
+                ),
+                base_url=mock_api_credentials["base_url"],
+            )
+        )
+
+        drafts = await client.drafts.list_for_conversation("cnv_abc")
+        assert len(drafts) == 2
+        assert [d.id for d in drafts] == ["msg_1", "msg_2"]
+
+    async def test_list_for_conversation_empty(self, mock_api_credentials):
+        from frontapp_public_api_client import FrontappClient
+
+        client = FrontappClient(**mock_api_credentials)
+        client.set_async_httpx_client(
+            httpx.AsyncClient(
+                transport=self._mock_response(
+                    {"_results": [], "_pagination": {}, "_links": {}}
+                ),
+                base_url=mock_api_credentials["base_url"],
+            )
+        )
+
+        drafts = await client.drafts.list_for_conversation("cnv_abc")
+        assert drafts == []
+
+    async def test_create_on_channel_returns_domain_draft(self, mock_api_credentials):
+        from frontapp_public_api_client import FrontappClient
+
+        client = FrontappClient(**mock_api_credentials)
+        client.set_async_httpx_client(
+            httpx.AsyncClient(
+                transport=self._mock_response(
+                    {
+                        "id": "msg_new",
+                        "type": "email",
+                        "is_inbound": False,
+                        "draft_mode": "shared",
+                        "subject": "Hello",
+                        "body": "<p>Hi there</p>",
+                        "blurb": "Hi there",
+                        "created_at": 1701292639,
+                    }
+                ),
+                base_url=mock_api_credentials["base_url"],
+            )
+        )
+
+        draft = await client.drafts.create_on_channel(
+            "cha_abc",
+            body="<p>Hi there</p>",
+            subject="Hello",
+            mode="shared",
+        )
+        assert isinstance(draft, Draft)
+        assert draft.id == "msg_new"
+        assert draft.draft_mode == "shared"
+        # Unix-seconds → AwareDatetime via the validator.
+        assert isinstance(draft.created_at, datetime)
+
+    async def test_delete_returns_true_on_204(self, mock_api_credentials):
+        from frontapp_public_api_client import FrontappClient
+
+        client = FrontappClient(**mock_api_credentials)
+        client.set_async_httpx_client(
+            httpx.AsyncClient(
+                transport=httpx.MockTransport(
+                    lambda req: httpx.Response(204, content=b"")
+                ),
+                base_url=mock_api_credentials["base_url"],
+            )
+        )
+
+        success = await client.drafts.delete("msg_abc")
+        assert success is True
+
+    def test_drafts_property_lazy_caches(self, mock_api_credentials):
+        """``client.drafts`` returns the same Drafts instance across calls."""
+        from frontapp_public_api_client import FrontappClient
+
+        client = FrontappClient(**mock_api_credentials)
+        first = client.drafts
+        second = client.drafts
+        assert first is second


### PR DESCRIPTION
## Summary

First-class drafts vertical, per #14 (HIGH PRIORITY). Establishes the **drafts-first outbound** pattern: agents draft, humans review and send in Front's UI. The Frontapp MCP no longer exposes any tool that sends a customer-facing message directly — outbound flows always pass through `create_draft_reply` / `create_draft_on_channel`.

## What ships

### `client.drafts` helper (5 methods)

- `list_for_conversation(conversation_id)` → `list[MessageResponse]` — uses the standard `field_results` unwrap despite `api-facts.yaml` classifying as `raw_array` (known classifier quirk; runtime parsed type is `ListConversationDraftsResponse200`)
- `create_on_channel(channel_id, body, ...)` → `Draft`
- `create_reply(conversation_id, body, channel_id, ...)` → raw response
- `edit(draft_id, body, channel_id, ...)` → `Draft` — full-replacement PATCH; `body` + `channel_id` are both required even when only changing metadata
- `delete(draft_id)` → `bool`

### `Draft` domain model

Pydantic v2 projection of `MessageResponse`, reusing `TeammateSummary` + `RecipientSummary` from the conversations domain. New tiny `AttachmentSummary` (placeholder for #12). Frozen, `extra="ignore"`, unix-timestamp validator on `created_at`.

### 5 new MCP tools (all 4 mutations use two-step confirm)

- `list_conversation_drafts` (cached 30s)
- `create_draft_on_channel`
- `create_draft_reply`
- `edit_draft`
- `delete_draft`

### `reply_to_conversation` removed

The conversations vertical no longer exposes a direct-send MCP tool. `server.py:instructions=` steers the LLM toward drafts. The Python helper `client.conversations.reply()` stays for direct API access — only the MCP tool surface enforces drafts-first.

### ADR-0016 amended

New section "Drafts-first outbound" documenting the third safety gate beyond preview + elicitation: the human is the only one who can actually send.

## Scope decisions vs the issue body

| Decision | Rationale |
| -------- | --------- |
| **No `send_draft` tool** | Front has no `/drafts/{id}/send` endpoint. |
| **No `get_draft` tool** | Front has no `GET /drafts/{id}`. Lookup goes through `list_conversation_drafts` + filter. |
| **Attachments pass-through** | Typed as `list[Any] \| None`; full upload mechanism is unresolved upstream and tracked in #12. |
| **`edit_draft` trailing slash** | `/drafts/{message_id}/` is preserved at the API layer; the parameter is surfaced as `draft_id` at the helper boundary. |

## Tests

**First helper-level tests** in this repo — `tests/test_drafts.py` establishes the pattern future verticals will reuse:

- Domain validation: minimal payload, unix timestamp coercion, ISO string passthrough, `extra="ignore"`, frozen-ness, `draft_mode` Literal validation, attachment projection, `type` alias
- Helper integration via `httpx.MockTransport`: `field_results` unwrap, empty response, `create_on_channel` round-trip, 204 delete
- Lazy-property caching

`frontapp_mcp_server/tests/test_drafts_tools.py` — MCP-tool tests:

- Preview path (4 mutations × no API call)
- Declined elicitation path (no API call)
- Confirmed execution path (helper invoked with correct shape)
- `DraftSummary` projection (author name from first/last + username fallback)

22 new tests added, 65 passing total.

## Test plan

- [x] `uv run poe check` passes (format, prettier, ruff, ty, yamllint, pytest, api-facts)
- [x] `uv run poe facts` regenerated; `tags.drafts.helper.built` and `tags.drafts.domain.built` flipped to `true`
- [x] grep confirms no remaining `reply_to_conversation` references in MCP tool surface or instructions

Closes #14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)