### PR TITLE
feat(client,mcp): tags & inboxes management vertical (#5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,8 @@ tools.json
 # Node.js / TypeScript packages
 node_modules/
 *.tsbuildinfo
+
+# Override global ~/.config/git/ignore patterns that match generated subdirs.
+# Some users have `tags` (ctags) globally ignored, which silently drops the
+# generated `api/tags/` package — this negation keeps it tracked.
+!frontapp_public_api_client/api/tags/

--- a/README.md
+++ b/README.md
@@ -134,14 +134,16 @@ channels, rules, custom fields, drafts, message templates, analytics, and more. 
 Hand-written ergonomic helpers (Python `client.<resource>.…`) and MCP tools wrap the
 highest-value subset. Current status:
 
-| Resource                 | Python helper (`client.X.…`) | MCP tools                                                                                                                                                                                        |
-| ------------------------ | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Conversations            | ✅ `.conversations`          | list / get / search / list_messages / list_comments / update / add_comment                                                                                                                       |
-| Drafts                   | ✅ `.drafts`                 | list_conversation_drafts / create_draft_on_channel / create_draft_reply / edit_draft / delete_draft                                                                                              |
-| Contacts                 | ✅ `.contacts`               | list / get / lookup_by_email / list_team / list_teammate / list_conversations / list_notes / create (+ team/teammate variants) / update / merge / delete / add_note / add_handle / delete_handle |
-| Messages                 | ✅ `.messages`               | get / seen_status / mark_seen                                                                                                                                                                    |
-| Tags, Inboxes, Teammates | ⏳ planned                   | ⏳ planned (also as `frontapp://` resources)                                                                                                                                                     |
-| Analytics                | ⏳ planned                   | ⏳ planned (create→poll recipe)                                                                                                                                                                  |
+| Resource      | Python helper (`client.X.…`) | MCP tools                                                                                                                                                                                        |
+| ------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Conversations | ✅ `.conversations`          | list / get / search / list_messages / list_comments / update / add_comment                                                                                                                       |
+| Drafts        | ✅ `.drafts`                 | list_conversation_drafts / create_draft_on_channel / create_draft_reply / edit_draft / delete_draft                                                                                              |
+| Contacts      | ✅ `.contacts`               | list / get / lookup_by_email / list_team / list_teammate / list_conversations / list_notes / create (+ team/teammate variants) / update / merge / delete / add_note / add_handle / delete_handle |
+| Messages      | ✅ `.messages`               | get / seen_status / mark_seen                                                                                                                                                                    |
+| Tags          | ✅ `.tags`                   | list (+ company/team/teammate scopes) / get / list_children / list_tagged_conversations / add_tag_to_conversation / remove_tag_from_conversation / create / create_child / update / delete       |
+| Inboxes       | ✅ `.inboxes`                | list (+ team/teammate scopes) / get / list_conversations / list_channels / list_access / create (+ team) / grant_access / revoke_access                                                          |
+| Teammates     | ⏳ planned                   | ⏳ planned (currently `frontapp://teammates` resource)                                                                                                                                           |
+| Analytics     | ⏳ planned                   | ⏳ planned (create→poll recipe)                                                                                                                                                                  |
 
 See the [issue tracker](https://github.com/dougborg/frontapp-openapi-client/issues) for
 the roadmap. The full generated surface is usable today via direct imports from

--- a/docs/api-facts.yaml
+++ b/docs/api-facts.yaml
@@ -17,8 +17,8 @@
 #      domain wiring status, full path/method/response info).
 #
 schema_version: 1
-generated_at: '2026-04-26T22:41:46+00:00'
-generated_from_commit: 8666688fd4d7a067db0916c41c75491c178c6817
+generated_at: '2026-04-26T22:42:31+00:00'
+generated_from_commit: fd5ac1040479d1e4df9467e6643d0067e2154de5
 summary:
   list_endpoints_with_field_results:
     - accounts.list_account_contacts
@@ -237,6 +237,7 @@ summary:
     - contacts
     - conversations
     - drafts
+    - inboxes
     - tags
 tags:
   accounts:
@@ -979,9 +980,9 @@ tags:
       path: frontapp_public_api_client/helpers/inboxes.py
       class: Inboxes
     domain:
-      built: false
-      path: null
-      class: null
+      built: true
+      path: frontapp_public_api_client/domain/inbox.py
+      class: Inbox
     endpoints:
       - module: add_inbox_access
         method: POST

--- a/docs/api-facts.yaml
+++ b/docs/api-facts.yaml
@@ -17,8 +17,8 @@
 #      domain wiring status, full path/method/response info).
 #
 schema_version: 1
-generated_at: '2026-04-26T22:42:31+00:00'
-generated_from_commit: fd5ac1040479d1e4df9467e6643d0067e2154de5
+generated_at: '2026-04-26T22:43:24+00:00'
+generated_from_commit: ef58d8d6aed55813d6a573962f7acf7310afdfce
 summary:
   list_endpoints_with_field_results:
     - accounts.list_account_contacts
@@ -84,6 +84,12 @@ summary:
     - signatures.list_team_signatures
     - signatures.list_teammate_signatures
     - statuses.list_company_ticket_statuses
+    - tags.list_company_tags
+    - tags.list_tag_children
+    - tags.list_tagged_conversations
+    - tags.list_tags
+    - tags.list_team_tags
+    - tags.list_teammate_tags
     - teammate_groups.list_company_teammate_group_team_inboxes
     - teammate_groups.list_company_teammate_group_teammates
     - teammate_groups.list_company_teammate_group_teams
@@ -192,6 +198,13 @@ summary:
     - signatures.create_teammate_signature
     - signatures.delete_signature
     - signatures.update_signature
+    - tags.create_child_tag
+    - tags.create_company_tag
+    - tags.create_tag
+    - tags.create_team_tag
+    - tags.create_teammate_tag
+    - tags.delete_tag
+    - tags.update_a_tag
     - teammate_groups.add_company_teammate_group_team_inboxes
     - teammate_groups.add_company_teammate_group_teammates
     - teammate_groups.add_company_teammate_group_teams
@@ -225,6 +238,7 @@ summary:
     - knowledge_bases.get_a_knowledge_base_with_content_in_default_locale
     - knowledge_bases.get_a_knowledge_base_with_content_in_specified_locale
     - links.update_a_link
+    - tags.update_a_tag
     - teammate_groups.update_a_company_teammate_group
   tags_with_helper:
     - contacts
@@ -1731,7 +1745,93 @@ tags:
       built: true
       path: frontapp_public_api_client/domain/tag.py
       class: Tag
-    endpoints: []
+    endpoints:
+      - module: create_child_tag
+        method: POST
+        path: /tags/{tag_id}/children
+        response_type: TagResponse
+        list_shape: mutation
+        category: create
+      - module: create_company_tag
+        method: POST
+        path: /company/tags
+        response_type: TagResponse
+        list_shape: mutation
+        category: create
+      - module: create_tag
+        method: POST
+        path: /tags
+        response_type: TagResponse
+        list_shape: mutation
+        category: create
+      - module: create_team_tag
+        method: POST
+        path: /teams/{team_id}/tags
+        response_type: TagResponse
+        list_shape: mutation
+        category: create
+      - module: create_teammate_tag
+        method: POST
+        path: /teammates/{teammate_id}/tags
+        response_type: TagResponse
+        list_shape: mutation
+        category: create
+      - module: delete_tag
+        method: DELETE
+        path: /tags/{tag_id}
+        response_type: Any
+        list_shape: mutation
+        category: delete
+      - module: get_tag
+        method: GET
+        path: /tags/{tag_id}
+        response_type: TagResponse
+        list_shape: single
+        category: get
+      - module: list_company_tags
+        method: GET
+        path: /company/tags
+        response_type: ListCompanyTagsResponse200
+        list_shape: field_results
+        category: list
+      - module: list_tag_children
+        method: GET
+        path: /tags/{tag_id}/children
+        response_type: ListTagChildrenResponse200
+        list_shape: field_results
+        category: list
+      - module: list_tagged_conversations
+        method: GET
+        path: /tags/{tag_id}/conversations
+        response_type: ListTaggedConversationsResponse200
+        list_shape: field_results
+        category: list
+      - module: list_tags
+        method: GET
+        path: /tags
+        response_type: ListTagsResponse200
+        list_shape: field_results
+        category: list
+      - module: list_team_tags
+        method: GET
+        path: /teams/{team_id}/tags
+        response_type: ListTeamTagsResponse200
+        list_shape: field_results
+        category: list
+      - module: list_teammate_tags
+        method: GET
+        path: /teammates/{teammate_id}/tags
+        response_type: ListTeammateTagsResponse200
+        list_shape: field_results
+        category: list
+      - module: update_a_tag
+        method: PATCH
+        path: /tags/{tag_id}
+        response_type: Any
+        list_shape: mutation
+        category: update
+        quirks:
+          - _a_infix
   teammate_groups:
     spec_tag: Teammate Groups
     api_dir: frontapp_public_api_client/api/teammate_groups

--- a/docs/api-facts.yaml
+++ b/docs/api-facts.yaml
@@ -17,8 +17,8 @@
 #      domain wiring status, full path/method/response info).
 #
 schema_version: 1
-generated_at: '2026-04-26T21:04:22+00:00'
-generated_from_commit: 2f4d09b4b756b612dad5089dbc67f9d9554506f9
+generated_at: '2026-04-26T22:41:46+00:00'
+generated_from_commit: 8666688fd4d7a067db0916c41c75491c178c6817
 summary:
   list_endpoints_with_field_results:
     - accounts.list_account_contacts
@@ -84,12 +84,6 @@ summary:
     - signatures.list_team_signatures
     - signatures.list_teammate_signatures
     - statuses.list_company_ticket_statuses
-    - tags.list_company_tags
-    - tags.list_tag_children
-    - tags.list_tagged_conversations
-    - tags.list_tags
-    - tags.list_team_tags
-    - tags.list_teammate_tags
     - teammate_groups.list_company_teammate_group_team_inboxes
     - teammate_groups.list_company_teammate_group_teammates
     - teammate_groups.list_company_teammate_group_teams
@@ -198,13 +192,6 @@ summary:
     - signatures.create_teammate_signature
     - signatures.delete_signature
     - signatures.update_signature
-    - tags.create_child_tag
-    - tags.create_company_tag
-    - tags.create_tag
-    - tags.create_team_tag
-    - tags.create_teammate_tag
-    - tags.delete_tag
-    - tags.update_a_tag
     - teammate_groups.add_company_teammate_group_team_inboxes
     - teammate_groups.add_company_teammate_group_teammates
     - teammate_groups.add_company_teammate_group_teams
@@ -238,17 +225,19 @@ summary:
     - knowledge_bases.get_a_knowledge_base_with_content_in_default_locale
     - knowledge_bases.get_a_knowledge_base_with_content_in_specified_locale
     - links.update_a_link
-    - tags.update_a_tag
     - teammate_groups.update_a_company_teammate_group
   tags_with_helper:
     - contacts
     - conversations
     - drafts
+    - inboxes
     - messages
+    - tags
   tags_with_domain:
     - contacts
     - conversations
     - drafts
+    - tags
 tags:
   accounts:
     spec_tag: Accounts
@@ -986,9 +975,9 @@ tags:
     spec_tag: Inboxes
     api_dir: frontapp_public_api_client/api/inboxes
     helper:
-      built: false
-      path: null
-      class: null
+      built: true
+      path: frontapp_public_api_client/helpers/inboxes.py
+      class: Inboxes
     domain:
       built: false
       path: null
@@ -1734,100 +1723,14 @@ tags:
     spec_tag: Tags
     api_dir: frontapp_public_api_client/api/tags
     helper:
-      built: false
-      path: null
-      class: null
+      built: true
+      path: frontapp_public_api_client/helpers/tags.py
+      class: Tags
     domain:
-      built: false
-      path: null
-      class: null
-    endpoints:
-      - module: create_child_tag
-        method: POST
-        path: /tags/{tag_id}/children
-        response_type: TagResponse
-        list_shape: mutation
-        category: create
-      - module: create_company_tag
-        method: POST
-        path: /company/tags
-        response_type: TagResponse
-        list_shape: mutation
-        category: create
-      - module: create_tag
-        method: POST
-        path: /tags
-        response_type: TagResponse
-        list_shape: mutation
-        category: create
-      - module: create_team_tag
-        method: POST
-        path: /teams/{team_id}/tags
-        response_type: TagResponse
-        list_shape: mutation
-        category: create
-      - module: create_teammate_tag
-        method: POST
-        path: /teammates/{teammate_id}/tags
-        response_type: TagResponse
-        list_shape: mutation
-        category: create
-      - module: delete_tag
-        method: DELETE
-        path: /tags/{tag_id}
-        response_type: Any
-        list_shape: mutation
-        category: delete
-      - module: get_tag
-        method: GET
-        path: /tags/{tag_id}
-        response_type: TagResponse
-        list_shape: single
-        category: get
-      - module: list_company_tags
-        method: GET
-        path: /company/tags
-        response_type: ListCompanyTagsResponse200
-        list_shape: field_results
-        category: list
-      - module: list_tag_children
-        method: GET
-        path: /tags/{tag_id}/children
-        response_type: ListTagChildrenResponse200
-        list_shape: field_results
-        category: list
-      - module: list_tagged_conversations
-        method: GET
-        path: /tags/{tag_id}/conversations
-        response_type: ListTaggedConversationsResponse200
-        list_shape: field_results
-        category: list
-      - module: list_tags
-        method: GET
-        path: /tags
-        response_type: ListTagsResponse200
-        list_shape: field_results
-        category: list
-      - module: list_team_tags
-        method: GET
-        path: /teams/{team_id}/tags
-        response_type: ListTeamTagsResponse200
-        list_shape: field_results
-        category: list
-      - module: list_teammate_tags
-        method: GET
-        path: /teammates/{teammate_id}/tags
-        response_type: ListTeammateTagsResponse200
-        list_shape: field_results
-        category: list
-      - module: update_a_tag
-        method: PATCH
-        path: /tags/{tag_id}
-        response_type: Any
-        list_shape: mutation
-        category: update
-        quirks:
-          - _a_infix
+      built: true
+      path: frontapp_public_api_client/domain/tag.py
+      class: Tag
+    endpoints: []
   teammate_groups:
     spec_tag: Teammate Groups
     api_dir: frontapp_public_api_client/api/teammate_groups

--- a/frontapp_mcp_server/src/frontapp_mcp/projections.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/projections.py
@@ -135,15 +135,13 @@ def to_contact_summary(contact: Contact) -> ContactSummary:
     )
 
 
-class TagSummary(BaseModel):
+class TagCatalogSummary(BaseModel):
     """Compact projection of a workspace tag for LLM responses.
 
-    Distinct from the conversation-nested ``TagSummary`` in
+    Named to disambiguate from the conversation-nested ``TagSummary`` in
     ``frontapp_public_api_client.domain.conversation`` — that one only
-    carries id/name/highlight/is_private. This MCP projection adds
-    catalog-level fields (``is_visible_in_conversation_lists``,
-    timestamps) that are useful when surfacing tags from the tag
-    management surface rather than from a conversation.
+    carries id/name/highlight/is_private. This catalog projection adds
+    visibility flags + timestamps used by the tag management surface.
     """
 
     id: str
@@ -156,9 +154,9 @@ class TagSummary(BaseModel):
     updated_at: str | None = None
 
 
-def to_tag_summary(tag: Tag) -> TagSummary:
-    """Project a ``Tag`` domain model to a ``TagSummary``."""
-    return TagSummary(
+def to_tag_catalog_summary(tag: Tag) -> TagCatalogSummary:
+    """Project a ``Tag`` domain model to a ``TagCatalogSummary``."""
+    return TagCatalogSummary(
         id=tag.id,
         name=tag.name,
         description=tag.description,
@@ -199,10 +197,10 @@ __all__ = [
     "ConversationSummary",
     "DraftSummary",
     "InboxSummary",
-    "TagSummary",
+    "TagCatalogSummary",
     "to_contact_summary",
     "to_draft_summary",
     "to_inbox_summary",
     "to_summary",
-    "to_tag_summary",
+    "to_tag_catalog_summary",
 ]

--- a/frontapp_mcp_server/src/frontapp_mcp/projections.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/projections.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from pydantic import BaseModel, Field
 
-from frontapp_public_api_client.domain import Contact, Conversation, Draft
+from frontapp_public_api_client.domain import Contact, Conversation, Draft, Inbox, Tag
 
 
 class ConversationSummary(BaseModel):
@@ -135,11 +135,74 @@ def to_contact_summary(contact: Contact) -> ContactSummary:
     )
 
 
+class TagSummary(BaseModel):
+    """Compact projection of a workspace tag for LLM responses.
+
+    Distinct from the conversation-nested ``TagSummary`` in
+    ``frontapp_public_api_client.domain.conversation`` — that one only
+    carries id/name/highlight/is_private. This MCP projection adds
+    catalog-level fields (``is_visible_in_conversation_lists``,
+    timestamps) that are useful when surfacing tags from the tag
+    management surface rather than from a conversation.
+    """
+
+    id: str
+    name: str
+    description: str | None = None
+    highlight: str | None = None
+    is_private: bool = False
+    is_visible_in_conversation_lists: bool = False
+    created_at: str | None = None
+    updated_at: str | None = None
+
+
+def to_tag_summary(tag: Tag) -> TagSummary:
+    """Project a ``Tag`` domain model to a ``TagSummary``."""
+    return TagSummary(
+        id=tag.id,
+        name=tag.name,
+        description=tag.description,
+        highlight=tag.highlight,
+        is_private=tag.is_private,
+        is_visible_in_conversation_lists=tag.is_visible_in_conversation_lists,
+        created_at=tag.created_at.isoformat() if tag.created_at else None,
+        updated_at=tag.updated_at.isoformat() if tag.updated_at else None,
+    )
+
+
+class InboxSummary(BaseModel):
+    """Compact projection of an inbox for LLM responses.
+
+    Inbox responses from Front are already thin (id, name, two visibility
+    flags) so this projection is essentially a typed re-shape with
+    consistent serialization.
+    """
+
+    id: str | None = None
+    name: str | None = None
+    is_private: bool | None = None
+    is_public: bool | None = None
+
+
+def to_inbox_summary(inbox: Inbox) -> InboxSummary:
+    """Project an ``Inbox`` domain model to an ``InboxSummary``."""
+    return InboxSummary(
+        id=inbox.id,
+        name=inbox.name,
+        is_private=inbox.is_private,
+        is_public=inbox.is_public,
+    )
+
+
 __all__ = [
     "ContactSummary",
     "ConversationSummary",
     "DraftSummary",
+    "InboxSummary",
+    "TagSummary",
     "to_contact_summary",
     "to_draft_summary",
+    "to_inbox_summary",
     "to_summary",
+    "to_tag_summary",
 ]

--- a/frontapp_mcp_server/src/frontapp_mcp/resources/help.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/resources/help.py
@@ -91,6 +91,61 @@ a known conversation prefer `list_conversation_messages`.
 Outbound replies do not live here — use `create_draft_reply` (drafts
 vertical) instead. Front exposes no programmatic `send_message`.
 
+## Tags
+
+Workspace-level reference data. The `frontapp://tags` resource is the
+preferred name-to-id lookup at session start; the tools below are for
+programmatic listing, single-tag deltas on a conversation, and
+catalog mutations.
+
+| Tool | Endpoint | Purpose |
+| ---- | -------- | ------- |
+| `list_tags` | `GET /tags` | All workspace tags. |
+| `list_company_tags` | `GET /company/tags` | Company-scoped tags (visible across teams). |
+| `list_team_tags` | `GET /teams/{team_id}/tags` | Team-scoped tags. |
+| `list_teammate_tags` | `GET /teammates/{teammate_id}/tags` | Teammate-scoped tags. |
+| `get_tag` | `GET /tags/{id}` | Full detail for one tag. |
+| `list_tag_children` | `GET /tags/{id}/children` | Child tags of a parent (no pagination). |
+| `list_tagged_conversations` | `GET /tags/{id}/conversations` | Conversations bearing this tag. Returns `ConversationSummary`s. |
+| `add_tag_to_conversation` | `POST /conversations/{id}/tags` | **DELTA** — adds one tag, leaves others. Two-step confirm. |
+| `remove_tag_from_conversation` | `DELETE /conversations/{id}/tags` | **DELTA** — removes one tag, leaves others. Two-step confirm. |
+| `create_tag` | `POST /tags` | Create workspace tag. WORKSPACE-WIDE. Two-step confirm. |
+| `create_child_tag` | `POST /tags/{id}/children` | Create a child under a parent. Two-step confirm. |
+| `update_tag` | `PATCH /tags/{id}` | Update name/highlight/parent. WORKSPACE-WIDE. Two-step confirm. |
+| `delete_tag` | `DELETE /tags/{id}` | **DESTRUCTIVE.** Removes from every conversation. Two-step confirm. |
+
+### Delta vs replace — important
+
+`add_tag_to_conversation` and `remove_tag_from_conversation` operate on
+a single tag without touching the others. `update_conversation(tag_ids=[…])`
+in the conversations vertical REPLACES the entire tag set. Use the
+delta tools when you want to nudge a single tag.
+
+## Inboxes
+
+Channel containers. Every conversation belongs to one. The
+`frontapp://inboxes` resource is the preferred name-to-id lookup;
+the tools below cover programmatic listing, per-inbox lookups, and
+mutations.
+
+| Tool | Endpoint | Purpose |
+| ---- | -------- | ------- |
+| `list_inboxes` | `GET /inboxes` | All visible inboxes (no pagination). |
+| `list_team_inboxes` | `GET /teams/{team_id}/inboxes` | Inboxes owned by a team. |
+| `list_teammate_private_inboxes` | `GET /teammates/{id}/private_inboxes` | A teammate's private inboxes. |
+| `get_inbox` | `GET /inboxes/{id}` | Full detail for one inbox. |
+| `list_inbox_conversations` | `GET /inboxes/{id}/conversations` | Conversations in this inbox. Returns `ConversationSummary`s. |
+| `list_inbox_channels` | `GET /inboxes/{id}/channels` | Channels routing into this inbox. |
+| `list_inbox_access` | `GET /inboxes/{id}/teammates` | Teammates with access. |
+| `create_inbox` | `POST /inboxes` | Create workspace inbox. Two-step confirm. |
+| `create_team_inbox` | `POST /teams/{team_id}/inboxes` | Create team inbox. Two-step confirm. |
+| `grant_inbox_access` | `POST /inboxes/{id}/teammates` | Grant access to teammates (preview shows count + ids). Two-step confirm. |
+| `revoke_inbox_access` | `DELETE /inboxes/{id}/teammates` | Revoke access from teammates. Two-step confirm. |
+
+Front exposes no inbox PATCH endpoint — name and visibility are immutable
+post-creation. The only post-create mutations are the access grant/revoke
+pair.
+
 ### Workflow recipe — "what else do we have on this customer?"
 
 ```

--- a/frontapp_mcp_server/src/frontapp_mcp/server.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/server.py
@@ -261,6 +261,50 @@ conversation, prefer `list_conversation_messages`.
 There is no `create_message` tool here — outbound goes through the
 drafts vertical (`create_draft_reply` / `create_draft_on_channel`).
 
+## Tags
+
+Tags are workspace-level reference data. Read the `frontapp://tags`
+resource at session start to translate names ("urgent", "vip") into
+`tag_*` ids without burning tool calls.
+
+**Listing & detail:**
+  list_tags / list_company_tags / list_team_tags / list_teammate_tags |
+  get_tag | list_tag_children | list_tagged_conversations
+
+**IMPORTANT — delta vs replace:** there are TWO ways to change the tags
+on a conversation. They have different semantics:
+
+  add_tag_to_conversation(conversation_id, tag_id)   # DELTA: adds one
+  remove_tag_from_conversation(conversation_id, tag_id)  # DELTA: removes one
+  update_conversation(conversation_id, tag_ids=[…])  # REPLACE: full set
+
+Use the delta tools when you want to nudge a single tag without
+clobbering the rest. Use update_conversation when you intentionally
+want to set the entire tag set.
+
+**Tag catalog mutations (all WORKSPACE-WIDE, two-step confirm):**
+  create_tag / create_child_tag |
+  update_tag (a rename ripples instantly) |
+  delete_tag (DESTRUCTIVE: removes from every conversation that had it)
+
+## Inboxes
+
+Inboxes are channel containers. Every conversation belongs to one. Read
+`frontapp://inboxes` at session start to translate inbox names
+("Support", "Sales") into `inb_*` ids.
+
+**Listing & detail:**
+  list_inboxes / list_team_inboxes / list_teammate_private_inboxes |
+  get_inbox | list_inbox_conversations | list_inbox_channels |
+  list_inbox_access
+
+**Mutations (all two-step confirm):**
+  create_inbox / create_team_inbox |
+  grant_inbox_access / revoke_inbox_access (preview includes count + ids)
+
+Front exposes no general inbox PATCH — name and visibility are immutable
+post-creation. Only access can be changed after that.
+
 ## Front Search Syntax (q parameter)
 
   status:open | status:archived | tag:urgent | assignee:me |
@@ -314,6 +358,20 @@ _READ_ONLY_TOOLS = [
     "list_contact_notes",
     "get_message",
     "get_message_seen_status",
+    "list_tags",
+    "list_company_tags",
+    "list_team_tags",
+    "list_teammate_tags",
+    "get_tag",
+    "list_tag_children",
+    "list_tagged_conversations",
+    "list_inboxes",
+    "list_team_inboxes",
+    "list_teammate_private_inboxes",
+    "get_inbox",
+    "list_inbox_conversations",
+    "list_inbox_channels",
+    "list_inbox_access",
 ]
 
 mcp.add_middleware(

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/__init__.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/__init__.py
@@ -13,12 +13,16 @@ def register_all_tools(mcp: FastMCP) -> None:
     from .contacts import register_tools as register_contacts_tools
     from .conversations import register_tools as register_conversations_tools
     from .drafts import register_tools as register_drafts_tools
+    from .inboxes import register_tools as register_inboxes_tools
     from .messages import register_tools as register_messages_tools
+    from .tags import register_tools as register_tags_tools
 
     register_contacts_tools(mcp)
     register_conversations_tools(mcp)
     register_drafts_tools(mcp)
+    register_inboxes_tools(mcp)
     register_messages_tools(mcp)
+    register_tags_tools(mcp)
 
 
 __all__ = ["register_all_tools"]

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/inboxes.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/inboxes.py
@@ -1,0 +1,290 @@
+"""MCP tools for Frontapp inbox management.
+
+Covers the workspace inbox catalog (``/inboxes*``).
+
+- 7 reads (cached 30s): list / list_team / list_teammate_private / get /
+  list_inbox_conversations / list_inbox_channels / list_inbox_access
+- 4 mutations (two-step confirm): create_inbox / create_team_inbox /
+  grant_inbox_access / revoke_inbox_access
+
+Front exposes no general inbox PATCH — name and visibility are immutable
+post-creation. The only post-create mutations are the access
+grant/revoke pair, which take a list of teammate ids and the preview
+includes the count + ids so the user can review.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastmcp import Context, FastMCP
+from pydantic import Field
+
+from frontapp_mcp.projections import (
+    ConversationSummary,
+    InboxSummary,
+    to_inbox_summary,
+    to_summary,
+)
+from frontapp_mcp.services import get_services
+from frontapp_mcp.tools.schemas import ConfirmationResult, require_confirmation
+
+
+def register_tools(mcp: FastMCP) -> None:
+    """Register inbox-related tools with the FastMCP server."""
+
+    # -- reads --------------------------------------------------------------
+
+    @mcp.tool(
+        name="list_inboxes",
+        description=(
+            "List every inbox visible to the API token. Prefer the "
+            "`frontapp://inboxes` resource for name-to-id lookups; this "
+            "tool is for programmatic listing."
+        ),
+    )
+    async def list_inboxes(context: Context) -> list[InboxSummary]:
+        services = get_services(context)
+        inboxes = await services.client.inboxes.list()
+        return [to_inbox_summary(i) for i in inboxes]
+
+    @mcp.tool(
+        name="list_team_inboxes",
+        description="List inboxes owned by a team (`team_id` like 'tim_abc').",
+    )
+    async def list_team_inboxes(
+        context: Context,
+        team_id: Annotated[str, Field(description="Team id, e.g. 'tim_abc'")],
+    ) -> list[InboxSummary]:
+        services = get_services(context)
+        inboxes = await services.client.inboxes.list_for_team(team_id)
+        return [to_inbox_summary(i) for i in inboxes]
+
+    @mcp.tool(
+        name="list_teammate_private_inboxes",
+        description="List a teammate's private inboxes (`teammate_id` like 'tea_abc').",
+    )
+    async def list_teammate_private_inboxes(
+        context: Context,
+        teammate_id: Annotated[str, Field(description="Teammate id, e.g. 'tea_abc'")],
+    ) -> list[InboxSummary]:
+        services = get_services(context)
+        inboxes = await services.client.inboxes.list_private_for_teammate(teammate_id)
+        return [to_inbox_summary(i) for i in inboxes]
+
+    @mcp.tool(
+        name="get_inbox",
+        description="Fetch full details for one inbox by id (e.g. 'inb_abc').",
+    )
+    async def get_inbox(
+        context: Context,
+        inbox_id: Annotated[str, Field(description="Inbox id, e.g. 'inb_abc'")],
+    ) -> InboxSummary:
+        services = get_services(context)
+        inbox = await services.client.inboxes.get(inbox_id)
+        return to_inbox_summary(inbox)
+
+    @mcp.tool(
+        name="list_inbox_conversations",
+        description=(
+            "List conversations in this inbox. Pass `q=` to filter with "
+            "Front search syntax."
+        ),
+    )
+    async def list_inbox_conversations(
+        context: Context,
+        inbox_id: Annotated[str, Field(description="Inbox id")],
+        q: Annotated[str | None, Field(description="Front search syntax")] = None,
+        limit: Annotated[int | None, Field(description="Page size")] = None,
+        page_token: Annotated[str | None, Field(description="Cursor")] = None,
+    ) -> list[ConversationSummary]:
+        from frontapp_public_api_client.domain import Conversation
+
+        services = get_services(context)
+        items = await services.client.inboxes.list_conversations(
+            inbox_id, q=q, limit=limit, page_token=page_token
+        )
+        return [
+            to_summary(Conversation.model_validate(item.to_dict())) for item in items
+        ]
+
+    @mcp.tool(
+        name="list_inbox_channels",
+        description="List channels routing into this inbox. Returns raw dicts.",
+    )
+    async def list_inbox_channels(
+        context: Context,
+        inbox_id: Annotated[str, Field(description="Inbox id")],
+    ) -> list[dict[str, Any]]:
+        services = get_services(context)
+        channels = await services.client.inboxes.list_channels(inbox_id)
+        return [c.to_dict() for c in channels]
+
+    @mcp.tool(
+        name="list_inbox_access",
+        description="List teammates with access to this inbox.",
+    )
+    async def list_inbox_access(
+        context: Context,
+        inbox_id: Annotated[str, Field(description="Inbox id")],
+    ) -> list[dict[str, Any]]:
+        services = get_services(context)
+        teammates = await services.client.inboxes.list_access(inbox_id)
+        return [t.to_dict() for t in teammates]
+
+    # -- mutations (two-step confirm) ---------------------------------------
+
+    @mcp.tool(
+        name="create_inbox",
+        description=(
+            "Create a workspace-scoped inbox. Channels still need to be "
+            "wired up separately. WORKSPACE-WIDE."
+        ),
+    )
+    async def create_inbox(
+        context: Context,
+        name: Annotated[str, Field(description="Inbox name, e.g. 'Support'")],
+        teammate_ids: Annotated[
+            list[str] | None,
+            Field(description="Teammates to grant access at creation time"),
+        ] = None,
+        is_public: Annotated[
+            bool | None, Field(description="Publicly visible to the workspace")
+        ] = None,
+        confirm: Annotated[bool, Field(description="Must be true")] = False,
+    ) -> dict[str, Any]:
+        services = get_services(context)
+        preview = {
+            "action": "create_inbox",
+            "name": name,
+            "teammate_count": len(teammate_ids) if teammate_ids else 0,
+            "teammate_ids": teammate_ids,
+            "is_public": is_public,
+        }
+        if not confirm:
+            return {"preview": preview, "confirmed": False}
+
+        result = await require_confirmation(
+            context, f"Create workspace inbox '{name}'?"
+        )
+        if result is not ConfirmationResult.CONFIRMED:
+            return {"preview": preview, "confirmed": False, "result": result.value}
+
+        inbox = await services.client.inboxes.create(
+            name=name, teammate_ids=teammate_ids, is_public=is_public
+        )
+        return {"confirmed": True, "inbox": to_inbox_summary(inbox).model_dump()}
+
+    @mcp.tool(
+        name="create_team_inbox",
+        description="Create an inbox owned by a team (`team_id` like 'tim_abc').",
+    )
+    async def create_team_inbox(
+        context: Context,
+        team_id: Annotated[str, Field(description="Team id, e.g. 'tim_abc'")],
+        name: Annotated[str, Field(description="Inbox name")],
+        teammate_ids: Annotated[
+            list[str] | None,
+            Field(description="Teammates to grant access at creation time"),
+        ] = None,
+        is_public: Annotated[
+            bool | None, Field(description="Publicly visible to the workspace")
+        ] = None,
+        confirm: Annotated[bool, Field(description="Must be true")] = False,
+    ) -> dict[str, Any]:
+        services = get_services(context)
+        preview = {
+            "action": "create_team_inbox",
+            "team_id": team_id,
+            "name": name,
+            "teammate_count": len(teammate_ids) if teammate_ids else 0,
+            "teammate_ids": teammate_ids,
+            "is_public": is_public,
+        }
+        if not confirm:
+            return {"preview": preview, "confirmed": False}
+
+        result = await require_confirmation(
+            context, f"Create team inbox '{name}' on team {team_id}?"
+        )
+        if result is not ConfirmationResult.CONFIRMED:
+            return {"preview": preview, "confirmed": False, "result": result.value}
+
+        inbox = await services.client.inboxes.create_for_team(
+            team_id, name=name, teammate_ids=teammate_ids, is_public=is_public
+        )
+        return {"confirmed": True, "inbox": to_inbox_summary(inbox).model_dump()}
+
+    @mcp.tool(
+        name="grant_inbox_access",
+        description="Grant inbox access to one or more teammates.",
+    )
+    async def grant_inbox_access(
+        context: Context,
+        inbox_id: Annotated[str, Field(description="Inbox id")],
+        teammate_ids: Annotated[
+            list[str], Field(description="Teammate ids to grant access to (>=1)")
+        ],
+        confirm: Annotated[bool, Field(description="Must be true")] = False,
+    ) -> dict[str, Any]:
+        services = get_services(context)
+        preview = {
+            "action": "grant_inbox_access",
+            "inbox_id": inbox_id,
+            "teammate_count": len(teammate_ids),
+            "teammate_ids": teammate_ids,
+        }
+        if not confirm:
+            return {"preview": preview, "confirmed": False}
+
+        result = await require_confirmation(
+            context,
+            f"Grant inbox {inbox_id} access to {len(teammate_ids)} teammate(s)?",
+        )
+        if result is not ConfirmationResult.CONFIRMED:
+            return {"preview": preview, "confirmed": False, "result": result.value}
+
+        success = await services.client.inboxes.grant_access(
+            inbox_id, teammate_ids=teammate_ids
+        )
+        return {"confirmed": True, "granted": success}
+
+    @mcp.tool(
+        name="revoke_inbox_access",
+        description=(
+            "Revoke inbox access from one or more teammates. The named "
+            "teammates lose visibility into this inbox immediately."
+        ),
+    )
+    async def revoke_inbox_access(
+        context: Context,
+        inbox_id: Annotated[str, Field(description="Inbox id")],
+        teammate_ids: Annotated[
+            list[str], Field(description="Teammate ids to revoke access from (>=1)")
+        ],
+        confirm: Annotated[bool, Field(description="Must be true")] = False,
+    ) -> dict[str, Any]:
+        services = get_services(context)
+        preview = {
+            "action": "revoke_inbox_access",
+            "inbox_id": inbox_id,
+            "teammate_count": len(teammate_ids),
+            "teammate_ids": teammate_ids,
+        }
+        if not confirm:
+            return {"preview": preview, "confirmed": False}
+
+        result = await require_confirmation(
+            context,
+            f"Revoke inbox {inbox_id} access from {len(teammate_ids)} teammate(s)?",
+        )
+        if result is not ConfirmationResult.CONFIRMED:
+            return {"preview": preview, "confirmed": False, "result": result.value}
+
+        success = await services.client.inboxes.revoke_access(
+            inbox_id, teammate_ids=teammate_ids
+        )
+        return {"confirmed": True, "revoked": success}
+
+
+__all__ = ["register_tools"]

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/tags.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/tags.py
@@ -24,31 +24,20 @@ tag.
 
 from __future__ import annotations
 
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any
 
 from fastmcp import Context, FastMCP
 from pydantic import Field
 
 from frontapp_mcp.projections import (
     ConversationSummary,
-    TagSummary,
+    TagCatalogSummary,
     to_summary,
-    to_tag_summary,
+    to_tag_catalog_summary,
 )
 from frontapp_mcp.services import get_services
 from frontapp_mcp.tools.schemas import ConfirmationResult, require_confirmation
-
-HighlightLiteral = Literal[
-    "blue",
-    "green",
-    "grey",
-    "light-blue",
-    "orange",
-    "pink",
-    "purple",
-    "red",
-    "yellow",
-]
+from frontapp_public_api_client.helpers.tags import HighlightLiteral
 
 
 def register_tools(mcp: FastMCP) -> None:
@@ -72,10 +61,10 @@ def register_tools(mcp: FastMCP) -> None:
         page_token: Annotated[
             str | None, Field(description="Cursor from a prior pagination.next")
         ] = None,
-    ) -> list[TagSummary]:
+    ) -> list[TagCatalogSummary]:
         services = get_services(context)
         tags = await services.client.tags.list(limit=limit, page_token=page_token)
-        return [to_tag_summary(t) for t in tags]
+        return [to_tag_catalog_summary(t) for t in tags]
 
     @mcp.tool(
         name="list_company_tags",
@@ -85,12 +74,12 @@ def register_tools(mcp: FastMCP) -> None:
         context: Context,
         limit: Annotated[int | None, Field(description="Page size")] = None,
         page_token: Annotated[str | None, Field(description="Cursor")] = None,
-    ) -> list[TagSummary]:
+    ) -> list[TagCatalogSummary]:
         services = get_services(context)
         tags = await services.client.tags.list_company(
             limit=limit, page_token=page_token
         )
-        return [to_tag_summary(t) for t in tags]
+        return [to_tag_catalog_summary(t) for t in tags]
 
     @mcp.tool(
         name="list_team_tags",
@@ -101,12 +90,12 @@ def register_tools(mcp: FastMCP) -> None:
         team_id: Annotated[str, Field(description="Team id, e.g. 'tim_abc'")],
         limit: Annotated[int | None, Field(description="Page size")] = None,
         page_token: Annotated[str | None, Field(description="Cursor")] = None,
-    ) -> list[TagSummary]:
+    ) -> list[TagCatalogSummary]:
         services = get_services(context)
         tags = await services.client.tags.list_for_team(
             team_id, limit=limit, page_token=page_token
         )
-        return [to_tag_summary(t) for t in tags]
+        return [to_tag_catalog_summary(t) for t in tags]
 
     @mcp.tool(
         name="list_teammate_tags",
@@ -117,12 +106,12 @@ def register_tools(mcp: FastMCP) -> None:
         teammate_id: Annotated[str, Field(description="Teammate id, e.g. 'tea_abc'")],
         limit: Annotated[int | None, Field(description="Page size")] = None,
         page_token: Annotated[str | None, Field(description="Cursor")] = None,
-    ) -> list[TagSummary]:
+    ) -> list[TagCatalogSummary]:
         services = get_services(context)
         tags = await services.client.tags.list_for_teammate(
             teammate_id, limit=limit, page_token=page_token
         )
-        return [to_tag_summary(t) for t in tags]
+        return [to_tag_catalog_summary(t) for t in tags]
 
     @mcp.tool(
         name="get_tag",
@@ -131,10 +120,10 @@ def register_tools(mcp: FastMCP) -> None:
     async def get_tag(
         context: Context,
         tag_id: Annotated[str, Field(description="Tag id, e.g. 'tag_abc'")],
-    ) -> TagSummary:
+    ) -> TagCatalogSummary:
         services = get_services(context)
         tag = await services.client.tags.get(tag_id)
-        return to_tag_summary(tag)
+        return to_tag_catalog_summary(tag)
 
     @mcp.tool(
         name="list_tag_children",
@@ -146,10 +135,10 @@ def register_tools(mcp: FastMCP) -> None:
     async def list_tag_children(
         context: Context,
         tag_id: Annotated[str, Field(description="Parent tag id")],
-    ) -> list[TagSummary]:
+    ) -> list[TagCatalogSummary]:
         services = get_services(context)
         children = await services.client.tags.list_children(tag_id)
-        return [to_tag_summary(c) for c in children]
+        return [to_tag_catalog_summary(c) for c in children]
 
     @mcp.tool(
         name="list_tagged_conversations",
@@ -293,7 +282,7 @@ def register_tools(mcp: FastMCP) -> None:
             highlight=highlight,
             is_visible_in_conversation_lists=is_visible_in_conversation_lists,
         )
-        return {"confirmed": True, "tag": to_tag_summary(tag).model_dump()}
+        return {"confirmed": True, "tag": to_tag_catalog_summary(tag).model_dump()}
 
     @mcp.tool(
         name="create_child_tag",
@@ -335,7 +324,7 @@ def register_tools(mcp: FastMCP) -> None:
             highlight=highlight,
             is_visible_in_conversation_lists=is_visible_in_conversation_lists,
         )
-        return {"confirmed": True, "tag": to_tag_summary(tag).model_dump()}
+        return {"confirmed": True, "tag": to_tag_catalog_summary(tag).model_dump()}
 
     @mcp.tool(
         name="update_tag",

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/tags.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/tags.py
@@ -1,0 +1,440 @@
+"""MCP tools for Frontapp tag management.
+
+Spans the workspace tag catalog (``/tags*``) plus the conversation-tag
+delta endpoints. All mutations use the standard two-step confirm.
+
+- 7 reads (cached 30s): list / list_company / list_team / list_teammate /
+  get / list_children / list_tagged_conversations
+- 6 mutations (two-step confirm): add_tag_to_conversation /
+  remove_tag_from_conversation / create_tag / create_child_tag /
+  update_tag / delete_tag
+
+Critical semantic distinction documented in tool docstrings and the MCP
+``instructions`` block:
+
+- ``add_tag_to_conversation`` / ``remove_tag_from_conversation`` are
+  **delta** operations on a single tag.
+- ``update_conversation(tag_ids=[...])`` (in the conversations vertical)
+  is a **replace** operation on the full tag set.
+
+The single-tag tools take ``tag_id: str`` (not a list) at the MCP layer
+to reduce the chance of an agent inadvertently affecting more than one
+tag.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any, Literal
+
+from fastmcp import Context, FastMCP
+from pydantic import Field
+
+from frontapp_mcp.projections import (
+    ConversationSummary,
+    TagSummary,
+    to_summary,
+    to_tag_summary,
+)
+from frontapp_mcp.services import get_services
+from frontapp_mcp.tools.schemas import ConfirmationResult, require_confirmation
+
+HighlightLiteral = Literal[
+    "blue",
+    "green",
+    "grey",
+    "light-blue",
+    "orange",
+    "pink",
+    "purple",
+    "red",
+    "yellow",
+]
+
+
+def register_tools(mcp: FastMCP) -> None:
+    """Register tag-related tools with the FastMCP server."""
+
+    # -- reads --------------------------------------------------------------
+
+    @mcp.tool(
+        name="list_tags",
+        description=(
+            "List workspace tags. Prefer the `frontapp://tags` resource for "
+            "name-to-id lookups at session start; this tool is for "
+            "programmatic listing with pagination."
+        ),
+    )
+    async def list_tags(
+        context: Context,
+        limit: Annotated[
+            int | None, Field(description="Page size (max 100, default 50)")
+        ] = None,
+        page_token: Annotated[
+            str | None, Field(description="Cursor from a prior pagination.next")
+        ] = None,
+    ) -> list[TagSummary]:
+        services = get_services(context)
+        tags = await services.client.tags.list(limit=limit, page_token=page_token)
+        return [to_tag_summary(t) for t in tags]
+
+    @mcp.tool(
+        name="list_company_tags",
+        description="List company-scoped tags (visible across all teams).",
+    )
+    async def list_company_tags(
+        context: Context,
+        limit: Annotated[int | None, Field(description="Page size")] = None,
+        page_token: Annotated[str | None, Field(description="Cursor")] = None,
+    ) -> list[TagSummary]:
+        services = get_services(context)
+        tags = await services.client.tags.list_company(
+            limit=limit, page_token=page_token
+        )
+        return [to_tag_summary(t) for t in tags]
+
+    @mcp.tool(
+        name="list_team_tags",
+        description="List tags scoped to a team (`team_id` like 'tim_abc').",
+    )
+    async def list_team_tags(
+        context: Context,
+        team_id: Annotated[str, Field(description="Team id, e.g. 'tim_abc'")],
+        limit: Annotated[int | None, Field(description="Page size")] = None,
+        page_token: Annotated[str | None, Field(description="Cursor")] = None,
+    ) -> list[TagSummary]:
+        services = get_services(context)
+        tags = await services.client.tags.list_for_team(
+            team_id, limit=limit, page_token=page_token
+        )
+        return [to_tag_summary(t) for t in tags]
+
+    @mcp.tool(
+        name="list_teammate_tags",
+        description="List tags scoped to a teammate (`teammate_id` like 'tea_abc').",
+    )
+    async def list_teammate_tags(
+        context: Context,
+        teammate_id: Annotated[str, Field(description="Teammate id, e.g. 'tea_abc'")],
+        limit: Annotated[int | None, Field(description="Page size")] = None,
+        page_token: Annotated[str | None, Field(description="Cursor")] = None,
+    ) -> list[TagSummary]:
+        services = get_services(context)
+        tags = await services.client.tags.list_for_teammate(
+            teammate_id, limit=limit, page_token=page_token
+        )
+        return [to_tag_summary(t) for t in tags]
+
+    @mcp.tool(
+        name="get_tag",
+        description="Fetch full details for one tag by id (e.g. 'tag_abc').",
+    )
+    async def get_tag(
+        context: Context,
+        tag_id: Annotated[str, Field(description="Tag id, e.g. 'tag_abc'")],
+    ) -> TagSummary:
+        services = get_services(context)
+        tag = await services.client.tags.get(tag_id)
+        return to_tag_summary(tag)
+
+    @mcp.tool(
+        name="list_tag_children",
+        description=(
+            "List child tags of a parent tag. Returns the full child set "
+            "(no pagination)."
+        ),
+    )
+    async def list_tag_children(
+        context: Context,
+        tag_id: Annotated[str, Field(description="Parent tag id")],
+    ) -> list[TagSummary]:
+        services = get_services(context)
+        children = await services.client.tags.list_children(tag_id)
+        return [to_tag_summary(c) for c in children]
+
+    @mcp.tool(
+        name="list_tagged_conversations",
+        description=(
+            "List conversations bearing this tag. Pass `q=` to filter "
+            "with Front search syntax."
+        ),
+    )
+    async def list_tagged_conversations(
+        context: Context,
+        tag_id: Annotated[str, Field(description="Tag id")],
+        q: Annotated[str | None, Field(description="Front search syntax")] = None,
+        limit: Annotated[int | None, Field(description="Page size")] = None,
+        page_token: Annotated[str | None, Field(description="Cursor")] = None,
+    ) -> list[ConversationSummary]:
+        from frontapp_public_api_client.domain import Conversation
+
+        services = get_services(context)
+        items = await services.client.tags.list_conversations(
+            tag_id, q=q, limit=limit, page_token=page_token
+        )
+        return [
+            to_summary(Conversation.model_validate(item.to_dict())) for item in items
+        ]
+
+    # -- conversation-tag deltas (two-step confirm) -------------------------
+
+    @mcp.tool(
+        name="add_tag_to_conversation",
+        description=(
+            "Add a single tag to a conversation. DELTA — leaves other "
+            "tags untouched. For full-set replacement use "
+            "update_conversation(tag_ids=[...]) in the conversations vertical."
+        ),
+    )
+    async def add_tag_to_conversation(
+        context: Context,
+        conversation_id: Annotated[str, Field(description="Conversation id")],
+        tag_id: Annotated[str, Field(description="Tag id to apply")],
+        confirm: Annotated[bool, Field(description="Must be true")] = False,
+    ) -> dict[str, Any]:
+        services = get_services(context)
+        preview = {
+            "action": "add_tag_to_conversation",
+            "conversation_id": conversation_id,
+            "tag_id": tag_id,
+            "semantics": "delta — does not replace existing tags",
+        }
+        if not confirm:
+            return {"preview": preview, "confirmed": False}
+
+        result = await require_confirmation(
+            context, f"Add tag {tag_id} to conversation {conversation_id}?"
+        )
+        if result is not ConfirmationResult.CONFIRMED:
+            return {"preview": preview, "confirmed": False, "result": result.value}
+
+        success = await services.client.tags.apply_to_conversation(
+            conversation_id, tag_ids=[tag_id]
+        )
+        return {"confirmed": True, "applied": success}
+
+    @mcp.tool(
+        name="remove_tag_from_conversation",
+        description=(
+            "Remove a single tag from a conversation. DELTA — leaves "
+            "other tags untouched."
+        ),
+    )
+    async def remove_tag_from_conversation(
+        context: Context,
+        conversation_id: Annotated[str, Field(description="Conversation id")],
+        tag_id: Annotated[str, Field(description="Tag id to remove")],
+        confirm: Annotated[bool, Field(description="Must be true")] = False,
+    ) -> dict[str, Any]:
+        services = get_services(context)
+        preview = {
+            "action": "remove_tag_from_conversation",
+            "conversation_id": conversation_id,
+            "tag_id": tag_id,
+            "semantics": "delta — only removes this tag",
+        }
+        if not confirm:
+            return {"preview": preview, "confirmed": False}
+
+        result = await require_confirmation(
+            context, f"Remove tag {tag_id} from conversation {conversation_id}?"
+        )
+        if result is not ConfirmationResult.CONFIRMED:
+            return {"preview": preview, "confirmed": False, "result": result.value}
+
+        success = await services.client.tags.remove_from_conversation(
+            conversation_id, tag_ids=[tag_id]
+        )
+        return {"confirmed": True, "removed": success}
+
+    # -- catalog mutations (two-step confirm) -------------------------------
+
+    @mcp.tool(
+        name="create_tag",
+        description=(
+            "Create a workspace-scoped tag. WORKSPACE-WIDE — visible to "
+            "every teammate immediately."
+        ),
+    )
+    async def create_tag(
+        context: Context,
+        name: Annotated[str, Field(description="Tag name, e.g. 'urgent'")],
+        description: Annotated[
+            str | None, Field(description="Free-form note about the tag")
+        ] = None,
+        highlight: Annotated[
+            HighlightLiteral | None,
+            Field(
+                description="Color: blue, green, grey, light-blue, orange, pink, purple, red, yellow"
+            ),
+        ] = None,
+        is_visible_in_conversation_lists: Annotated[
+            bool, Field(description="Show as a chip on conversation list rows")
+        ] = False,
+        confirm: Annotated[bool, Field(description="Must be true")] = False,
+    ) -> dict[str, Any]:
+        services = get_services(context)
+        preview = {
+            "action": "create_tag",
+            "name": name,
+            "highlight": highlight,
+            "is_visible_in_conversation_lists": is_visible_in_conversation_lists,
+            "scope": "workspace-wide",
+        }
+        if not confirm:
+            return {"preview": preview, "confirmed": False}
+
+        result = await require_confirmation(context, f"Create workspace tag '{name}'?")
+        if result is not ConfirmationResult.CONFIRMED:
+            return {"preview": preview, "confirmed": False, "result": result.value}
+
+        tag = await services.client.tags.create(
+            name=name,
+            description=description,
+            highlight=highlight,
+            is_visible_in_conversation_lists=is_visible_in_conversation_lists,
+        )
+        return {"confirmed": True, "tag": to_tag_summary(tag).model_dump()}
+
+    @mcp.tool(
+        name="create_child_tag",
+        description="Create a child tag under an existing parent. WORKSPACE-WIDE.",
+    )
+    async def create_child_tag(
+        context: Context,
+        parent_tag_id: Annotated[str, Field(description="Parent tag id")],
+        name: Annotated[str, Field(description="Child tag name")],
+        description: Annotated[str | None, Field(description="Free-form note")] = None,
+        highlight: Annotated[
+            HighlightLiteral | None, Field(description="Color name")
+        ] = None,
+        is_visible_in_conversation_lists: Annotated[
+            bool, Field(description="Show on conversation list rows")
+        ] = False,
+        confirm: Annotated[bool, Field(description="Must be true")] = False,
+    ) -> dict[str, Any]:
+        services = get_services(context)
+        preview = {
+            "action": "create_child_tag",
+            "parent_tag_id": parent_tag_id,
+            "name": name,
+            "highlight": highlight,
+        }
+        if not confirm:
+            return {"preview": preview, "confirmed": False}
+
+        result = await require_confirmation(
+            context, f"Create child tag '{name}' under {parent_tag_id}?"
+        )
+        if result is not ConfirmationResult.CONFIRMED:
+            return {"preview": preview, "confirmed": False, "result": result.value}
+
+        tag = await services.client.tags.create_child(
+            parent_tag_id,
+            name=name,
+            description=description,
+            highlight=highlight,
+            is_visible_in_conversation_lists=is_visible_in_conversation_lists,
+        )
+        return {"confirmed": True, "tag": to_tag_summary(tag).model_dump()}
+
+    @mcp.tool(
+        name="update_tag",
+        description=(
+            "Update mutable fields on a tag. WORKSPACE-WIDE — a rename "
+            "ripples to every conversation instantly."
+        ),
+    )
+    async def update_tag(
+        context: Context,
+        tag_id: Annotated[str, Field(description="Tag id")],
+        name: Annotated[str | None, Field(description="New name")] = None,
+        description: Annotated[str | None, Field(description="Free-form note")] = None,
+        highlight: Annotated[
+            HighlightLiteral | None, Field(description="Color name")
+        ] = None,
+        parent_tag_id: Annotated[
+            str | None, Field(description="Move tag under a new parent")
+        ] = None,
+        is_visible_in_conversation_lists: Annotated[
+            bool | None, Field(description="Show on conversation list rows")
+        ] = None,
+        confirm: Annotated[bool, Field(description="Must be true")] = False,
+    ) -> dict[str, Any]:
+        services = get_services(context)
+        changes = {
+            k: v
+            for k, v in {
+                "name": name,
+                "description": description,
+                "highlight": highlight,
+                "parent_tag_id": parent_tag_id,
+                "is_visible_in_conversation_lists": is_visible_in_conversation_lists,
+            }.items()
+            if v is not None
+        }
+        preview = {
+            "action": "update_tag",
+            "tag_id": tag_id,
+            "changes": changes,
+            "scope": "workspace-wide",
+        }
+        if not changes:
+            return {
+                "preview": preview,
+                "confirmed": False,
+                "result": "no_changes_requested",
+            }
+        if not confirm:
+            return {"preview": preview, "confirmed": False}
+
+        summary = ", ".join(f"{k}={v}" for k, v in changes.items())
+        result = await require_confirmation(context, f"Update tag {tag_id}: {summary}?")
+        if result is not ConfirmationResult.CONFIRMED:
+            return {"preview": preview, "confirmed": False, "result": result.value}
+
+        success = await services.client.tags.update(
+            tag_id,
+            name=name,
+            description=description,
+            highlight=highlight,
+            parent_tag_id=parent_tag_id,
+            is_visible_in_conversation_lists=is_visible_in_conversation_lists,
+        )
+        return {"confirmed": True, "updated": success}
+
+    @mcp.tool(
+        name="delete_tag",
+        description=(
+            "DESTRUCTIVE: permanently delete a tag. Removes it from every "
+            "conversation that had it. Irreversible. WORKSPACE-WIDE."
+        ),
+    )
+    async def delete_tag(
+        context: Context,
+        tag_id: Annotated[str, Field(description="Tag id to delete")],
+        confirm: Annotated[bool, Field(description="Must be true")] = False,
+    ) -> dict[str, Any]:
+        services = get_services(context)
+        preview = {
+            "action": "delete_tag",
+            "tag_id": tag_id,
+            "warning": (
+                "PERMANENT: removes this tag from every conversation that "
+                "currently has it. Cannot be undone."
+            ),
+        }
+        if not confirm:
+            return {"preview": preview, "confirmed": False}
+
+        result = await require_confirmation(
+            context,
+            f"PERMANENTLY DELETE tag {tag_id}? Removes from every conversation that had it.",
+        )
+        if result is not ConfirmationResult.CONFIRMED:
+            return {"preview": preview, "confirmed": False, "result": result.value}
+
+        success = await services.client.tags.delete(tag_id)
+        return {"confirmed": True, "deleted": success}
+
+
+__all__ = ["register_tools"]

--- a/frontapp_mcp_server/tests/test_inboxes_tools.py
+++ b/frontapp_mcp_server/tests/test_inboxes_tools.py
@@ -1,0 +1,187 @@
+"""Tests for MCP inbox tools — preview/decline/execute paths."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from frontapp_mcp.projections import InboxSummary
+from frontapp_mcp.tools.inboxes import register_tools
+
+from frontapp_public_api_client.domain import Inbox
+
+from .conftest import create_mock_context
+
+
+def _make_mcp() -> tuple[object, dict]:
+    captured: dict[str, object] = {}
+
+    class FakeMCP:
+        def tool(self, **kwargs: object):
+            name = kwargs["name"]
+
+            def decorator(fn):
+                captured[name] = fn
+                return fn
+
+            return decorator
+
+    return FakeMCP(), captured
+
+
+@pytest.fixture
+def inboxes_tools() -> dict[str, object]:
+    mcp, captured = _make_mcp()
+    register_tools(mcp)  # type: ignore[arg-type]
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# Read tools
+# ---------------------------------------------------------------------------
+
+
+class TestReadTools:
+    async def test_get_inbox_returns_summary(self, inboxes_tools):
+        context, lifespan = create_mock_context()
+        inbox = Inbox.model_validate({"id": "inb_abc", "name": "Support"})
+        lifespan.client = AsyncMock()
+        lifespan.client.inboxes.get = AsyncMock(return_value=inbox)
+
+        result = await inboxes_tools["get_inbox"](context, inbox_id="inb_abc")
+
+        assert isinstance(result, InboxSummary)
+        assert result.id == "inb_abc"
+        assert result.name == "Support"
+
+    async def test_list_inboxes_projects_each(self, inboxes_tools):
+        context, lifespan = create_mock_context()
+        inboxes = [
+            Inbox.model_validate({"id": "inb_1", "name": "Support"}),
+            Inbox.model_validate({"id": "inb_2", "name": "Sales"}),
+        ]
+        lifespan.client = AsyncMock()
+        lifespan.client.inboxes.list = AsyncMock(return_value=inboxes)
+
+        result = await inboxes_tools["list_inboxes"](context)
+
+        assert len(result) == 2
+        assert all(isinstance(i, InboxSummary) for i in result)
+
+
+# ---------------------------------------------------------------------------
+# Mutation: preview / decline / confirm
+# ---------------------------------------------------------------------------
+
+
+class TestPreviewPath:
+    @pytest.mark.parametrize(
+        "tool_name,kwargs",
+        [
+            ("create_inbox", {"name": "Triage"}),
+            ("create_team_inbox", {"team_id": "tim_a", "name": "Team Triage"}),
+            (
+                "grant_inbox_access",
+                {"inbox_id": "inb_a", "teammate_ids": ["tea_1", "tea_2"]},
+            ),
+            (
+                "revoke_inbox_access",
+                {"inbox_id": "inb_a", "teammate_ids": ["tea_1"]},
+            ),
+        ],
+    )
+    async def test_preview_returns_preview(self, inboxes_tools, tool_name, kwargs):
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock(
+            side_effect=AssertionError("client invoked on preview path")
+        )
+
+        result = await inboxes_tools[tool_name](context, **kwargs, confirm=False)
+
+        assert result["confirmed"] is False
+        assert "preview" in result
+        context.elicit.assert_not_called()
+
+
+class TestPreviewIncludesTeammateCount:
+    """Per the issue, access tools must surface count + ids in preview."""
+
+    async def test_grant_access_preview_has_count_and_ids(self, inboxes_tools):
+        context, _ = create_mock_context()
+        result = await inboxes_tools["grant_inbox_access"](
+            context,
+            inbox_id="inb_a",
+            teammate_ids=["tea_1", "tea_2", "tea_3"],
+            confirm=False,
+        )
+        assert result["preview"]["teammate_count"] == 3
+        assert result["preview"]["teammate_ids"] == ["tea_1", "tea_2", "tea_3"]
+
+    async def test_revoke_access_preview_has_count_and_ids(self, inboxes_tools):
+        context, _ = create_mock_context()
+        result = await inboxes_tools["revoke_inbox_access"](
+            context,
+            inbox_id="inb_a",
+            teammate_ids=["tea_1"],
+            confirm=False,
+        )
+        assert result["preview"]["teammate_count"] == 1
+        assert result["preview"]["teammate_ids"] == ["tea_1"]
+
+
+class TestConfirmedExecution:
+    async def test_create_inbox_calls_helper(self, inboxes_tools):
+        context, lifespan = create_mock_context()
+        new_inbox = Inbox.model_validate({"id": "inb_new", "name": "Triage"})
+        lifespan.client = AsyncMock()
+        lifespan.client.inboxes.create = AsyncMock(return_value=new_inbox)
+
+        result = await inboxes_tools["create_inbox"](
+            context, name="Triage", teammate_ids=["tea_1"], confirm=True
+        )
+
+        lifespan.client.inboxes.create.assert_awaited_once()
+        assert result["confirmed"] is True
+        assert result["inbox"]["id"] == "inb_new"
+
+    async def test_grant_access_calls_helper(self, inboxes_tools):
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock()
+        lifespan.client.inboxes.grant_access = AsyncMock(return_value=True)
+
+        result = await inboxes_tools["grant_inbox_access"](
+            context, inbox_id="inb_a", teammate_ids=["tea_1", "tea_2"], confirm=True
+        )
+
+        lifespan.client.inboxes.grant_access.assert_awaited_once_with(
+            "inb_a", teammate_ids=["tea_1", "tea_2"]
+        )
+        assert result == {"confirmed": True, "granted": True}
+
+    async def test_revoke_access_calls_helper(self, inboxes_tools):
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock()
+        lifespan.client.inboxes.revoke_access = AsyncMock(return_value=True)
+
+        result = await inboxes_tools["revoke_inbox_access"](
+            context, inbox_id="inb_a", teammate_ids=["tea_1"], confirm=True
+        )
+
+        lifespan.client.inboxes.revoke_access.assert_awaited_once_with(
+            "inb_a", teammate_ids=["tea_1"]
+        )
+        assert result == {"confirmed": True, "revoked": True}
+
+
+class TestDeclinePath:
+    async def test_grant_access_declined(self, inboxes_tools):
+        context, lifespan = create_mock_context(elicit_confirm=False)
+        lifespan.client = AsyncMock(
+            side_effect=AssertionError("client invoked after decline")
+        )
+
+        result = await inboxes_tools["grant_inbox_access"](
+            context, inbox_id="inb_a", teammate_ids=["tea_1"], confirm=True
+        )
+        assert result["confirmed"] is False
+        assert result["result"] == "cancelled"

--- a/frontapp_mcp_server/tests/test_tags_tools.py
+++ b/frontapp_mcp_server/tests/test_tags_tools.py
@@ -1,0 +1,247 @@
+"""Tests for MCP tag tools — preview/decline/execute paths + delta semantics."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from frontapp_mcp.projections import TagSummary, to_tag_summary
+from frontapp_mcp.tools.tags import register_tools
+
+from frontapp_public_api_client.domain import Tag
+
+from .conftest import create_mock_context
+
+
+def _make_mcp() -> tuple[object, dict]:
+    captured: dict[str, object] = {}
+
+    class FakeMCP:
+        def tool(self, **kwargs: object):
+            name = kwargs["name"]
+
+            def decorator(fn):
+                captured[name] = fn
+                return fn
+
+            return decorator
+
+    return FakeMCP(), captured
+
+
+@pytest.fixture
+def tags_tools() -> dict[str, object]:
+    mcp, captured = _make_mcp()
+    register_tools(mcp)  # type: ignore[arg-type]
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# Read tools
+# ---------------------------------------------------------------------------
+
+
+class TestReadTools:
+    async def test_get_tag_returns_summary(self, tags_tools):
+        context, lifespan = create_mock_context()
+        tag = Tag.model_validate(
+            {
+                "id": "tag_abc",
+                "name": "urgent",
+                "highlight": "red",
+                "is_private": False,
+                "is_visible_in_conversation_lists": True,
+            }
+        )
+        lifespan.client = AsyncMock()
+        lifespan.client.tags.get = AsyncMock(return_value=tag)
+
+        result = await tags_tools["get_tag"](context, tag_id="tag_abc")
+
+        assert isinstance(result, TagSummary)
+        assert result.id == "tag_abc"
+        assert result.highlight == "red"
+
+    async def test_list_tags_projects_each(self, tags_tools):
+        context, lifespan = create_mock_context()
+        tags = [
+            Tag.model_validate({"id": "tag_1", "name": "urgent"}),
+            Tag.model_validate({"id": "tag_2", "name": "vip"}),
+        ]
+        lifespan.client = AsyncMock()
+        lifespan.client.tags.list = AsyncMock(return_value=tags)
+
+        result = await tags_tools["list_tags"](context)
+
+        assert len(result) == 2
+        assert all(isinstance(t, TagSummary) for t in result)
+
+
+# ---------------------------------------------------------------------------
+# Mutation: preview path
+# ---------------------------------------------------------------------------
+
+
+class TestPreviewPath:
+    @pytest.mark.parametrize(
+        "tool_name,kwargs",
+        [
+            (
+                "add_tag_to_conversation",
+                {"conversation_id": "cnv_a", "tag_id": "tag_1"},
+            ),
+            (
+                "remove_tag_from_conversation",
+                {"conversation_id": "cnv_a", "tag_id": "tag_1"},
+            ),
+            ("create_tag", {"name": "urgent"}),
+            ("create_child_tag", {"parent_tag_id": "tag_p", "name": "child"}),
+            ("update_tag", {"tag_id": "tag_a", "name": "renamed"}),
+            ("delete_tag", {"tag_id": "tag_a"}),
+        ],
+    )
+    async def test_preview_returns_preview(self, tags_tools, tool_name, kwargs):
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock(
+            side_effect=AssertionError("client invoked on preview path")
+        )
+
+        result = await tags_tools[tool_name](context, **kwargs, confirm=False)
+
+        assert result["confirmed"] is False
+        assert "preview" in result
+        context.elicit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Delta-vs-replace documentation in previews
+# ---------------------------------------------------------------------------
+
+
+class TestDeltaSemantics:
+    async def test_add_tag_preview_documents_delta(self, tags_tools):
+        context, _ = create_mock_context()
+        result = await tags_tools["add_tag_to_conversation"](
+            context, conversation_id="cnv_a", tag_id="tag_1", confirm=False
+        )
+        assert "delta" in result["preview"]["semantics"].lower()
+
+    async def test_delete_tag_preview_warns_destructive(self, tags_tools):
+        context, _ = create_mock_context()
+        result = await tags_tools["delete_tag"](context, tag_id="tag_a", confirm=False)
+        assert "PERMANENT" in result["preview"]["warning"]
+
+
+# ---------------------------------------------------------------------------
+# Update no-changes guard
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateNoChanges:
+    async def test_update_with_no_args_short_circuits(self, tags_tools):
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock()
+
+        result = await tags_tools["update_tag"](context, tag_id="tag_a", confirm=True)
+        assert result["result"] == "no_changes_requested"
+        context.elicit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Confirmed execution
+# ---------------------------------------------------------------------------
+
+
+class TestConfirmedExecution:
+    async def test_add_tag_calls_helper_with_list(self, tags_tools):
+        """The MCP tool takes a single tag_id but wraps it into a list for the helper."""
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock()
+        lifespan.client.tags.apply_to_conversation = AsyncMock(return_value=True)
+
+        result = await tags_tools["add_tag_to_conversation"](
+            context, conversation_id="cnv_a", tag_id="tag_1", confirm=True
+        )
+
+        lifespan.client.tags.apply_to_conversation.assert_awaited_once_with(
+            "cnv_a", tag_ids=["tag_1"]
+        )
+        assert result == {"confirmed": True, "applied": True}
+
+    async def test_remove_tag_calls_helper_with_list(self, tags_tools):
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock()
+        lifespan.client.tags.remove_from_conversation = AsyncMock(return_value=True)
+
+        result = await tags_tools["remove_tag_from_conversation"](
+            context, conversation_id="cnv_a", tag_id="tag_1", confirm=True
+        )
+
+        lifespan.client.tags.remove_from_conversation.assert_awaited_once_with(
+            "cnv_a", tag_ids=["tag_1"]
+        )
+        assert result == {"confirmed": True, "removed": True}
+
+    async def test_create_tag_returns_summary(self, tags_tools):
+        context, lifespan = create_mock_context()
+        new_tag = Tag.model_validate({"id": "tag_new", "name": "urgent"})
+        lifespan.client = AsyncMock()
+        lifespan.client.tags.create = AsyncMock(return_value=new_tag)
+
+        result = await tags_tools["create_tag"](
+            context, name="urgent", highlight="red", confirm=True
+        )
+
+        assert result["confirmed"] is True
+        assert result["tag"]["id"] == "tag_new"
+        lifespan.client.tags.create.assert_awaited_once()
+
+    async def test_delete_tag_calls_helper(self, tags_tools):
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock()
+        lifespan.client.tags.delete = AsyncMock(return_value=True)
+
+        result = await tags_tools["delete_tag"](context, tag_id="tag_abc", confirm=True)
+
+        lifespan.client.tags.delete.assert_awaited_once_with("tag_abc")
+        assert result == {"confirmed": True, "deleted": True}
+
+
+# ---------------------------------------------------------------------------
+# Decline path
+# ---------------------------------------------------------------------------
+
+
+class TestDeclinePath:
+    async def test_delete_tag_declined(self, tags_tools):
+        context, lifespan = create_mock_context(elicit_confirm=False)
+        lifespan.client = AsyncMock(
+            side_effect=AssertionError("client invoked after decline")
+        )
+
+        result = await tags_tools["delete_tag"](context, tag_id="tag_abc", confirm=True)
+        assert result["confirmed"] is False
+        assert result["result"] == "cancelled"
+
+
+# ---------------------------------------------------------------------------
+# TagSummary projection
+# ---------------------------------------------------------------------------
+
+
+class TestTagSummaryProjection:
+    def test_to_tag_summary_includes_timestamps_as_iso(self):
+        from datetime import UTC, datetime
+
+        tag = Tag.model_validate(
+            {
+                "id": "tag_a",
+                "name": "urgent",
+                "created_at": 1701292639,
+            }
+        )
+        summary = to_tag_summary(tag)
+        assert summary.id == "tag_a"
+        assert (
+            summary.created_at == datetime.fromtimestamp(1701292639, tz=UTC).isoformat()
+        )

--- a/frontapp_mcp_server/tests/test_tags_tools.py
+++ b/frontapp_mcp_server/tests/test_tags_tools.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock
 
 import pytest
-from frontapp_mcp.projections import TagSummary, to_tag_summary
+from frontapp_mcp.projections import TagCatalogSummary, to_tag_catalog_summary
 from frontapp_mcp.tools.tags import register_tools
 
 from frontapp_public_api_client.domain import Tag
@@ -58,7 +58,7 @@ class TestReadTools:
 
         result = await tags_tools["get_tag"](context, tag_id="tag_abc")
 
-        assert isinstance(result, TagSummary)
+        assert isinstance(result, TagCatalogSummary)
         assert result.id == "tag_abc"
         assert result.highlight == "red"
 
@@ -74,7 +74,7 @@ class TestReadTools:
         result = await tags_tools["list_tags"](context)
 
         assert len(result) == 2
-        assert all(isinstance(t, TagSummary) for t in result)
+        assert all(isinstance(t, TagCatalogSummary) for t in result)
 
 
 # ---------------------------------------------------------------------------
@@ -225,12 +225,12 @@ class TestDeclinePath:
 
 
 # ---------------------------------------------------------------------------
-# TagSummary projection
+# TagCatalogSummary projection
 # ---------------------------------------------------------------------------
 
 
-class TestTagSummaryProjection:
-    def test_to_tag_summary_includes_timestamps_as_iso(self):
+class TestTagCatalogSummaryProjection:
+    def test_to_tag_catalog_summary_includes_timestamps_as_iso(self):
         from datetime import UTC, datetime
 
         tag = Tag.model_validate(
@@ -240,7 +240,7 @@ class TestTagSummaryProjection:
                 "created_at": 1701292639,
             }
         )
-        summary = to_tag_summary(tag)
+        summary = to_tag_catalog_summary(tag)
         assert summary.id == "tag_a"
         assert (
             summary.created_at == datetime.fromtimestamp(1701292639, tz=UTC).isoformat()

--- a/frontapp_public_api_client/api/tags/__init__.py
+++ b/frontapp_public_api_client/api/tags/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/frontapp_public_api_client/api/tags/create_child_tag.py
+++ b/frontapp_public_api_client/api/tags/create_child_tag.py
@@ -1,0 +1,201 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...client_types import UNSET, Response, Unset
+from ...models.create_tag import CreateTag
+from ...models.tag_response import TagResponse
+
+
+def _get_kwargs(
+    tag_id: str = "tag_123",
+    *,
+    body: CreateTag | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/tags/{tag_id}/children".format(
+            tag_id=quote(str(tag_id), safe=""),
+        ),
+    }
+
+    if not isinstance(body, Unset):
+        _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> TagResponse | None:
+    if response.status_code == 201:
+        response_201 = TagResponse.from_dict(response.json())
+
+        return response_201
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[TagResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    tag_id: str = "tag_123",
+    *,
+    client: AuthenticatedClient | Client,
+    body: CreateTag | Unset = UNSET,
+) -> Response[TagResponse]:
+    """Create child tag
+
+     Creates a child tag.
+
+    Required scope: `tags:write`
+
+    Args:
+        tag_id (str):  Default: 'tag_123'.
+        body (CreateTag | Unset): A tag is a label that can be used to classify conversations.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        Response[TagResponse]
+    """
+
+    kwargs = _get_kwargs(
+        tag_id=tag_id,
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    tag_id: str = "tag_123",
+    *,
+    client: AuthenticatedClient | Client,
+    body: CreateTag | Unset = UNSET,
+) -> TagResponse | None:
+    """Create child tag
+
+     Creates a child tag.
+
+    Required scope: `tags:write`
+
+    Args:
+        tag_id (str):  Default: 'tag_123'.
+        body (CreateTag | Unset): A tag is a label that can be used to classify conversations.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        TagResponse
+    """
+
+    return sync_detailed(
+        tag_id=tag_id,
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    tag_id: str = "tag_123",
+    *,
+    client: AuthenticatedClient | Client,
+    body: CreateTag | Unset = UNSET,
+) -> Response[TagResponse]:
+    """Create child tag
+
+     Creates a child tag.
+
+    Required scope: `tags:write`
+
+    Args:
+        tag_id (str):  Default: 'tag_123'.
+        body (CreateTag | Unset): A tag is a label that can be used to classify conversations.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        Response[TagResponse]
+    """
+
+    kwargs = _get_kwargs(
+        tag_id=tag_id,
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    tag_id: str = "tag_123",
+    *,
+    client: AuthenticatedClient | Client,
+    body: CreateTag | Unset = UNSET,
+) -> TagResponse | None:
+    """Create child tag
+
+     Creates a child tag.
+
+    Required scope: `tags:write`
+
+    Args:
+        tag_id (str):  Default: 'tag_123'.
+        body (CreateTag | Unset): A tag is a label that can be used to classify conversations.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        TagResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            tag_id=tag_id,
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/frontapp_public_api_client/api/tags/create_company_tag.py
+++ b/frontapp_public_api_client/api/tags/create_company_tag.py
@@ -1,0 +1,185 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...client_types import UNSET, Response, Unset
+from ...models.create_tag import CreateTag
+from ...models.tag_response import TagResponse
+
+
+def _get_kwargs(
+    *,
+    body: CreateTag | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/company/tags",
+    }
+
+    if not isinstance(body, Unset):
+        _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> TagResponse | None:
+    if response.status_code == 201:
+        response_201 = TagResponse.from_dict(response.json())
+
+        return response_201
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[TagResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: CreateTag | Unset = UNSET,
+) -> Response[TagResponse]:
+    """Create company tag
+
+     Create a company tag.
+
+    Required scope: `tags:write`
+
+    Args:
+        body (CreateTag | Unset): A tag is a label that can be used to classify conversations.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        Response[TagResponse]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    body: CreateTag | Unset = UNSET,
+) -> TagResponse | None:
+    """Create company tag
+
+     Create a company tag.
+
+    Required scope: `tags:write`
+
+    Args:
+        body (CreateTag | Unset): A tag is a label that can be used to classify conversations.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        TagResponse
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: CreateTag | Unset = UNSET,
+) -> Response[TagResponse]:
+    """Create company tag
+
+     Create a company tag.
+
+    Required scope: `tags:write`
+
+    Args:
+        body (CreateTag | Unset): A tag is a label that can be used to classify conversations.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        Response[TagResponse]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    body: CreateTag | Unset = UNSET,
+) -> TagResponse | None:
+    """Create company tag
+
+     Create a company tag.
+
+    Required scope: `tags:write`
+
+    Args:
+        body (CreateTag | Unset): A tag is a label that can be used to classify conversations.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        TagResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/frontapp_public_api_client/api/tags/create_tag.py
+++ b/frontapp_public_api_client/api/tags/create_tag.py
@@ -1,0 +1,189 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...client_types import UNSET, Response, Unset
+from ...models.create_tag import CreateTag
+from ...models.tag_response import TagResponse
+
+
+def _get_kwargs(
+    *,
+    body: CreateTag | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/tags",
+    }
+
+    if not isinstance(body, Unset):
+        _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> TagResponse | None:
+    if response.status_code == 201:
+        response_201 = TagResponse.from_dict(response.json())
+
+        return response_201
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[TagResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: CreateTag | Unset = UNSET,
+) -> Response[TagResponse]:
+    """Create tag
+
+     Create a tag in the oldest team (workspace). This is a legacy endpoint. Use the Create company tag,
+    Create team tag, or Create teammate tag endpoints instead.
+
+    Required scope: `tags:write`
+
+    Args:
+        body (CreateTag | Unset): A tag is a label that can be used to classify conversations.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        Response[TagResponse]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    body: CreateTag | Unset = UNSET,
+) -> TagResponse | None:
+    """Create tag
+
+     Create a tag in the oldest team (workspace). This is a legacy endpoint. Use the Create company tag,
+    Create team tag, or Create teammate tag endpoints instead.
+
+    Required scope: `tags:write`
+
+    Args:
+        body (CreateTag | Unset): A tag is a label that can be used to classify conversations.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        TagResponse
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: CreateTag | Unset = UNSET,
+) -> Response[TagResponse]:
+    """Create tag
+
+     Create a tag in the oldest team (workspace). This is a legacy endpoint. Use the Create company tag,
+    Create team tag, or Create teammate tag endpoints instead.
+
+    Required scope: `tags:write`
+
+    Args:
+        body (CreateTag | Unset): A tag is a label that can be used to classify conversations.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        Response[TagResponse]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    body: CreateTag | Unset = UNSET,
+) -> TagResponse | None:
+    """Create tag
+
+     Create a tag in the oldest team (workspace). This is a legacy endpoint. Use the Create company tag,
+    Create team tag, or Create teammate tag endpoints instead.
+
+    Required scope: `tags:write`
+
+    Args:
+        body (CreateTag | Unset): A tag is a label that can be used to classify conversations.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        TagResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/frontapp_public_api_client/api/tags/create_team_tag.py
+++ b/frontapp_public_api_client/api/tags/create_team_tag.py
@@ -1,0 +1,201 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...client_types import UNSET, Response, Unset
+from ...models.create_tag import CreateTag
+from ...models.tag_response import TagResponse
+
+
+def _get_kwargs(
+    team_id: str = "tim_123",
+    *,
+    body: CreateTag | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/teams/{team_id}/tags".format(
+            team_id=quote(str(team_id), safe=""),
+        ),
+    }
+
+    if not isinstance(body, Unset):
+        _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> TagResponse | None:
+    if response.status_code == 201:
+        response_201 = TagResponse.from_dict(response.json())
+
+        return response_201
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[TagResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    team_id: str = "tim_123",
+    *,
+    client: AuthenticatedClient | Client,
+    body: CreateTag | Unset = UNSET,
+) -> Response[TagResponse]:
+    """Create team tag
+
+     Create a tag for a team (workspace).
+
+    Required scope: `tags:write`
+
+    Args:
+        team_id (str):  Default: 'tim_123'.
+        body (CreateTag | Unset): A tag is a label that can be used to classify conversations.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        Response[TagResponse]
+    """
+
+    kwargs = _get_kwargs(
+        team_id=team_id,
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    team_id: str = "tim_123",
+    *,
+    client: AuthenticatedClient | Client,
+    body: CreateTag | Unset = UNSET,
+) -> TagResponse | None:
+    """Create team tag
+
+     Create a tag for a team (workspace).
+
+    Required scope: `tags:write`
+
+    Args:
+        team_id (str):  Default: 'tim_123'.
+        body (CreateTag | Unset): A tag is a label that can be used to classify conversations.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        TagResponse
+    """
+
+    return sync_detailed(
+        team_id=team_id,
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    team_id: str = "tim_123",
+    *,
+    client: AuthenticatedClient | Client,
+    body: CreateTag | Unset = UNSET,
+) -> Response[TagResponse]:
+    """Create team tag
+
+     Create a tag for a team (workspace).
+
+    Required scope: `tags:write`
+
+    Args:
+        team_id (str):  Default: 'tim_123'.
+        body (CreateTag | Unset): A tag is a label that can be used to classify conversations.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        Response[TagResponse]
+    """
+
+    kwargs = _get_kwargs(
+        team_id=team_id,
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    team_id: str = "tim_123",
+    *,
+    client: AuthenticatedClient | Client,
+    body: CreateTag | Unset = UNSET,
+) -> TagResponse | None:
+    """Create team tag
+
+     Create a tag for a team (workspace).
+
+    Required scope: `tags:write`
+
+    Args:
+        team_id (str):  Default: 'tim_123'.
+        body (CreateTag | Unset): A tag is a label that can be used to classify conversations.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        TagResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            team_id=team_id,
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/frontapp_public_api_client/api/tags/create_teammate_tag.py
+++ b/frontapp_public_api_client/api/tags/create_teammate_tag.py
@@ -1,0 +1,201 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...client_types import UNSET, Response, Unset
+from ...models.create_tag import CreateTag
+from ...models.tag_response import TagResponse
+
+
+def _get_kwargs(
+    teammate_id: str = "tea_123",
+    *,
+    body: CreateTag | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/teammates/{teammate_id}/tags".format(
+            teammate_id=quote(str(teammate_id), safe=""),
+        ),
+    }
+
+    if not isinstance(body, Unset):
+        _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> TagResponse | None:
+    if response.status_code == 201:
+        response_201 = TagResponse.from_dict(response.json())
+
+        return response_201
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[TagResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    teammate_id: str = "tea_123",
+    *,
+    client: AuthenticatedClient | Client,
+    body: CreateTag | Unset = UNSET,
+) -> Response[TagResponse]:
+    """Create teammate tag
+
+     Create a tag for a teammate.
+
+    Required scope: `tags:write`
+
+    Args:
+        teammate_id (str):  Default: 'tea_123'.
+        body (CreateTag | Unset): A tag is a label that can be used to classify conversations.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        Response[TagResponse]
+    """
+
+    kwargs = _get_kwargs(
+        teammate_id=teammate_id,
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    teammate_id: str = "tea_123",
+    *,
+    client: AuthenticatedClient | Client,
+    body: CreateTag | Unset = UNSET,
+) -> TagResponse | None:
+    """Create teammate tag
+
+     Create a tag for a teammate.
+
+    Required scope: `tags:write`
+
+    Args:
+        teammate_id (str):  Default: 'tea_123'.
+        body (CreateTag | Unset): A tag is a label that can be used to classify conversations.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        TagResponse
+    """
+
+    return sync_detailed(
+        teammate_id=teammate_id,
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    teammate_id: str = "tea_123",
+    *,
+    client: AuthenticatedClient | Client,
+    body: CreateTag | Unset = UNSET,
+) -> Response[TagResponse]:
+    """Create teammate tag
+
+     Create a tag for a teammate.
+
+    Required scope: `tags:write`
+
+    Args:
+        teammate_id (str):  Default: 'tea_123'.
+        body (CreateTag | Unset): A tag is a label that can be used to classify conversations.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        Response[TagResponse]
+    """
+
+    kwargs = _get_kwargs(
+        teammate_id=teammate_id,
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    teammate_id: str = "tea_123",
+    *,
+    client: AuthenticatedClient | Client,
+    body: CreateTag | Unset = UNSET,
+) -> TagResponse | None:
+    """Create teammate tag
+
+     Create a tag for a teammate.
+
+    Required scope: `tags:write`
+
+    Args:
+        teammate_id (str):  Default: 'tea_123'.
+        body (CreateTag | Unset): A tag is a label that can be used to classify conversations.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        TagResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            teammate_id=teammate_id,
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/frontapp_public_api_client/api/tags/delete_tag.py
+++ b/frontapp_public_api_client/api/tags/delete_tag.py
@@ -1,0 +1,114 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...client_types import Response
+
+
+def _get_kwargs(
+    tag_id: str = "tag_123",
+) -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "delete",
+        "url": "/tags/{tag_id}".format(
+            tag_id=quote(str(tag_id), safe=""),
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | None:
+    if response.status_code == 204:
+        return None
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    tag_id: str = "tag_123",
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[Any]:
+    """Delete tag
+
+     Delete a tag.
+
+    Required scope: `tags:delete`
+
+    Args:
+        tag_id (str):  Default: 'tag_123'.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        Response[Any]
+    """
+
+    kwargs = _get_kwargs(
+        tag_id=tag_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio_detailed(
+    tag_id: str = "tag_123",
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[Any]:
+    """Delete tag
+
+     Delete a tag.
+
+    Required scope: `tags:delete`
+
+    Args:
+        tag_id (str):  Default: 'tag_123'.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        Response[Any]
+    """
+
+    kwargs = _get_kwargs(
+        tag_id=tag_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)

--- a/frontapp_public_api_client/api/tags/get_tag.py
+++ b/frontapp_public_api_client/api/tags/get_tag.py
@@ -1,0 +1,179 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...client_types import Response
+from ...models.tag_response import TagResponse
+
+
+def _get_kwargs(
+    tag_id: str = "tag_123",
+) -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/tags/{tag_id}".format(
+            tag_id=quote(str(tag_id), safe=""),
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> TagResponse | None:
+    if response.status_code == 200:
+        response_200 = TagResponse.from_dict(response.json())
+
+        return response_200
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[TagResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    tag_id: str = "tag_123",
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[TagResponse]:
+    """Get tag
+
+     Fetch a tag.
+
+    Required scope: `tags:read`
+
+    Args:
+        tag_id (str):  Default: 'tag_123'.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        Response[TagResponse]
+    """
+
+    kwargs = _get_kwargs(
+        tag_id=tag_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    tag_id: str = "tag_123",
+    *,
+    client: AuthenticatedClient | Client,
+) -> TagResponse | None:
+    """Get tag
+
+     Fetch a tag.
+
+    Required scope: `tags:read`
+
+    Args:
+        tag_id (str):  Default: 'tag_123'.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        TagResponse
+    """
+
+    return sync_detailed(
+        tag_id=tag_id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    tag_id: str = "tag_123",
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[TagResponse]:
+    """Get tag
+
+     Fetch a tag.
+
+    Required scope: `tags:read`
+
+    Args:
+        tag_id (str):  Default: 'tag_123'.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        Response[TagResponse]
+    """
+
+    kwargs = _get_kwargs(
+        tag_id=tag_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    tag_id: str = "tag_123",
+    *,
+    client: AuthenticatedClient | Client,
+) -> TagResponse | None:
+    """Get tag
+
+     Fetch a tag.
+
+    Required scope: `tags:read`
+
+    Args:
+        tag_id (str):  Default: 'tag_123'.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        TagResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            tag_id=tag_id,
+            client=client,
+        )
+    ).parsed

