### PR TITLE
chore(harness): drop ruff check --fix from format-on-edit hook (#50)

### DIFF
--- a/.claude/hooks/format-on-edit.sh
+++ b/.claude/hooks/format-on-edit.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
 # PostToolUse hook: silently format files after Edit/Write/MultiEdit succeeds.
 #
-# - *.py  → ruff check --fix && ruff format (one `uv run` to amortize startup)
+# - *.py  → ruff format (style only — NO ruff check --fix; see #50)
 # - *.md  → ./node_modules/.bin/prettier --write (direct binary, skips pnpm shim)
+#
+# This hook is intentionally **format-only**, not lint-and-fix. Earlier
+# versions ran `ruff check --fix` here too, but it caused a race where
+# TYPE_CHECKING imports got pruned between an agent's two Edits (one adding
+# the import, the next adding the usage) — every vertical PR hit it 3-5
+# times. Linting still happens at `uv run poe check` and in CI; doing it on
+# every edit was over-eager.
 #
 # Zero-token on success. Never blocks (exit 0 even when the formatter exits
 # non-zero) — formatting failures must not undo a successful edit. PostToolUse
@@ -63,10 +70,8 @@ cd "$CLAUDE_PROJECT_DIR" || exit 0
 case "$file_path" in
   *.py)
     if command -v uv >/dev/null 2>&1; then
-      # One `uv run` invocation for both — amortizes uv's setup cost
-      # (~150-300ms) so a typical .py edit takes ~half as long.
-      uv run sh -c 'ruff check --fix "$1" && ruff format "$1"' _ "$file_path" \
-        >/dev/null 2>&1 || true
+      # Format-only — NO `ruff check --fix`. See header comment + #50.
+      uv run ruff format "$file_path" >/dev/null 2>&1 || true
     fi
     ;;
   *.md)


### PR DESCRIPTION
## Summary

The format-on-edit PostToolUse hook ran `ruff check --fix && ruff format` on every successful Edit. The `--fix` half is destructive about unused imports, which caused a race in agent-driven multi-edit workflows:

1. Agent edits a file to add `from .foo import Bar` under `TYPE_CHECKING`
2. Hook fires, sees `Bar` unused, prunes the import
3. Agent's next edit adds `bar: Bar | None = None`
4. Validation fails with F821: undefined name `Bar`

Drafts (#45) hit this 3 times; contacts (#46) hit it 3 more. Every TYPE_CHECKING import in a vertical PR ended up costing extra edits.

## Change

Drop `ruff check --fix` from the hook. Keep `ruff format` (style-only, semantic-neutral). Lint errors are surfaced at `uv run poe check` and in CI — that's the right tier; doing it on every edit was over-eager.

```bash
# Before
uv run sh -c 'ruff check --fix "$1" && ruff format "$1"' _ "$file_path"

# After
uv run ruff format "$file_path"
```

Updated the header comment to call out the format-only intent and reference #50 so future hook editors don't accidentally re-add `--fix`.

## Test plan

- [x] Smoke test: misformatted `.py` file → still gets reformatted
- [x] Smoke test: unused-import `.py` file → import preserved (was: pruned)
- [x] `uv run poe check` — all 104 tests pass

Closes #50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)