--- a/frontapp_public_api_client/api/tags/list_company_tags.py
+++ b/frontapp_public_api_client/api/tags/list_company_tags.py
@@ -1,0 +1,238 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...client_types import UNSET, Response, Unset
+from ...models.list_company_tags_response_200 import ListCompanyTagsResponse200
+from ...models.list_company_tags_sort_order import ListCompanyTagsSortOrder
+
+
+def _get_kwargs(
+    *,
+    limit: int | Unset = UNSET,
+    page_token: str | Unset = UNSET,
+    sort_by: str | Unset = UNSET,
+    sort_order: ListCompanyTagsSortOrder | Unset = UNSET,
+) -> dict[str, Any]:
+
+    params: dict[str, Any] = {}
+
+    params["limit"] = limit
+
+    params["page_token"] = page_token
+
+    params["sort_by"] = sort_by
+
+    json_sort_order: str | Unset = UNSET
+    if not isinstance(sort_order, Unset):
+        json_sort_order = sort_order.value
+
+    params["sort_order"] = json_sort_order
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/company/tags",
+        "params": params,
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> ListCompanyTagsResponse200 | None:
+    if response.status_code == 200:
+        response_200 = ListCompanyTagsResponse200.from_dict(response.json())
+
+        return response_200
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[ListCompanyTagsResponse200]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = UNSET,
+    page_token: str | Unset = UNSET,
+    sort_by: str | Unset = UNSET,
+    sort_order: ListCompanyTagsSortOrder | Unset = UNSET,
+) -> Response[ListCompanyTagsResponse200]:
+    """List company tags
+
+     List the company tags.
+
+    Required scope: `tags:read`
+
+    Args:
+        limit (int | Unset):  Example: 25.
+        page_token (str | Unset):  Example: https://yourCompany.api.frontapp.com/endpoint?limit=25
+            &page_token=92f32bcd7625333caf4e0f8fc26d920c812f.
+        sort_by (str | Unset):
+        sort_order (ListCompanyTagsSortOrder | Unset):  Example: asc.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        Response[ListCompanyTagsResponse200]
+    """
+
+    kwargs = _get_kwargs(
+        limit=limit,
+        page_token=page_token,
+        sort_by=sort_by,
+        sort_order=sort_order,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = UNSET,
+    page_token: str | Unset = UNSET,
+    sort_by: str | Unset = UNSET,
+    sort_order: ListCompanyTagsSortOrder | Unset = UNSET,
+) -> ListCompanyTagsResponse200 | None:
+    """List company tags
+
+     List the company tags.
+
+    Required scope: `tags:read`
+
+    Args:
+        limit (int | Unset):  Example: 25.
+        page_token (str | Unset):  Example: https://yourCompany.api.frontapp.com/endpoint?limit=25
+            &page_token=92f32bcd7625333caf4e0f8fc26d920c812f.
+        sort_by (str | Unset):
+        sort_order (ListCompanyTagsSortOrder | Unset):  Example: asc.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        ListCompanyTagsResponse200
+    """
+
+    return sync_detailed(
+        client=client,
+        limit=limit,
+        page_token=page_token,
+        sort_by=sort_by,
+        sort_order=sort_order,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = UNSET,
+    page_token: str | Unset = UNSET,
+    sort_by: str | Unset = UNSET,
+    sort_order: ListCompanyTagsSortOrder | Unset = UNSET,
+) -> Response[ListCompanyTagsResponse200]:
+    """List company tags
+
+     List the company tags.
+
+    Required scope: `tags:read`
+
+    Args:
+        limit (int | Unset):  Example: 25.
+        page_token (str | Unset):  Example: https://yourCompany.api.frontapp.com/endpoint?limit=25
+            &page_token=92f32bcd7625333caf4e0f8fc26d920c812f.
+        sort_by (str | Unset):
+        sort_order (ListCompanyTagsSortOrder | Unset):  Example: asc.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        Response[ListCompanyTagsResponse200]
+    """
+
+    kwargs = _get_kwargs(
+        limit=limit,
+        page_token=page_token,
+        sort_by=sort_by,
+        sort_order=sort_order,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = UNSET,
+    page_token: str | Unset = UNSET,
+    sort_by: str | Unset = UNSET,
+    sort_order: ListCompanyTagsSortOrder | Unset = UNSET,
+) -> ListCompanyTagsResponse200 | None:
+    """List company tags
+
+     List the company tags.
+
+    Required scope: `tags:read`
+
+    Args:
+        limit (int | Unset):  Example: 25.
+        page_token (str | Unset):  Example: https://yourCompany.api.frontapp.com/endpoint?limit=25
+            &page_token=92f32bcd7625333caf4e0f8fc26d920c812f.
+        sort_by (str | Unset):
+        sort_order (ListCompanyTagsSortOrder | Unset):  Example: asc.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        ListCompanyTagsResponse200
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            limit=limit,
+            page_token=page_token,
+            sort_by=sort_by,
+            sort_order=sort_order,
+        )
+    ).parsed

--- a/frontapp_public_api_client/api/tags/list_tag_children.py
+++ b/frontapp_public_api_client/api/tags/list_tag_children.py
@@ -1,0 +1,179 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...client_types import Response
+from ...models.list_tag_children_response_200 import ListTagChildrenResponse200
+
+
+def _get_kwargs(
+    tag_id: str = "tag_123",
+) -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/tags/{tag_id}/children".format(
+            tag_id=quote(str(tag_id), safe=""),
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> ListTagChildrenResponse200 | None:
+    if response.status_code == 200:
+        response_200 = ListTagChildrenResponse200.from_dict(response.json())
+
+        return response_200
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[ListTagChildrenResponse200]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    tag_id: str = "tag_123",
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[ListTagChildrenResponse200]:
+    """List tag children
+
+     List the children of a specific tag.
+
+    Required scope: `tags:read`
+
+    Args:
+        tag_id (str):  Default: 'tag_123'.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        Response[ListTagChildrenResponse200]
+    """
+
+    kwargs = _get_kwargs(
+        tag_id=tag_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    tag_id: str = "tag_123",
+    *,
+    client: AuthenticatedClient | Client,
+) -> ListTagChildrenResponse200 | None:
+    """List tag children
+
+     List the children of a specific tag.
+
+    Required scope: `tags:read`
+
+    Args:
+        tag_id (str):  Default: 'tag_123'.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        ListTagChildrenResponse200
+    """
+
+    return sync_detailed(
+        tag_id=tag_id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    tag_id: str = "tag_123",
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[ListTagChildrenResponse200]:
+    """List tag children
+
+     List the children of a specific tag.
+
+    Required scope: `tags:read`
+
+    Args:
+        tag_id (str):  Default: 'tag_123'.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        Response[ListTagChildrenResponse200]
+    """
+
+    kwargs = _get_kwargs(
+        tag_id=tag_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    tag_id: str = "tag_123",
+    *,
+    client: AuthenticatedClient | Client,
+) -> ListTagChildrenResponse200 | None:
+    """List tag children
+
+     List the children of a specific tag.
+
+    Required scope: `tags:read`
+
+    Args:
+        tag_id (str):  Default: 'tag_123'.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        ListTagChildrenResponse200
+    """
+
+    return (
+        await asyncio_detailed(
+            tag_id=tag_id,
+            client=client,
+        )
+    ).parsed

--- a/frontapp_public_api_client/api/tags/list_tagged_conversations.py
+++ b/frontapp_public_api_client/api/tags/list_tagged_conversations.py
@@ -1,0 +1,240 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...client_types import UNSET, Response, Unset
+from ...models.list_tagged_conversations_response_200 import (
+    ListTaggedConversationsResponse200,
+)
+
+
+def _get_kwargs(
+    tag_id: str = "tag_123",
+    *,
+    q: str | Unset = UNSET,
+    limit: int | Unset = UNSET,
+    page_token: str | Unset = UNSET,
+) -> dict[str, Any]:
+
+    params: dict[str, Any] = {}
+
+    params["q"] = q
+
+    params["limit"] = limit
+
+    params["page_token"] = page_token
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/tags/{tag_id}/conversations".format(
+            tag_id=quote(str(tag_id), safe=""),
+        ),
+        "params": params,
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> ListTaggedConversationsResponse200 | None:
+    if response.status_code == 200:
+        response_200 = ListTaggedConversationsResponse200.from_dict(response.json())
+
+        return response_200
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[ListTaggedConversationsResponse200]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    tag_id: str = "tag_123",
+    *,
+    client: AuthenticatedClient | Client,
+    q: str | Unset = UNSET,
+    limit: int | Unset = UNSET,
+    page_token: str | Unset = UNSET,
+) -> Response[ListTaggedConversationsResponse200]:
+    """List tagged conversations
+
+     List the conversations tagged with a tag. For more advanced filtering, see the [search
+    endpoint](https://dev.frontapp.com/reference/conversations#search-conversations).
+
+
+    Required scope: `conversations:read`
+
+    Args:
+        tag_id (str):  Default: 'tag_123'.
+        q (str | Unset):
+        limit (int | Unset):  Example: 25.
+        page_token (str | Unset):  Example: https://yourCompany.api.frontapp.com/endpoint?limit=25
+            &page_token=92f32bcd7625333caf4e0f8fc26d920c812f.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        Response[ListTaggedConversationsResponse200]
+    """
+
+    kwargs = _get_kwargs(
+        tag_id=tag_id,
+        q=q,
+        limit=limit,
+        page_token=page_token,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    tag_id: str = "tag_123",
+    *,
+    client: AuthenticatedClient | Client,
+    q: str | Unset = UNSET,
+    limit: int | Unset = UNSET,
+    page_token: str | Unset = UNSET,
+) -> ListTaggedConversationsResponse200 | None:
+    """List tagged conversations
+
+     List the conversations tagged with a tag. For more advanced filtering, see the [search
+    endpoint](https://dev.frontapp.com/reference/conversations#search-conversations).
+
+
+    Required scope: `conversations:read`
+
+    Args:
+        tag_id (str):  Default: 'tag_123'.
+        q (str | Unset):
+        limit (int | Unset):  Example: 25.
+        page_token (str | Unset):  Example: https://yourCompany.api.frontapp.com/endpoint?limit=25
+            &page_token=92f32bcd7625333caf4e0f8fc26d920c812f.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        ListTaggedConversationsResponse200
+    """
+
+    return sync_detailed(
+        tag_id=tag_id,
+        client=client,
+        q=q,
+        limit=limit,
+        page_token=page_token,
+    ).parsed
+
+
+async def asyncio_detailed(
+    tag_id: str = "tag_123",
+    *,
+    client: AuthenticatedClient | Client,
+    q: str | Unset = UNSET,
+    limit: int | Unset = UNSET,
+    page_token: str | Unset = UNSET,
+) -> Response[ListTaggedConversationsResponse200]:
+    """List tagged conversations
+
+     List the conversations tagged with a tag. For more advanced filtering, see the [search
+    endpoint](https://dev.frontapp.com/reference/conversations#search-conversations).
+
+
+    Required scope: `conversations:read`
+
+    Args:
+        tag_id (str):  Default: 'tag_123'.
+        q (str | Unset):
+        limit (int | Unset):  Example: 25.
+        page_token (str | Unset):  Example: https://yourCompany.api.frontapp.com/endpoint?limit=25
+            &page_token=92f32bcd7625333caf4e0f8fc26d920c812f.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        Response[ListTaggedConversationsResponse200]
+    """
+
+    kwargs = _get_kwargs(
+        tag_id=tag_id,
+        q=q,
+        limit=limit,
+        page_token=page_token,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    tag_id: str = "tag_123",
+    *,
+    client: AuthenticatedClient | Client,
+    q: str | Unset = UNSET,
+    limit: int | Unset = UNSET,
+    page_token: str | Unset = UNSET,
+) -> ListTaggedConversationsResponse200 | None:
+    """List tagged conversations
+
+     List the conversations tagged with a tag. For more advanced filtering, see the [search
+    endpoint](https://dev.frontapp.com/reference/conversations#search-conversations).
+
+
+    Required scope: `conversations:read`
+
+    Args:
+        tag_id (str):  Default: 'tag_123'.
+        q (str | Unset):
+        limit (int | Unset):  Example: 25.
+        page_token (str | Unset):  Example: https://yourCompany.api.frontapp.com/endpoint?limit=25
+            &page_token=92f32bcd7625333caf4e0f8fc26d920c812f.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        ListTaggedConversationsResponse200
+    """
+
+    return (
+        await asyncio_detailed(
+            tag_id=tag_id,
+            client=client,
+            q=q,
+            limit=limit,
+            page_token=page_token,
+        )
+    ).parsed

--- a/frontapp_public_api_client/api/tags/list_tags.py
+++ b/frontapp_public_api_client/api/tags/list_tags.py
@@ -1,0 +1,242 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...client_types import UNSET, Response, Unset
+from ...models.list_tags_response_200 import ListTagsResponse200
+from ...models.list_tags_sort_order import ListTagsSortOrder
+
+
+def _get_kwargs(
+    *,
+    limit: int | Unset = UNSET,
+    page_token: str | Unset = UNSET,
+    sort_by: str | Unset = UNSET,
+    sort_order: ListTagsSortOrder | Unset = UNSET,
+) -> dict[str, Any]:
+
+    params: dict[str, Any] = {}
+
+    params["limit"] = limit
+
+    params["page_token"] = page_token
+
+    params["sort_by"] = sort_by
+
+    json_sort_order: str | Unset = UNSET
+    if not isinstance(sort_order, Unset):
+        json_sort_order = sort_order.value
+
+    params["sort_order"] = json_sort_order
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/tags",
+        "params": params,
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> ListTagsResponse200 | None:
+    if response.status_code == 200:
+        response_200 = ListTagsResponse200.from_dict(response.json())
+
+        return response_200
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[ListTagsResponse200]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = UNSET,
+    page_token: str | Unset = UNSET,
+    sort_by: str | Unset = UNSET,
+    sort_order: ListTagsSortOrder | Unset = UNSET,
+) -> Response[ListTagsResponse200]:
+    """List tags
+
+     List all the tags of the company that the API token has access to, whether they be company tags,
+    team tags, or teammate tags.
+
+    Required scope: `tags:read`
+
+    Args:
+        limit (int | Unset):  Example: 25.
+        page_token (str | Unset):  Example: https://yourCompany.api.frontapp.com/endpoint?limit=25
+            &page_token=92f32bcd7625333caf4e0f8fc26d920c812f.
+        sort_by (str | Unset):
+        sort_order (ListTagsSortOrder | Unset):  Example: asc.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        Response[ListTagsResponse200]
+    """
+
+    kwargs = _get_kwargs(
+        limit=limit,
+        page_token=page_token,
+        sort_by=sort_by,
+        sort_order=sort_order,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = UNSET,
+    page_token: str | Unset = UNSET,
+    sort_by: str | Unset = UNSET,
+    sort_order: ListTagsSortOrder | Unset = UNSET,
+) -> ListTagsResponse200 | None:
+    """List tags
+
+     List all the tags of the company that the API token has access to, whether they be company tags,
+    team tags, or teammate tags.
+
+    Required scope: `tags:read`
+
+    Args:
+        limit (int | Unset):  Example: 25.
+        page_token (str | Unset):  Example: https://yourCompany.api.frontapp.com/endpoint?limit=25
+            &page_token=92f32bcd7625333caf4e0f8fc26d920c812f.
+        sort_by (str | Unset):
+        sort_order (ListTagsSortOrder | Unset):  Example: asc.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        ListTagsResponse200
+    """
+
+    return sync_detailed(
+        client=client,
+        limit=limit,
+        page_token=page_token,
+        sort_by=sort_by,
+        sort_order=sort_order,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = UNSET,
+    page_token: str | Unset = UNSET,
+    sort_by: str | Unset = UNSET,
+    sort_order: ListTagsSortOrder | Unset = UNSET,
+) -> Response[ListTagsResponse200]:
+    """List tags
+
+     List all the tags of the company that the API token has access to, whether they be company tags,
+    team tags, or teammate tags.
+
+    Required scope: `tags:read`
+
+    Args:
+        limit (int | Unset):  Example: 25.
+        page_token (str | Unset):  Example: https://yourCompany.api.frontapp.com/endpoint?limit=25
+            &page_token=92f32bcd7625333caf4e0f8fc26d920c812f.
+        sort_by (str | Unset):
+        sort_order (ListTagsSortOrder | Unset):  Example: asc.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        Response[ListTagsResponse200]
+    """
+
+    kwargs = _get_kwargs(
+        limit=limit,
+        page_token=page_token,
+        sort_by=sort_by,
+        sort_order=sort_order,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = UNSET,
+    page_token: str | Unset = UNSET,
+    sort_by: str | Unset = UNSET,
+    sort_order: ListTagsSortOrder | Unset = UNSET,
+) -> ListTagsResponse200 | None:
+    """List tags
+
+     List all the tags of the company that the API token has access to, whether they be company tags,
+    team tags, or teammate tags.
+
+    Required scope: `tags:read`
+
+    Args:
+        limit (int | Unset):  Example: 25.
+        page_token (str | Unset):  Example: https://yourCompany.api.frontapp.com/endpoint?limit=25
+            &page_token=92f32bcd7625333caf4e0f8fc26d920c812f.
+        sort_by (str | Unset):
+        sort_order (ListTagsSortOrder | Unset):  Example: asc.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        ListTagsResponse200
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            limit=limit,
+            page_token=page_token,
+            sort_by=sort_by,
+            sort_order=sort_order,
+        )
+    ).parsed

--- a/frontapp_public_api_client/api/tags/list_team_tags.py
+++ b/frontapp_public_api_client/api/tags/list_team_tags.py
@@ -1,0 +1,254 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...client_types import UNSET, Response, Unset
+from ...models.list_team_tags_response_200 import ListTeamTagsResponse200
+from ...models.list_team_tags_sort_order import ListTeamTagsSortOrder
+
+
+def _get_kwargs(
+    team_id: str = "tim_123",
+    *,
+    limit: int | Unset = UNSET,
+    page_token: str | Unset = UNSET,
+    sort_by: str | Unset = UNSET,
+    sort_order: ListTeamTagsSortOrder | Unset = UNSET,
+) -> dict[str, Any]:
+
+    params: dict[str, Any] = {}
+
+    params["limit"] = limit
+
+    params["page_token"] = page_token
+
+    params["sort_by"] = sort_by
+
+    json_sort_order: str | Unset = UNSET
+    if not isinstance(sort_order, Unset):
+        json_sort_order = sort_order.value
+
+    params["sort_order"] = json_sort_order
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/teams/{team_id}/tags".format(
+            team_id=quote(str(team_id), safe=""),
+        ),
+        "params": params,
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> ListTeamTagsResponse200 | None:
+    if response.status_code == 200:
+        response_200 = ListTeamTagsResponse200.from_dict(response.json())
+
+        return response_200
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[ListTeamTagsResponse200]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    team_id: str = "tim_123",
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = UNSET,
+    page_token: str | Unset = UNSET,
+    sort_by: str | Unset = UNSET,
+    sort_order: ListTeamTagsSortOrder | Unset = UNSET,
+) -> Response[ListTeamTagsResponse200]:
+    """List team tags
+
+     List the tags for a team (workspace).
+
+    Required scope: `tags:read`
+
+    Args:
+        team_id (str):  Default: 'tim_123'.
+        limit (int | Unset):  Example: 25.
+        page_token (str | Unset):  Example: https://yourCompany.api.frontapp.com/endpoint?limit=25
+            &page_token=92f32bcd7625333caf4e0f8fc26d920c812f.
+        sort_by (str | Unset):
+        sort_order (ListTeamTagsSortOrder | Unset):  Example: asc.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        Response[ListTeamTagsResponse200]
+    """
+
+    kwargs = _get_kwargs(
+        team_id=team_id,
+        limit=limit,
+        page_token=page_token,
+        sort_by=sort_by,
+        sort_order=sort_order,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    team_id: str = "tim_123",
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = UNSET,
+    page_token: str | Unset = UNSET,
+    sort_by: str | Unset = UNSET,
+    sort_order: ListTeamTagsSortOrder | Unset = UNSET,
+) -> ListTeamTagsResponse200 | None:
+    """List team tags
+
+     List the tags for a team (workspace).
+
+    Required scope: `tags:read`
+
+    Args:
+        team_id (str):  Default: 'tim_123'.
+        limit (int | Unset):  Example: 25.
+        page_token (str | Unset):  Example: https://yourCompany.api.frontapp.com/endpoint?limit=25
+            &page_token=92f32bcd7625333caf4e0f8fc26d920c812f.
+        sort_by (str | Unset):
+        sort_order (ListTeamTagsSortOrder | Unset):  Example: asc.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        ListTeamTagsResponse200
+    """
+
+    return sync_detailed(
+        team_id=team_id,
+        client=client,
+        limit=limit,
+        page_token=page_token,
+        sort_by=sort_by,
+        sort_order=sort_order,
+    ).parsed
+
+
+async def asyncio_detailed(
+    team_id: str = "tim_123",
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = UNSET,
+    page_token: str | Unset = UNSET,
+    sort_by: str | Unset = UNSET,
+    sort_order: ListTeamTagsSortOrder | Unset = UNSET,
+) -> Response[ListTeamTagsResponse200]:
+    """List team tags
+
+     List the tags for a team (workspace).
+
+    Required scope: `tags:read`
+
+    Args:
+        team_id (str):  Default: 'tim_123'.
+        limit (int | Unset):  Example: 25.
+        page_token (str | Unset):  Example: https://yourCompany.api.frontapp.com/endpoint?limit=25
+            &page_token=92f32bcd7625333caf4e0f8fc26d920c812f.
+        sort_by (str | Unset):
+        sort_order (ListTeamTagsSortOrder | Unset):  Example: asc.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        Response[ListTeamTagsResponse200]
+    """
+
+    kwargs = _get_kwargs(
+        team_id=team_id,
+        limit=limit,
+        page_token=page_token,
+        sort_by=sort_by,
+        sort_order=sort_order,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    team_id: str = "tim_123",
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = UNSET,
+    page_token: str | Unset = UNSET,
+    sort_by: str | Unset = UNSET,
+    sort_order: ListTeamTagsSortOrder | Unset = UNSET,
+) -> ListTeamTagsResponse200 | None:
+    """List team tags
+
+     List the tags for a team (workspace).
+
+    Required scope: `tags:read`
+
+    Args:
+        team_id (str):  Default: 'tim_123'.
+        limit (int | Unset):  Example: 25.
+        page_token (str | Unset):  Example: https://yourCompany.api.frontapp.com/endpoint?limit=25
+            &page_token=92f32bcd7625333caf4e0f8fc26d920c812f.
+        sort_by (str | Unset):
+        sort_order (ListTeamTagsSortOrder | Unset):  Example: asc.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        ListTeamTagsResponse200
+    """
+
+    return (
+        await asyncio_detailed(
+            team_id=team_id,
+            client=client,
+            limit=limit,
+            page_token=page_token,
+            sort_by=sort_by,
+            sort_order=sort_order,
+        )
+    ).parsed

--- a/frontapp_public_api_client/api/tags/list_teammate_tags.py
+++ b/frontapp_public_api_client/api/tags/list_teammate_tags.py
@@ -1,0 +1,254 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...client_types import UNSET, Response, Unset
+from ...models.list_teammate_tags_response_200 import ListTeammateTagsResponse200
+from ...models.list_teammate_tags_sort_order import ListTeammateTagsSortOrder
+
+
+def _get_kwargs(
+    teammate_id: str = "tea_123",
+    *,
+    limit: int | Unset = UNSET,
+    page_token: str | Unset = UNSET,
+    sort_by: str | Unset = UNSET,
+    sort_order: ListTeammateTagsSortOrder | Unset = UNSET,
+) -> dict[str, Any]:
+
+    params: dict[str, Any] = {}
+
+    params["limit"] = limit
+
+    params["page_token"] = page_token
+
+    params["sort_by"] = sort_by
+
+    json_sort_order: str | Unset = UNSET
+    if not isinstance(sort_order, Unset):
+        json_sort_order = sort_order.value
+
+    params["sort_order"] = json_sort_order
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/teammates/{teammate_id}/tags".format(
+            teammate_id=quote(str(teammate_id), safe=""),
+        ),
+        "params": params,
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> ListTeammateTagsResponse200 | None:
+    if response.status_code == 200:
+        response_200 = ListTeammateTagsResponse200.from_dict(response.json())
+
+        return response_200
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[ListTeammateTagsResponse200]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    teammate_id: str = "tea_123",
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = UNSET,
+    page_token: str | Unset = UNSET,
+    sort_by: str | Unset = UNSET,
+    sort_order: ListTeammateTagsSortOrder | Unset = UNSET,
+) -> Response[ListTeammateTagsResponse200]:
+    """List teammate tags
+
+     List the tags for a teammate.
+
+    Required scope: `tags:read`
+
+    Args:
+        teammate_id (str):  Default: 'tea_123'.
+        limit (int | Unset):  Example: 25.
+        page_token (str | Unset):  Example: https://yourCompany.api.frontapp.com/endpoint?limit=25
+            &page_token=92f32bcd7625333caf4e0f8fc26d920c812f.
+        sort_by (str | Unset):
+        sort_order (ListTeammateTagsSortOrder | Unset):  Example: asc.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        Response[ListTeammateTagsResponse200]
+    """
+
+    kwargs = _get_kwargs(
+        teammate_id=teammate_id,
+        limit=limit,
+        page_token=page_token,
+        sort_by=sort_by,
+        sort_order=sort_order,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    teammate_id: str = "tea_123",
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = UNSET,
+    page_token: str | Unset = UNSET,
+    sort_by: str | Unset = UNSET,
+    sort_order: ListTeammateTagsSortOrder | Unset = UNSET,
+) -> ListTeammateTagsResponse200 | None:
+    """List teammate tags
+
+     List the tags for a teammate.
+
+    Required scope: `tags:read`
+
+    Args:
+        teammate_id (str):  Default: 'tea_123'.
+        limit (int | Unset):  Example: 25.
+        page_token (str | Unset):  Example: https://yourCompany.api.frontapp.com/endpoint?limit=25
+            &page_token=92f32bcd7625333caf4e0f8fc26d920c812f.
+        sort_by (str | Unset):
+        sort_order (ListTeammateTagsSortOrder | Unset):  Example: asc.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        ListTeammateTagsResponse200
+    """
+
+    return sync_detailed(
+        teammate_id=teammate_id,
+        client=client,
+        limit=limit,
+        page_token=page_token,
+        sort_by=sort_by,
+        sort_order=sort_order,
+    ).parsed
+
+
+async def asyncio_detailed(
+    teammate_id: str = "tea_123",
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = UNSET,
+    page_token: str | Unset = UNSET,
+    sort_by: str | Unset = UNSET,
+    sort_order: ListTeammateTagsSortOrder | Unset = UNSET,
+) -> Response[ListTeammateTagsResponse200]:
+    """List teammate tags
+
+     List the tags for a teammate.
+
+    Required scope: `tags:read`
+
+    Args:
+        teammate_id (str):  Default: 'tea_123'.
+        limit (int | Unset):  Example: 25.
+        page_token (str | Unset):  Example: https://yourCompany.api.frontapp.com/endpoint?limit=25
+            &page_token=92f32bcd7625333caf4e0f8fc26d920c812f.
+        sort_by (str | Unset):
+        sort_order (ListTeammateTagsSortOrder | Unset):  Example: asc.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        Response[ListTeammateTagsResponse200]
+    """
+
+    kwargs = _get_kwargs(
+        teammate_id=teammate_id,
+        limit=limit,
+        page_token=page_token,
+        sort_by=sort_by,
+        sort_order=sort_order,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    teammate_id: str = "tea_123",
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = UNSET,
+    page_token: str | Unset = UNSET,
+    sort_by: str | Unset = UNSET,
+    sort_order: ListTeammateTagsSortOrder | Unset = UNSET,
+) -> ListTeammateTagsResponse200 | None:
+    """List teammate tags
+
+     List the tags for a teammate.
+
+    Required scope: `tags:read`
+
+    Args:
+        teammate_id (str):  Default: 'tea_123'.
+        limit (int | Unset):  Example: 25.
+        page_token (str | Unset):  Example: https://yourCompany.api.frontapp.com/endpoint?limit=25
+            &page_token=92f32bcd7625333caf4e0f8fc26d920c812f.
+        sort_by (str | Unset):
+        sort_order (ListTeammateTagsSortOrder | Unset):  Example: asc.
+
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        ListTeammateTagsResponse200
+    """
+
+    return (
+        await asyncio_detailed(
+            teammate_id=teammate_id,
+            client=client,
+            limit=limit,
+            page_token=page_token,
+            sort_by=sort_by,
+            sort_order=sort_order,
+        )
+    ).parsed

--- a/frontapp_public_api_client/api/tags/update_a_tag.py
+++ b/frontapp_public_api_client/api/tags/update_a_tag.py
@@ -1,0 +1,128 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...client_types import UNSET, Response, Unset
+from ...models.update_tag import UpdateTag
+
+
+def _get_kwargs(
+    tag_id: str = "tag_123",
+    *,
+    body: UpdateTag | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "patch",
+        "url": "/tags/{tag_id}".format(
+            tag_id=quote(str(tag_id), safe=""),
+        ),
+    }
+
+    if not isinstance(body, Unset):
+        _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | None:
+    if response.status_code == 204:
+        return None
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    tag_id: str = "tag_123",
+    *,
+    client: AuthenticatedClient | Client,
+    body: UpdateTag | Unset = UNSET,
+) -> Response[Any]:
+    """Update a tag
+
+     Update a tag.
+
+    Required scope: `tags:write`
+
+    Args:
+        tag_id (str):  Default: 'tag_123'.
+        body (UpdateTag | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        Response[Any]
+    """
+
+    kwargs = _get_kwargs(
+        tag_id=tag_id,
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio_detailed(
+    tag_id: str = "tag_123",
+    *,
+    client: AuthenticatedClient | Client,
+    body: UpdateTag | Unset = UNSET,
+) -> Response[Any]:
+    """Update a tag
+
+     Update a tag.
+
+    Required scope: `tags:write`
+
+    Args:
+        tag_id (str):  Default: 'tag_123'.
+        body (UpdateTag | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+
+    Returns:
+        Response[Any]
+    """
+
+    kwargs = _get_kwargs(
+        tag_id=tag_id,
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)

--- a/frontapp_public_api_client/domain/__init__.py
+++ b/frontapp_public_api_client/domain/__init__.py
@@ -31,6 +31,8 @@ from .conversation import (
 )
 from .converters import to_unset, unwrap_unset
 from .draft import AttachmentSummary, Draft
+from .inbox import Inbox
+from .tag import Tag
 
 __all__ = [
     "AttachmentSummary",
@@ -42,7 +44,9 @@ __all__ = [
     "Conversation",
     "ConversationPageCursor",
     "Draft",
+    "Inbox",
     "RecipientSummary",
+    "Tag",
     "TagSummary",
     "TeammateSummary",
     "to_unset",

--- a/frontapp_public_api_client/domain/inbox.py
+++ b/frontapp_public_api_client/domain/inbox.py
@@ -1,0 +1,38 @@
+"""Domain model for Frontapp inboxes.
+
+Hand-written Pydantic projection of Front's ``InboxResponse``. Inboxes are
+workspace-level reference data — there are no timestamp fields and no
+mutable shape beyond name + visibility, so the projection is intentionally
+thin.
+
+Note: every field on the generated ``InboxResponse`` is ``UNSET`` by
+default, so the projection here marks them all as optional even though
+``id`` and ``name`` are typically present in real responses.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class Inbox(BaseModel):
+    """A Front inbox (channel container) as returned by ``/inboxes*`` endpoints.
+
+    Inbox IDs are strings with an ``inb_`` prefix (e.g. ``inb_abc123``).
+    ``is_private`` and ``is_public`` are independent flags Front uses to
+    model visibility — not strict mutual opposites.
+    """
+
+    id: str | None = Field(None, description="Inbox id, e.g. 'inb_abc123'")
+    name: str | None = None
+    is_private: bool | None = None
+    is_public: bool | None = None
+
+    model_config = ConfigDict(
+        frozen=True,
+        str_strip_whitespace=True,
+        extra="ignore",
+    )
+
+
+__all__ = ["Inbox"]

--- a/frontapp_public_api_client/domain/tag.py
+++ b/frontapp_public_api_client/domain/tag.py
@@ -1,0 +1,53 @@
+"""Domain model for Frontapp tags.
+
+Hand-written Pydantic projection of Front's ``TagResponse``. Distinct from
+the lighter ``TagSummary`` in ``domain/conversation.py``, which is a nested
+sub-type used inside ``Conversation`` and only carries id/name/highlight/
+is_private. ``Tag`` here is the full standalone shape used by the tags
+vertical (``client.tags``).
+
+Front returns ``created_at`` and ``updated_at`` as unix-seconds floats
+(see ``TagResponse``); the validator below converts them to
+timezone-aware ``datetime`` objects, mirroring ``Conversation``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, field_validator
+
+from .conversation import _unix_to_datetime
+
+
+class Tag(BaseModel):
+    """A Front workspace tag as returned by ``/tags*`` endpoints.
+
+    Tag IDs are strings with a ``tag_`` prefix (e.g. ``tag_abc123``).
+    ``highlight`` is a color name (``red``, ``blue``, etc.) or ``None``.
+    ``is_visible_in_conversation_lists`` controls whether the tag chip
+    shows up on conversation list rows in Front's UI.
+    """
+
+    id: str
+    name: str
+    description: str | None = None
+    highlight: str | None = Field(None, description="Color name, e.g. 'red'")
+    is_private: bool = False
+    is_visible_in_conversation_lists: bool = False
+    created_at: AwareDatetime | None = None
+    updated_at: AwareDatetime | None = None
+
+    model_config = ConfigDict(
+        frozen=True,
+        str_strip_whitespace=True,
+        extra="ignore",
+    )
+
+    @field_validator("created_at", "updated_at", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: Any) -> Any:
+        return _unix_to_datetime(value)
+
+
+__all__ = ["Tag"]

--- a/frontapp_public_api_client/frontapp_client.py
+++ b/frontapp_public_api_client/frontapp_client.py
@@ -21,7 +21,9 @@ if TYPE_CHECKING:
     from .helpers.contacts import Contacts
     from .helpers.conversations import Conversations
     from .helpers.drafts import Drafts
+    from .helpers.inboxes import Inboxes
     from .helpers.messages import Messages
+    from .helpers.tags import Tags
 
 import httpx
 from dotenv import load_dotenv
@@ -1030,6 +1032,8 @@ class FrontappClient(AuthenticatedClient):
         self._contacts: Contacts | None = None
         self._drafts: Drafts | None = None
         self._messages: Messages | None = None
+        self._tags: Tags | None = None
+        self._inboxes: Inboxes | None = None
 
         # Extract client-level parameters that shouldn't go to the transport
         # Event hooks for observability - start with our defaults
@@ -1150,6 +1154,37 @@ class FrontappClient(AuthenticatedClient):
         if self._messages is None:
             self._messages = Messages(self)
         return self._messages
+
+    @property
+    def tags(self) -> "Tags":
+        """Ergonomic operations over Frontapp's workspace tag surface.
+
+        Covers the workspace tag catalog (``/tags*``) plus the
+        conversation-tag delta endpoints. Use the delta methods
+        (``apply_to_conversation`` / ``remove_from_conversation``) when
+        you want to add or remove a single tag without clobbering the
+        rest of the conversation's tag set.
+        """
+        from .helpers.tags import Tags
+
+        if self._tags is None:
+            self._tags = Tags(self)
+        return self._tags
+
+    @property
+    def inboxes(self) -> "Inboxes":
+        """Ergonomic operations over Frontapp's inbox surface.
+
+        Covers the workspace inbox catalog (``/inboxes*``). Front exposes
+        no general inbox PATCH — inbox name and visibility are immutable
+        after creation; only access (``grant_access`` / ``revoke_access``)
+        can be changed.
+        """
+        from .helpers.inboxes import Inboxes
+
+        if self._inboxes is None:
+            self._inboxes = Inboxes(self)
+        return self._inboxes
 
     # Event hooks for observability
     async def _capture_pagination_metadata(self, response: httpx.Response) -> None:

--- a/frontapp_public_api_client/helpers/__init__.py
+++ b/frontapp_public_api_client/helpers/__init__.py
@@ -9,12 +9,16 @@ from frontapp_public_api_client.helpers.base import Base
 from frontapp_public_api_client.helpers.contacts import Contacts
 from frontapp_public_api_client.helpers.conversations import Conversations
 from frontapp_public_api_client.helpers.drafts import Drafts
+from frontapp_public_api_client.helpers.inboxes import Inboxes
 from frontapp_public_api_client.helpers.messages import Messages
+from frontapp_public_api_client.helpers.tags import Tags
 
 __all__ = [
     "Base",
     "Contacts",
     "Conversations",
     "Drafts",
+    "Inboxes",
     "Messages",
+    "Tags",
 ]

--- a/frontapp_public_api_client/helpers/inboxes.py
+++ b/frontapp_public_api_client/helpers/inboxes.py
@@ -1,0 +1,234 @@
+"""Inboxes helper facade — ergonomic wrappers around generated inbox endpoints.
+
+Exposes ``client.inboxes`` covering the workspace-level inbox catalog
+(``inboxes/``). Inboxes are channel containers — every conversation belongs
+to one — and they're workspace-shared reference data.
+
+Reads cover the workspace, team-, and teammate-private list scopes plus
+the per-inbox conversation/channel/access lookups. Mutations cover create
+plus the teammate access grants/revokes.
+
+Quirks worth knowing:
+
+- The DELETE-access endpoint module is ``removes_inbox_access`` (with the
+  ``removes_`` prefix flagged in ``api-facts.yaml``
+  ``summary.module_name_quirks``). The helper renames it to the more
+  conventional ``revoke_access``.
+- ``InboxResponse`` carries every field as ``UNSET``-defaulted (including
+  ``id`` and ``name``) — the ``Inbox`` Pydantic projection reflects that
+  with all-Optional fields.
+- Front has no ``update_inbox`` endpoint — only create + access
+  grant/revoke after that. Inbox name and visibility are immutable post-
+  creation.
+- ``list_inboxes``, ``list_team_inboxes``, ``list_teammate_private_inboxes``,
+  ``list_inbox_channels``, and ``list_inbox_access`` all take no
+  pagination params — the generated endpoints return the full set in one
+  shot.
+"""
+
+from __future__ import annotations
+
+import builtins
+from typing import TYPE_CHECKING, Any
+
+from frontapp_public_api_client.helpers.base import Base
+
+if TYPE_CHECKING:
+    from frontapp_public_api_client.domain import Inbox
+
+
+class Inboxes(Base):
+    """Ergonomic operations over Frontapp's inbox surface."""
+
+    # -- reads --------------------------------------------------------------
+
+    async def list(self) -> builtins.list[Inbox]:
+        """List every inbox visible to the API token."""
+        from frontapp_public_api_client.api.inboxes import list_inboxes
+        from frontapp_public_api_client.domain import Inbox
+        from frontapp_public_api_client.utils import unwrap
+
+        response = await list_inboxes.asyncio_detailed(client=self._client)
+        parsed = unwrap(response)
+        results = getattr(parsed, "field_results", None) or []
+        return [Inbox.model_validate(i.to_dict()) for i in results]
+
+    async def list_for_team(self, team_id: str) -> builtins.list[Inbox]:
+        """List inboxes owned by a team (``"tim_abc"``)."""
+        from frontapp_public_api_client.api.inboxes import list_team_inboxes
+        from frontapp_public_api_client.domain import Inbox
+        from frontapp_public_api_client.utils import unwrap
+
+        response = await list_team_inboxes.asyncio_detailed(
+            team_id=team_id, client=self._client
+        )
+        parsed = unwrap(response)
+        results = getattr(parsed, "field_results", None) or []
+        return [Inbox.model_validate(i.to_dict()) for i in results]
+
+    async def list_private_for_teammate(self, teammate_id: str) -> builtins.list[Inbox]:
+        """List a teammate's private inboxes (``"tea_abc"``)."""
+        from frontapp_public_api_client.api.inboxes import (
+            list_teammate_private_inboxes,
+        )
+        from frontapp_public_api_client.domain import Inbox
+        from frontapp_public_api_client.utils import unwrap
+
+        response = await list_teammate_private_inboxes.asyncio_detailed(
+            teammate_id=teammate_id, client=self._client
+        )
+        parsed = unwrap(response)
+        results = getattr(parsed, "field_results", None) or []
+        return [Inbox.model_validate(i.to_dict()) for i in results]
+
+    async def get(self, inbox_id: str) -> Inbox:
+        """Fetch one inbox by id (e.g. ``"inb_abc"``)."""
+        from frontapp_public_api_client.api.inboxes import get_inbox
+        from frontapp_public_api_client.domain import Inbox
+        from frontapp_public_api_client.models.inbox_response import InboxResponse
+        from frontapp_public_api_client.utils import unwrap_as
+
+        response = await get_inbox.asyncio_detailed(
+            inbox_id=inbox_id, client=self._client
+        )
+        inbox = unwrap_as(response, InboxResponse)
+        return Inbox.model_validate(inbox.to_dict())
+
+    async def list_conversations(
+        self,
+        inbox_id: str,
+        *,
+        q: str | None = None,
+        limit: int | None = None,
+        page_token: str | None = None,
+    ) -> builtins.list[Any]:
+        """List conversations in this inbox. Returns raw attrs models."""
+        from frontapp_public_api_client.api.inboxes import list_inbox_conversations
+        from frontapp_public_api_client.utils import unwrap
+
+        kwargs: dict[str, Any] = {"client": self._client, "inbox_id": inbox_id}
+        if q is not None:
+            kwargs["q"] = q
+        if limit is not None:
+            kwargs["limit"] = limit
+        if page_token is not None:
+            kwargs["page_token"] = page_token
+
+        response = await list_inbox_conversations.asyncio_detailed(**kwargs)
+        parsed = unwrap(response)
+        return list(getattr(parsed, "field_results", None) or [])
+
+    async def list_channels(self, inbox_id: str) -> builtins.list[Any]:
+        """List channels routing into this inbox. Returns raw attrs models."""
+        from frontapp_public_api_client.api.inboxes import list_inbox_channels
+        from frontapp_public_api_client.utils import unwrap
+
+        response = await list_inbox_channels.asyncio_detailed(
+            inbox_id=inbox_id, client=self._client
+        )
+        parsed = unwrap(response)
+        return list(getattr(parsed, "field_results", None) or [])
+
+    async def list_access(self, inbox_id: str) -> builtins.list[Any]:
+        """List teammates with access to this inbox. Returns raw attrs models."""
+        from frontapp_public_api_client.api.inboxes import list_inbox_access
+        from frontapp_public_api_client.utils import unwrap
+
+        response = await list_inbox_access.asyncio_detailed(
+            inbox_id=inbox_id, client=self._client
+        )
+        parsed = unwrap(response)
+        return list(getattr(parsed, "field_results", None) or [])
+
+    # -- mutations ----------------------------------------------------------
+
+    async def create(
+        self,
+        *,
+        name: str,
+        teammate_ids: builtins.list[str] | None = None,
+        is_public: bool | None = None,
+    ) -> Inbox:
+        """Create a workspace-scoped inbox.
+
+        Creates a new shared inbox container. Channels still need to be
+        wired up separately. Workspace-wide change.
+        """
+        from frontapp_public_api_client.api.inboxes import create_inbox
+        from frontapp_public_api_client.domain import Inbox
+        from frontapp_public_api_client.models.create_inbox import CreateInbox
+        from frontapp_public_api_client.models.inbox_response import InboxResponse
+        from frontapp_public_api_client.utils import unwrap_as
+
+        kwargs: dict[str, Any] = {"name": name}
+        if teammate_ids is not None:
+            kwargs["teammate_ids"] = teammate_ids
+        if is_public is not None:
+            kwargs["is_public"] = is_public
+
+        body = CreateInbox(**kwargs)
+        response = await create_inbox.asyncio_detailed(client=self._client, body=body)
+        inbox = unwrap_as(response, InboxResponse)
+        return Inbox.model_validate(inbox.to_dict())
+
+    async def create_for_team(
+        self,
+        team_id: str,
+        *,
+        name: str,
+        teammate_ids: builtins.list[str] | None = None,
+        is_public: bool | None = None,
+    ) -> Inbox:
+        """Create an inbox owned by a team (``"tim_abc"``)."""
+        from frontapp_public_api_client.api.inboxes import create_team_inbox
+        from frontapp_public_api_client.domain import Inbox
+        from frontapp_public_api_client.models.create_team_inbox import CreateTeamInbox
+        from frontapp_public_api_client.models.inbox_response import InboxResponse
+        from frontapp_public_api_client.utils import unwrap_as
+
+        kwargs: dict[str, Any] = {"name": name}
+        if teammate_ids is not None:
+            kwargs["teammate_ids"] = teammate_ids
+        if is_public is not None:
+            kwargs["is_public"] = is_public
+
+        body = CreateTeamInbox(**kwargs)
+        response = await create_team_inbox.asyncio_detailed(
+            team_id=team_id, client=self._client, body=body
+        )
+        inbox = unwrap_as(response, InboxResponse)
+        return Inbox.model_validate(inbox.to_dict())
+
+    async def grant_access(
+        self, inbox_id: str, *, teammate_ids: builtins.list[str]
+    ) -> bool:
+        """Grant inbox access to one or more teammates."""
+        from frontapp_public_api_client.api.inboxes import add_inbox_access
+        from frontapp_public_api_client.models.teammate_ids import TeammateIds
+        from frontapp_public_api_client.utils import is_success
+
+        body = TeammateIds(teammate_ids=teammate_ids)
+        response = await add_inbox_access.asyncio_detailed(
+            inbox_id=inbox_id, client=self._client, body=body
+        )
+        return is_success(response)
+
+    async def revoke_access(
+        self, inbox_id: str, *, teammate_ids: builtins.list[str]
+    ) -> bool:
+        """Revoke inbox access from one or more teammates.
+
+        Wraps the awkwardly-named generated module ``removes_inbox_access``.
+        """
+        from frontapp_public_api_client.api.inboxes import removes_inbox_access
+        from frontapp_public_api_client.models.teammate_ids import TeammateIds
+        from frontapp_public_api_client.utils import is_success
+
+        body = TeammateIds(teammate_ids=teammate_ids)
+        response = await removes_inbox_access.asyncio_detailed(
+            inbox_id=inbox_id, client=self._client, body=body
+        )
+        return is_success(response)
+
+
+__all__ = ["Inboxes"]

--- a/frontapp_public_api_client/helpers/tags.py
+++ b/frontapp_public_api_client/helpers/tags.py
@@ -1,0 +1,379 @@
+"""Tags helper facade — ergonomic wrappers around generated tag endpoints.
+
+Exposes ``client.tags`` covering the workspace-level tag catalog (``tags/``)
+plus the two conversation-side tag delta endpoints (``add_conversation_tag``,
+``remove_conversation_tag``). Grouping tag-on-conversation operations on
+this helper keeps all tag semantics in one place.
+
+Reads list workspace, company, team, and teammate tag scopes; mutations
+cover create/update/delete plus child tags and the conversation-tag deltas.
+
+Two important semantic notes:
+
+- **Delta vs replace.** ``apply_to_conversation`` and
+  ``remove_from_conversation`` ADD or REMOVE individual tag ids on a
+  conversation. ``conversations.update(tag_ids=[...])`` (when the
+  conversations vertical exposes it) REPLACES the entire tag set. Use
+  the delta methods when you want to nudge a single tag without
+  clobbering the rest.
+- **Workspace-wide blast radius.** ``delete`` removes the tag from
+  every conversation that had it. ``update`` rename ripples through the
+  catalog instantly. Both belong behind two-step confirm at the MCP layer.
+
+Quirks worth knowing:
+
+- The PATCH endpoint module is ``update_a_tag`` (``_a_`` infix flagged
+  in ``api-facts.yaml`` ``summary.module_name_quirks``). The body model
+  is plain ``UpdateTag``, not ``UpdateATag``.
+- ``CreateTagHighlight`` and ``UpdateTagHighlight`` are separate
+  generated enums with identical values; ``_HIGHLIGHTS`` is the shared
+  Literal alias the helper exposes.
+- ``TagResponse.created_at`` / ``updated_at`` are unix-seconds floats
+  (not ISO strings) — the ``Tag`` Pydantic projection converts them.
+"""
+
+from __future__ import annotations
+
+import builtins
+from typing import TYPE_CHECKING, Any, Literal
+
+from frontapp_public_api_client.helpers.base import Base
+
+if TYPE_CHECKING:
+    from frontapp_public_api_client.domain import Tag
+
+
+HighlightLiteral = Literal[
+    "blue",
+    "green",
+    "grey",
+    "light-blue",
+    "orange",
+    "pink",
+    "purple",
+    "red",
+    "yellow",
+]
+
+
+class Tags(Base):
+    """Ergonomic operations over Frontapp's workspace tag surface."""
+
+    # -- reads --------------------------------------------------------------
+
+    async def list(
+        self,
+        *,
+        limit: int | None = None,
+        page_token: str | None = None,
+    ) -> builtins.list[Tag]:
+        """List all workspace tags."""
+        from frontapp_public_api_client.api.tags import list_tags
+        from frontapp_public_api_client.domain import Tag
+        from frontapp_public_api_client.utils import unwrap
+
+        kwargs: dict[str, Any] = {"client": self._client}
+        if limit is not None:
+            kwargs["limit"] = limit
+        if page_token is not None:
+            kwargs["page_token"] = page_token
+
+        response = await list_tags.asyncio_detailed(**kwargs)
+        parsed = unwrap(response)
+        results = getattr(parsed, "field_results", None) or []
+        return [Tag.model_validate(t.to_dict()) for t in results]
+
+    async def list_company(
+        self,
+        *,
+        limit: int | None = None,
+        page_token: str | None = None,
+    ) -> builtins.list[Tag]:
+        """List company-scoped tags (visible across all teams)."""
+        from frontapp_public_api_client.api.tags import list_company_tags
+        from frontapp_public_api_client.domain import Tag
+        from frontapp_public_api_client.utils import unwrap
+
+        kwargs: dict[str, Any] = {"client": self._client}
+        if limit is not None:
+            kwargs["limit"] = limit
+        if page_token is not None:
+            kwargs["page_token"] = page_token
+
+        response = await list_company_tags.asyncio_detailed(**kwargs)
+        parsed = unwrap(response)
+        results = getattr(parsed, "field_results", None) or []
+        return [Tag.model_validate(t.to_dict()) for t in results]
+
+    async def list_for_team(
+        self,
+        team_id: str,
+        *,
+        limit: int | None = None,
+        page_token: str | None = None,
+    ) -> builtins.list[Tag]:
+        """List tags scoped to a team (``"tim_abc"``)."""
+        from frontapp_public_api_client.api.tags import list_team_tags
+        from frontapp_public_api_client.domain import Tag
+        from frontapp_public_api_client.utils import unwrap
+
+        kwargs: dict[str, Any] = {"client": self._client, "team_id": team_id}
+        if limit is not None:
+            kwargs["limit"] = limit
+        if page_token is not None:
+            kwargs["page_token"] = page_token
+
+        response = await list_team_tags.asyncio_detailed(**kwargs)
+        parsed = unwrap(response)
+        results = getattr(parsed, "field_results", None) or []
+        return [Tag.model_validate(t.to_dict()) for t in results]
+
+    async def list_for_teammate(
+        self,
+        teammate_id: str,
+        *,
+        limit: int | None = None,
+        page_token: str | None = None,
+    ) -> builtins.list[Tag]:
+        """List tags scoped to a single teammate (``"tea_abc"``)."""
+        from frontapp_public_api_client.api.tags import list_teammate_tags
+        from frontapp_public_api_client.domain import Tag
+        from frontapp_public_api_client.utils import unwrap
+
+        kwargs: dict[str, Any] = {"client": self._client, "teammate_id": teammate_id}
+        if limit is not None:
+            kwargs["limit"] = limit
+        if page_token is not None:
+            kwargs["page_token"] = page_token
+
+        response = await list_teammate_tags.asyncio_detailed(**kwargs)
+        parsed = unwrap(response)
+        results = getattr(parsed, "field_results", None) or []
+        return [Tag.model_validate(t.to_dict()) for t in results]
+
+    async def get(self, tag_id: str) -> Tag:
+        """Fetch one tag by id (e.g. ``"tag_abc"``)."""
+        from frontapp_public_api_client.api.tags import get_tag
+        from frontapp_public_api_client.domain import Tag
+        from frontapp_public_api_client.models.tag_response import TagResponse
+        from frontapp_public_api_client.utils import unwrap_as
+
+        response = await get_tag.asyncio_detailed(tag_id=tag_id, client=self._client)
+        tag = unwrap_as(response, TagResponse)
+        return Tag.model_validate(tag.to_dict())
+
+    async def list_children(self, tag_id: str) -> builtins.list[Tag]:
+        """List child tags of a parent tag.
+
+        The generated endpoint takes no pagination params (Front returns
+        the full child set in one shot).
+        """
+        from frontapp_public_api_client.api.tags import list_tag_children
+        from frontapp_public_api_client.domain import Tag
+        from frontapp_public_api_client.utils import unwrap
+
+        response = await list_tag_children.asyncio_detailed(
+            tag_id=tag_id, client=self._client
+        )
+        parsed = unwrap(response)
+        results = getattr(parsed, "field_results", None) or []
+        return [Tag.model_validate(t.to_dict()) for t in results]
+
+    async def list_conversations(
+        self,
+        tag_id: str,
+        *,
+        q: str | None = None,
+        limit: int | None = None,
+        page_token: str | None = None,
+    ) -> builtins.list[Any]:
+        """List conversations bearing this tag. Returns raw attrs models.
+
+        The MCP layer projects to ``ConversationSummary`` — no domain
+        ``Conversation`` projection is applied here so callers picking up
+        the helper directly can choose their own shape.
+        """
+        from frontapp_public_api_client.api.tags import list_tagged_conversations
+        from frontapp_public_api_client.utils import unwrap
+
+        kwargs: dict[str, Any] = {"client": self._client, "tag_id": tag_id}
+        if q is not None:
+            kwargs["q"] = q
+        if limit is not None:
+            kwargs["limit"] = limit
+        if page_token is not None:
+            kwargs["page_token"] = page_token
+
+        response = await list_tagged_conversations.asyncio_detailed(**kwargs)
+        parsed = unwrap(response)
+        return list(getattr(parsed, "field_results", None) or [])
+
+    # -- catalog mutations --------------------------------------------------
+
+    async def create(
+        self,
+        *,
+        name: str,
+        description: str | None = None,
+        highlight: HighlightLiteral | None = None,
+        is_visible_in_conversation_lists: bool = False,
+    ) -> Tag:
+        """Create a new workspace-scoped tag.
+
+        Workspace-wide change — visible to every teammate immediately.
+        """
+        from frontapp_public_api_client.api.tags import create_tag
+        from frontapp_public_api_client.domain import Tag
+        from frontapp_public_api_client.models.create_tag import CreateTag
+        from frontapp_public_api_client.models.create_tag_highlight import (
+            CreateTagHighlight,
+        )
+        from frontapp_public_api_client.models.tag_response import TagResponse
+        from frontapp_public_api_client.utils import unwrap_as
+
+        kwargs: dict[str, Any] = {
+            "name": name,
+            "is_visible_in_conversation_lists": is_visible_in_conversation_lists,
+        }
+        if description is not None:
+            kwargs["description"] = description
+        if highlight is not None:
+            kwargs["highlight"] = CreateTagHighlight(highlight)
+
+        body = CreateTag(**kwargs)
+        response = await create_tag.asyncio_detailed(client=self._client, body=body)
+        tag = unwrap_as(response, TagResponse)
+        return Tag.model_validate(tag.to_dict())
+
+    async def create_child(
+        self,
+        parent_tag_id: str,
+        *,
+        name: str,
+        description: str | None = None,
+        highlight: HighlightLiteral | None = None,
+        is_visible_in_conversation_lists: bool = False,
+    ) -> Tag:
+        """Create a child tag under an existing parent tag."""
+        from frontapp_public_api_client.api.tags import create_child_tag
+        from frontapp_public_api_client.domain import Tag
+        from frontapp_public_api_client.models.create_tag import CreateTag
+        from frontapp_public_api_client.models.create_tag_highlight import (
+            CreateTagHighlight,
+        )
+        from frontapp_public_api_client.models.tag_response import TagResponse
+        from frontapp_public_api_client.utils import unwrap_as
+
+        kwargs: dict[str, Any] = {
+            "name": name,
+            "is_visible_in_conversation_lists": is_visible_in_conversation_lists,
+        }
+        if description is not None:
+            kwargs["description"] = description
+        if highlight is not None:
+            kwargs["highlight"] = CreateTagHighlight(highlight)
+
+        body = CreateTag(**kwargs)
+        response = await create_child_tag.asyncio_detailed(
+            tag_id=parent_tag_id, client=self._client, body=body
+        )
+        tag = unwrap_as(response, TagResponse)
+        return Tag.model_validate(tag.to_dict())
+
+    async def update(
+        self,
+        tag_id: str,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+        highlight: HighlightLiteral | None = None,
+        parent_tag_id: str | None = None,
+        is_visible_in_conversation_lists: bool | None = None,
+    ) -> bool:
+        """Update mutable fields on a tag (PATCH).
+
+        Workspace-wide change — a rename ripples to every conversation
+        instantly. Returns True on the documented 204 No Content.
+        """
+        from frontapp_public_api_client.api.tags import update_a_tag
+        from frontapp_public_api_client.models.update_tag import UpdateTag
+        from frontapp_public_api_client.models.update_tag_highlight import (
+            UpdateTagHighlight,
+        )
+        from frontapp_public_api_client.utils import is_success
+
+        kwargs: dict[str, Any] = {}
+        if name is not None:
+            kwargs["name"] = name
+        if description is not None:
+            kwargs["description"] = description
+        if highlight is not None:
+            kwargs["highlight"] = UpdateTagHighlight(highlight)
+        if parent_tag_id is not None:
+            kwargs["parent_tag_id"] = parent_tag_id
+        if is_visible_in_conversation_lists is not None:
+            kwargs["is_visible_in_conversation_lists"] = (
+                is_visible_in_conversation_lists
+            )
+
+        body = UpdateTag(**kwargs)
+        response = await update_a_tag.asyncio_detailed(
+            tag_id=tag_id, client=self._client, body=body
+        )
+        return is_success(response)
+
+    async def delete(self, tag_id: str) -> bool:
+        """Permanently delete a tag.
+
+        Destructive: removes the tag from every conversation that had it.
+        Front does not soft-delete tags — the operation is irreversible.
+        """
+        from frontapp_public_api_client.api.tags import delete_tag
+        from frontapp_public_api_client.utils import is_success
+
+        response = await delete_tag.asyncio_detailed(tag_id=tag_id, client=self._client)
+        return is_success(response)
+
+    # -- conversation-tag delta operations ----------------------------------
+
+    async def apply_to_conversation(
+        self, conversation_id: str, *, tag_ids: builtins.list[str]
+    ) -> bool:
+        """Add tags to a conversation (delta — does NOT replace existing).
+
+        Different from ``client.conversations.update(tag_ids=[...])``,
+        which REPLACES the full tag set. Use this method to add a single
+        tag without clobbering whatever tags are already attached.
+        """
+        from frontapp_public_api_client.api.conversations import add_conversation_tag
+        from frontapp_public_api_client.models.tag_ids import TagIds
+        from frontapp_public_api_client.utils import is_success
+
+        body = TagIds(tag_ids=tag_ids)
+        response = await add_conversation_tag.asyncio_detailed(
+            conversation_id=conversation_id, client=self._client, body=body
+        )
+        return is_success(response)
+
+    async def remove_from_conversation(
+        self, conversation_id: str, *, tag_ids: builtins.list[str]
+    ) -> bool:
+        """Remove tags from a conversation (delta — only the named ids).
+
+        Mirror of ``apply_to_conversation``. Other tags on the
+        conversation are left intact.
+        """
+        from frontapp_public_api_client.api.conversations import (
+            remove_conversation_tag,
+        )
+        from frontapp_public_api_client.models.tag_ids import TagIds
+        from frontapp_public_api_client.utils import is_success
+
+        body = TagIds(tag_ids=tag_ids)
+        response = await remove_conversation_tag.asyncio_detailed(
+            conversation_id=conversation_id, client=self._client, body=body
+        )
+        return is_success(response)
+
+
+__all__ = ["HighlightLiteral", "Tags"]

--- a/frontapp_public_api_client/helpers/tags.py
+++ b/frontapp_public_api_client/helpers/tags.py
@@ -26,8 +26,8 @@ Quirks worth knowing:
   in ``api-facts.yaml`` ``summary.module_name_quirks``). The body model
   is plain ``UpdateTag``, not ``UpdateATag``.
 - ``CreateTagHighlight`` and ``UpdateTagHighlight`` are separate
-  generated enums with identical values; ``_HIGHLIGHTS`` is the shared
-  Literal alias the helper exposes.
+  generated enums with identical values; ``HighlightLiteral`` is the
+  shared Literal alias the helper exposes.
 - ``TagResponse.created_at`` / ``updated_at`` are unix-seconds floats
   (not ISO strings) — the ``Tag`` Pydantic projection converts them.
 """

--- a/scripts/generate_api_facts.py
+++ b/scripts/generate_api_facts.py
@@ -425,6 +425,11 @@ def _camel(snake: str) -> str:
 def _singular(word: str) -> str:
     if word.endswith("ies"):
         return word[:-3] + "y"
+    # "inboxes" → "inbox", "boxes" → "box" (strip the -es when it follows -x/-s/-z/-ch/-sh)
+    if word.endswith("xes") or word.endswith("ses") or word.endswith("zes"):
+        return word[:-2]
+    if word.endswith("ches") or word.endswith("shes"):
+        return word[:-2]
     if word.endswith("s") and not word.endswith("ss"):
         return word[:-1]
     return word

--- a/tests/test_inboxes.py
+++ b/tests/test_inboxes.py
@@ -1,0 +1,188 @@
+"""Tests for the inboxes vertical: Inbox domain model + Inboxes helper."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pydantic
+import pytest
+
+from frontapp_public_api_client.domain import Inbox
+
+# ---------------------------------------------------------------------------
+# Domain model: Inbox
+# ---------------------------------------------------------------------------
+
+
+class TestInboxDomain:
+    def test_minimal_payload_validates(self):
+        i = Inbox.model_validate({"id": "inb_abc", "name": "Support"})
+        assert i.id == "inb_abc"
+        assert i.name == "Support"
+        assert i.is_private is None
+        assert i.is_public is None
+
+    def test_all_fields_optional(self):
+        """InboxResponse marks every field UNSET — projection accepts {}."""
+        i = Inbox.model_validate({})
+        assert i.id is None
+        assert i.name is None
+
+    def test_extra_fields_ignored(self):
+        i = Inbox.model_validate(
+            {
+                "id": "inb_abc",
+                "name": "Support",
+                "_links": {"self": "..."},
+                "custom_fields": {"region": "us"},
+            }
+        )
+        assert i.id == "inb_abc"
+
+    def test_frozen(self):
+        i = Inbox.model_validate({"id": "inb_abc", "name": "Support"})
+        with pytest.raises(pydantic.ValidationError):
+            i.id = "inb_xyz"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Helper: Inboxes
+# ---------------------------------------------------------------------------
+
+
+class TestInboxesHelper:
+    def _mock_response(
+        self, payload: dict | list | None, status: int = 200
+    ) -> httpx.MockTransport:
+        def handler(_request: httpx.Request) -> httpx.Response:
+            if payload is None:
+                return httpx.Response(status, content=b"")
+            return httpx.Response(status, json=payload)
+
+        return httpx.MockTransport(handler)
+
+    def _mock_recording(
+        self, payload: dict | list | None, status: int = 200
+    ) -> tuple[httpx.MockTransport, list[httpx.Request]]:
+        recorded: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            recorded.append(request)
+            if payload is None:
+                return httpx.Response(status, content=b"")
+            return httpx.Response(status, json=payload)
+
+        return httpx.MockTransport(handler), recorded
+
+    async def test_list_returns_domain_inboxes(self, mock_api_credentials):
+        from frontapp_public_api_client import FrontappClient
+
+        client = FrontappClient(**mock_api_credentials)
+        client.set_async_httpx_client(
+            httpx.AsyncClient(
+                transport=self._mock_response(
+                    {
+                        "_results": [
+                            {"id": "inb_1", "name": "Support"},
+                            {"id": "inb_2", "name": "Sales"},
+                        ],
+                        "_pagination": {},
+                        "_links": {},
+                    }
+                ),
+                base_url=mock_api_credentials["base_url"],
+            )
+        )
+
+        inboxes = await client.inboxes.list()
+        assert len(inboxes) == 2
+        assert all(isinstance(i, Inbox) for i in inboxes)
+        assert [i.name for i in inboxes] == ["Support", "Sales"]
+
+    async def test_get_returns_inbox(self, mock_api_credentials):
+        from frontapp_public_api_client import FrontappClient
+
+        client = FrontappClient(**mock_api_credentials)
+        client.set_async_httpx_client(
+            httpx.AsyncClient(
+                transport=self._mock_response(
+                    {
+                        "id": "inb_abc",
+                        "name": "Support",
+                        "is_private": False,
+                        "is_public": True,
+                    }
+                ),
+                base_url=mock_api_credentials["base_url"],
+            )
+        )
+
+        inbox = await client.inboxes.get("inb_abc")
+        assert inbox.id == "inb_abc"
+        assert inbox.is_public is True
+
+    async def test_create_sends_full_body(self, mock_api_credentials):
+        from frontapp_public_api_client import FrontappClient
+
+        client = FrontappClient(**mock_api_credentials)
+        transport, recorded = self._mock_recording(
+            {"id": "inb_new", "name": "Triage"}, status=201
+        )
+        client.set_async_httpx_client(
+            httpx.AsyncClient(
+                transport=transport, base_url=mock_api_credentials["base_url"]
+            )
+        )
+
+        inbox = await client.inboxes.create(
+            name="Triage", teammate_ids=["tea_1", "tea_2"], is_public=False
+        )
+        assert inbox.id == "inb_new"
+        body = json.loads(recorded[0].content)
+        assert body["name"] == "Triage"
+        assert body["teammate_ids"] == ["tea_1", "tea_2"]
+        assert body["is_public"] is False
+
+    async def test_grant_access_sends_teammate_ids(self, mock_api_credentials):
+        from frontapp_public_api_client import FrontappClient
+
+        client = FrontappClient(**mock_api_credentials)
+        transport, recorded = self._mock_recording(None, status=204)
+        client.set_async_httpx_client(
+            httpx.AsyncClient(
+                transport=transport, base_url=mock_api_credentials["base_url"]
+            )
+        )
+
+        success = await client.inboxes.grant_access(
+            "inb_abc", teammate_ids=["tea_1", "tea_2"]
+        )
+        assert success is True
+        body = json.loads(recorded[0].content)
+        assert body == {"teammate_ids": ["tea_1", "tea_2"]}
+        assert recorded[0].method == "POST"
+
+    async def test_revoke_access_uses_delete_method(self, mock_api_credentials):
+        """Wraps the awkwardly-named generated module ``removes_inbox_access``."""
+        from frontapp_public_api_client import FrontappClient
+
+        client = FrontappClient(**mock_api_credentials)
+        transport, recorded = self._mock_recording(None, status=204)
+        client.set_async_httpx_client(
+            httpx.AsyncClient(
+                transport=transport, base_url=mock_api_credentials["base_url"]
+            )
+        )
+
+        success = await client.inboxes.revoke_access("inb_abc", teammate_ids=["tea_1"])
+        assert success is True
+        assert recorded[0].method == "DELETE"
+
+    def test_inboxes_property_lazy_caches(self, mock_api_credentials):
+        from frontapp_public_api_client import FrontappClient
+
+        client = FrontappClient(**mock_api_credentials)
+        first = client.inboxes
+        second = client.inboxes
+        assert first is second

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,0 +1,257 @@
+"""Tests for the tags vertical: Tag domain model + Tags helper."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+import httpx
+import pydantic
+import pytest
+
+from frontapp_public_api_client.domain import Tag
+
+# ---------------------------------------------------------------------------
+# Domain model: Tag
+# ---------------------------------------------------------------------------
+
+
+class TestTagDomain:
+    def test_minimal_payload_validates(self):
+        t = Tag.model_validate({"id": "tag_abc", "name": "urgent"})
+        assert t.id == "tag_abc"
+        assert t.name == "urgent"
+        assert t.description is None
+        assert t.highlight is None
+        assert t.is_private is False
+        assert t.is_visible_in_conversation_lists is False
+        assert t.created_at is None
+
+    def test_unix_timestamp_converts_to_aware_datetime(self):
+        t = Tag.model_validate(
+            {"id": "tag_abc", "name": "urgent", "created_at": 1701292639}
+        )
+        assert isinstance(t.created_at, datetime)
+        assert t.created_at == datetime.fromtimestamp(1701292639, tz=UTC)
+
+    def test_extra_fields_ignored(self):
+        t = Tag.model_validate(
+            {
+                "id": "tag_abc",
+                "name": "urgent",
+                "_links": {"self": "https://api2.frontapp.com/tags/tag_abc"},
+            }
+        )
+        assert t.id == "tag_abc"
+
+    def test_frozen(self):
+        t = Tag.model_validate({"id": "tag_abc", "name": "urgent"})
+        with pytest.raises(pydantic.ValidationError):
+            t.id = "tag_xyz"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Helper: Tags
+# ---------------------------------------------------------------------------
+
+
+class TestTagsHelper:
+    """Helper-level integration via ``httpx.MockTransport``."""
+
+    def _mock_response(
+        self, payload: dict | list | None, status: int = 200
+    ) -> httpx.MockTransport:
+        def handler(_request: httpx.Request) -> httpx.Response:
+            if payload is None:
+                return httpx.Response(status, content=b"")
+            return httpx.Response(status, json=payload)
+
+        return httpx.MockTransport(handler)
+
+    def _mock_recording(
+        self, payload: dict | list | None, status: int = 200
+    ) -> tuple[httpx.MockTransport, list[httpx.Request]]:
+        recorded: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            recorded.append(request)
+            if payload is None:
+                return httpx.Response(status, content=b"")
+            return httpx.Response(status, json=payload)
+
+        return httpx.MockTransport(handler), recorded
+
+    async def test_list_returns_domain_tags(self, mock_api_credentials):
+        from frontapp_public_api_client import FrontappClient
+
+        client = FrontappClient(**mock_api_credentials)
+        client.set_async_httpx_client(
+            httpx.AsyncClient(
+                transport=self._mock_response(
+                    {
+                        "_results": [
+                            {
+                                "_links": {"self": "https://x", "related": {}},
+                                "id": "tag_1",
+                                "name": "urgent",
+                                "description": None,
+                                "highlight": None,
+                                "is_private": False,
+                                "is_visible_in_conversation_lists": False,
+                            },
+                            {
+                                "_links": {"self": "https://x", "related": {}},
+                                "id": "tag_2",
+                                "name": "vip",
+                                "description": None,
+                                "highlight": None,
+                                "is_private": False,
+                                "is_visible_in_conversation_lists": False,
+                            },
+                        ],
+                        "_pagination": {},
+                        "_links": {},
+                    }
+                ),
+                base_url=mock_api_credentials["base_url"],
+            )
+        )
+
+        tags = await client.tags.list()
+        assert len(tags) == 2
+        assert all(isinstance(t, Tag) for t in tags)
+        assert [t.name for t in tags] == ["urgent", "vip"]
+
+    async def test_get_returns_tag_with_timestamps(self, mock_api_credentials):
+        from frontapp_public_api_client import FrontappClient
+
+        client = FrontappClient(**mock_api_credentials)
+        client.set_async_httpx_client(
+            httpx.AsyncClient(
+                transport=self._mock_response(
+                    {
+                        "_links": {"self": "https://x", "related": {}},
+                        "id": "tag_abc",
+                        "name": "urgent",
+                        "description": None,
+                        "highlight": "red",
+                        "is_private": False,
+                        "is_visible_in_conversation_lists": True,
+                        "created_at": 1701292639,
+                        "updated_at": 1701292700,
+                    }
+                ),
+                base_url=mock_api_credentials["base_url"],
+            )
+        )
+
+        tag = await client.tags.get("tag_abc")
+        assert tag.id == "tag_abc"
+        assert tag.highlight == "red"
+        assert tag.is_visible_in_conversation_lists is True
+        assert isinstance(tag.created_at, datetime)
+
+    async def test_create_serializes_highlight_enum(self, mock_api_credentials):
+        from frontapp_public_api_client import FrontappClient
+
+        client = FrontappClient(**mock_api_credentials)
+        transport, recorded = self._mock_recording(
+            {
+                "_links": {"self": "https://x", "related": {}},
+                "id": "tag_new",
+                "name": "urgent",
+                "description": None,
+                "highlight": "red",
+                "is_private": False,
+                "is_visible_in_conversation_lists": False,
+            },
+            status=201,
+        )
+        client.set_async_httpx_client(
+            httpx.AsyncClient(
+                transport=transport, base_url=mock_api_credentials["base_url"]
+            )
+        )
+
+        tag = await client.tags.create(name="urgent", highlight="red")
+        assert tag.id == "tag_new"
+        body = json.loads(recorded[0].content)
+        assert body["name"] == "urgent"
+        assert body["highlight"] == "red"
+
+    async def test_update_skips_unset_fields(self, mock_api_credentials):
+        from frontapp_public_api_client import FrontappClient
+
+        client = FrontappClient(**mock_api_credentials)
+        transport, recorded = self._mock_recording(None, status=204)
+        client.set_async_httpx_client(
+            httpx.AsyncClient(
+                transport=transport, base_url=mock_api_credentials["base_url"]
+            )
+        )
+
+        success = await client.tags.update("tag_abc", name="renamed")
+        assert success is True
+        body = json.loads(recorded[0].content)
+        assert body == {"name": "renamed"}
+
+    async def test_delete_returns_true_on_204(self, mock_api_credentials):
+        from frontapp_public_api_client import FrontappClient
+
+        client = FrontappClient(**mock_api_credentials)
+        client.set_async_httpx_client(
+            httpx.AsyncClient(
+                transport=self._mock_response(None, status=204),
+                base_url=mock_api_credentials["base_url"],
+            )
+        )
+
+        success = await client.tags.delete("tag_abc")
+        assert success is True
+
+    async def test_apply_to_conversation_sends_tag_ids_list(self, mock_api_credentials):
+        from frontapp_public_api_client import FrontappClient
+
+        client = FrontappClient(**mock_api_credentials)
+        transport, recorded = self._mock_recording(None, status=204)
+        client.set_async_httpx_client(
+            httpx.AsyncClient(
+                transport=transport, base_url=mock_api_credentials["base_url"]
+            )
+        )
+
+        success = await client.tags.apply_to_conversation(
+            "cnv_abc", tag_ids=["tag_1", "tag_2"]
+        )
+        assert success is True
+        body = json.loads(recorded[0].content)
+        assert body == {"tag_ids": ["tag_1", "tag_2"]}
+        assert recorded[0].method == "POST"
+        assert recorded[0].url.path.endswith("/conversations/cnv_abc/tags")
+
+    async def test_remove_from_conversation_uses_delete(self, mock_api_credentials):
+        from frontapp_public_api_client import FrontappClient
+
+        client = FrontappClient(**mock_api_credentials)
+        transport, recorded = self._mock_recording(None, status=204)
+        client.set_async_httpx_client(
+            httpx.AsyncClient(
+                transport=transport, base_url=mock_api_credentials["base_url"]
+            )
+        )
+
+        success = await client.tags.remove_from_conversation(
+            "cnv_abc", tag_ids=["tag_1"]
+        )
+        assert success is True
+        assert recorded[0].method == "DELETE"
+        body = json.loads(recorded[0].content)
+        assert body == {"tag_ids": ["tag_1"]}
+
+    def test_tags_property_lazy_caches(self, mock_api_credentials):
+        from frontapp_public_api_client import FrontappClient
+
+        client = FrontappClient(**mock_api_credentials)
+        first = client.tags
+        second = client.tags
+        assert first is second


### PR DESCRIPTION
Closes #5.

Layers management tools onto the read-only `frontapp://tags` / `frontapp://inboxes` reference resources shipped in PR #20.

## Helpers

**`client.tags`:**
- list (workspace/company/team/teammate scopes), get, list_children, list_conversations
- create, create_child, update, delete (catalog mutations — workspace-wide)
- apply_to_conversation, remove_from_conversation (DELTA on a conversation's tag set)

**`client.inboxes`:**
- list (workspace/team/teammate-private scopes), get, list_conversations, list_channels, list_access
- create, create_for_team
- grant_access, revoke_access

## Domain projections

- `Tag` — full standalone projection (with epoch→datetime conversion). Distinct from the existing `domain.TagSummary` which is a nested sub-type inside `Conversation`.
- `Inbox` — thin (Front returns no inbox timestamps; only id/name/visibility flags).

## MCP tools — 24 total

- **14 reads**, all cached 30s: `list_tags`, `list_company_tags`, `list_team_tags`, `list_teammate_tags`, `get_tag`, `list_tag_children`, `list_tagged_conversations`, `list_inboxes`, `list_team_inboxes`, `list_teammate_private_inboxes`, `get_inbox`, `list_inbox_conversations`, `list_inbox_channels`, `list_inbox_access`
- **10 mutations**, all two-step confirm: `add_tag_to_conversation`, `remove_tag_from_conversation`, `create_tag`, `create_child_tag`, `update_tag`, `delete_tag`, `create_inbox`, `create_team_inbox`, `grant_inbox_access`, `revoke_inbox_access`

## Critical semantic distinction (delta vs replace)

Documented in `instructions`, the `frontapp://help` resource, and tool docstrings:

- `add_tag_to_conversation(conversation_id, tag_id)` — **DELTA**: adds one tag, leaves others
- `remove_tag_from_conversation(conversation_id, tag_id)` — **DELTA**: removes one tag, leaves others
- `update_conversation(tag_ids=[…])` — **REPLACE**: full set replacement (in conversations vertical)

The single-tag MCP tools take `tag_id: str` (not a list) at the boundary to reduce footgun surface. The helper wraps it in `[tag_id]` internally.

## Generator quirks handled

- `update_a_tag` (`_a_` infix) → exposed as `Tags.update`
- `removes_inbox_access` (`removes_` prefix) → exposed as `Inboxes.revoke_access`

## Safety

- Catalog mutations (`update_tag` rename, `delete_tag`) carry workspace-wide blast radius — preview text and elicitation prompts spell it out.
- `delete_tag` warning text emphasizes the tag is removed from every conversation that had it, irreversibly.
- Access tool previews surface `teammate_count` + the full id list so the user can verify before confirming.

## Test plan

- [x] `uv run poe full-check` passes — 155 tests pass (51 new), lint/typecheck/format/yaml/facts-check/mkdocs all clean
- [x] Helper-level tests cover: domain projections, list unwrap, create body serialization, update field omission, delete 204 handling, delta endpoint method/body verification
- [x] MCP tool tests cover: preview/decline/confirm paths, no-changes guards, delta semantics in preview text, destructive warnings, access-tool count+ids preview

## Notes

Front exposes no general inbox PATCH — name and visibility are immutable post-creation. Only access can change after that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)