### PR TITLE
docs(mkdocs): clean up cross-package link warnings (#11)

### DIFF
--- a/docs/FRONTAPP_API_ENDPOINTS.md
+++ b/docs/FRONTAPP_API_ENDPOINTS.md
@@ -13,7 +13,7 @@ can be incorporated into the MCP Server.
 This inventory was imported from an earlier single-file MCP prototype; the status
 markers reflect that prototype's coverage, not this repo's. For the authoritative status
 of each vertical in this repo, see the API Coverage table in the
-[top-level README](../README.md).
+[top-level README](https://github.com/dougborg/frontapp-openapi-client/blob/main/README.md).
 
 The current MCP server exposes **8 conversation tools** today; contacts, messages, tags,
 inboxes, teammates, and analytics are tracked as open issues.
@@ -730,5 +730,7 @@ Each endpoint should follow the existing pattern:
   [frontapp_public_api_client/](../frontapp_public_api_client/) (Python client),
   [frontapp_mcp_server/](../frontapp_mcp_server/) (MCP server), and
   [packages/frontapp-client/](../packages/frontapp-client/) (TS client)
-- **Project Documentation**: [CLAUDE.md](../CLAUDE.md) and
-  [top-level README](../README.md)
+- **Project Documentation**:
+  [CLAUDE.md](https://github.com/dougborg/frontapp-openapi-client/blob/main/CLAUDE.md)
+  and
+  [top-level README](https://github.com/dougborg/frontapp-openapi-client/blob/main/README.md)

--- a/docs/MONOREPO_SEMANTIC_RELEASE.md
+++ b/docs/MONOREPO_SEMANTIC_RELEASE.md
@@ -141,7 +141,7 @@ No API tokens needed - authentication via GitHub OIDC.
 
 The MCP server package depends on the client library. When the client releases a new
 version, the MCP dependency is **automatically updated** via the
-[Update MCP Client Dependency workflow](../.github/workflows/update-mcp-dependency.yml).
+[Update MCP Client Dependency workflow](https://github.com/dougborg/frontapp-openapi-client/blob/main/.github/workflows/update-mcp-dependency.yml).
 
 **How it works:**
 
@@ -299,7 +299,7 @@ scopes
 dependency should be updated.
 
 **Solution**: This is now **automated**! The
-[Update MCP Client Dependency workflow](../.github/workflows/update-mcp-dependency.yml)
+[Update MCP Client Dependency workflow](https://github.com/dougborg/frontapp-openapi-client/blob/main/.github/workflows/update-mcp-dependency.yml)
 automatically:
 
 1. Detects when a new client release is published

--- a/docs/adr/0009-migrate-from-poetry-to-uv.md
+++ b/docs/adr/0009-migrate-from-poetry-to-uv.md
@@ -134,5 +134,5 @@ slow; no workspace support.
 - [uv documentation](https://docs.astral.sh/uv/)
 - [Astral blog — announcing uv](https://astral.sh/blog/uv)
 - [PEP 621 — Storing project metadata in pyproject.toml](https://peps.python.org/pep-0621/)
-- [ADR-0012: Validation Tiers for Agent Workflows](../../frontapp_public_api_client/docs/adr/0012-validation-tiers-for-agent-workflows.md)
+- [ADR-0012: Validation Tiers for Agent Workflows](https://github.com/dougborg/frontapp-openapi-client/blob/main/frontapp_public_api_client/docs/adr/0012-validation-tiers-for-agent-workflows.md)
   — uv's speed enables the quick-check tier

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -5,9 +5,9 @@ This directory contains Architecture Decision Records (ADRs) for
 
 For package-specific ADRs, see:
 
-- **[Client ADRs](../../frontapp_public_api_client/docs/adr/README.md)** -
+- **[Client ADRs](https://github.com/dougborg/frontapp-openapi-client/blob/main/frontapp_public_api_client/docs/adr/README.md)** -
   `frontapp-openapi-client` package decisions
-- **[MCP Server ADRs](../../frontapp_mcp_server/docs/adr/README.md)** -
+- **[MCP Server ADRs](https://github.com/dougborg/frontapp-openapi-client/blob/main/frontapp_mcp_server/docs/adr/README.md)** -
   `frontapp-mcp-server` package decisions
 
 ## What is an ADR?
@@ -69,9 +69,10 @@ ensure ordering.
 
 ## Related Documentation
 
-- [Client ADRs](../../frontapp_public_api_client/docs/adr/README.md) - Client package
-  ADRs
-- [MCP Server ADRs](../../frontapp_mcp_server/docs/adr/README.md) - MCP server package
-  ADRs
+- [Client ADRs](https://github.com/dougborg/frontapp-openapi-client/blob/main/frontapp_public_api_client/docs/adr/README.md) -
+  Client package ADRs
+- [MCP Server ADRs](https://github.com/dougborg/frontapp-openapi-client/blob/main/frontapp_mcp_server/docs/adr/README.md) -
+  MCP server package ADRs
 - [Contributing Guide](../CONTRIBUTING.md) - Contribution guidelines
-- [README](../../README.md) - Project overview and quick start
+- [README](https://github.com/dougborg/frontapp-openapi-client/blob/main/README.md) -
+  Project overview and quick start

--- a/frontapp_mcp_server/docs/README.md
+++ b/frontapp_mcp_server/docs/README.md
@@ -6,7 +6,8 @@ This directory contains all documentation specific to the `frontapp-mcp-server` 
 
 ### Getting Started
 
-- **[README](README.md)** — installation, tools, and configuration overview
+- **[Package README](https://github.com/dougborg/frontapp-openapi-client/blob/main/frontapp_mcp_server/README.md)**
+  — installation, tools, and configuration overview
 - **[Development Guide](development.md)** — setup and development workflow
 - **[Deployment Guide](deployment.md)** — production deployment strategies
 - **[Docker Guide](docker.md)** — container deployment
@@ -19,8 +20,10 @@ This directory contains all documentation specific to the `frontapp-mcp-server` 
 
 ## Quick Links
 
-- **[Main Repository README](../../README.md)** — project overview
-- **[Contributing Guide](../../docs/CONTRIBUTING.md)** — how to contribute
+- **[Main Repository README](https://github.com/dougborg/frontapp-openapi-client/blob/main/README.md)**
+  — project overview
+- **[Contributing Guide](https://github.com/dougborg/frontapp-openapi-client/blob/main/docs/CONTRIBUTING.md)**
+  — how to contribute
 - **[PyPI Package](https://pypi.org/project/frontapp-mcp-server/)**
 
 ## Package Information
@@ -32,5 +35,5 @@ This directory contains all documentation specific to the `frontapp-mcp-server` 
 
 ## Related Packages
 
-- **[frontapp-openapi-client](../../frontapp_public_api_client/docs/README.md)** —
-  Python client for the Frontapp API
+- **[frontapp-openapi-client](https://github.com/dougborg/frontapp-openapi-client/blob/main/frontapp_public_api_client/docs/README.md)**
+  — Python client for the Frontapp API

--- a/frontapp_mcp_server/docs/adr/0016-tool-interface-pattern.md
+++ b/frontapp_mcp_server/docs/adr/0016-tool-interface-pattern.md
@@ -316,5 +316,5 @@ follow the same pattern.
 ## References
 
 - [ADR-0017: Automated Tool Documentation](0017-automated-tool-documentation.md)
-- [ADR-0011: Pydantic Domain Models](../../../frontapp_public_api_client/docs/adr/0011-pydantic-domain-models.md)
+- [ADR-0011: Pydantic Domain Models](https://github.com/dougborg/frontapp-openapi-client/blob/main/frontapp_public_api_client/docs/adr/0011-pydantic-domain-models.md)
 - [FastMCP](https://github.com/jlowin/fastmcp) — elicitation API

--- a/frontapp_mcp_server/docs/adr/0017-automated-tool-documentation.md
+++ b/frontapp_mcp_server/docs/adr/0017-automated-tool-documentation.md
@@ -283,9 +283,9 @@ tool responses are small JSON objects and a Pydantic projection model
 ## References
 
 - [ADR-0016: Tool Interface Pattern](0016-tool-interface-pattern.md)
-- [ADR-004: Defer Observability to httpx](../../../frontapp_public_api_client/docs/adr/0004-defer-observability-to-httpx.md)
-- [`scripts/generate_tools_json.py`](../../../scripts/generate_tools_json.py) — metadata
-  generator
-- [`frontapp_mcp/resources/help.py`](../../src/frontapp_mcp/resources/help.py) — help
-  Markdown
+- [ADR-004: Defer Observability to httpx](https://github.com/dougborg/frontapp-openapi-client/blob/main/frontapp_public_api_client/docs/adr/0004-defer-observability-to-httpx.md)
+- [`scripts/generate_tools_json.py`](https://github.com/dougborg/frontapp-openapi-client/blob/main/scripts/generate_tools_json.py)
+  — metadata generator
+- [`frontapp_mcp/resources/help.py`](https://github.com/dougborg/frontapp-openapi-client/blob/main/frontapp_mcp_server/src/frontapp_mcp/resources/help.py)
+  — help Markdown
 - [Google Style Docstrings](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)

--- a/frontapp_mcp_server/docs/adr/README.md
+++ b/frontapp_mcp_server/docs/adr/README.md
@@ -33,5 +33,5 @@ We use the format proposed by Michael Nygard in
 ## Related
 
 - [Development Guide](../development.md)
-- [Contributing Guide](../../../docs/CONTRIBUTING.md)
-- [Monorepo ADRs](../../../docs/adr/README.md)
+- [Contributing Guide](https://github.com/dougborg/frontapp-openapi-client/blob/main/docs/CONTRIBUTING.md)
+- [Monorepo ADRs](https://github.com/dougborg/frontapp-openapi-client/blob/main/docs/adr/README.md)

--- a/frontapp_mcp_server/docs/deployment.md
+++ b/frontapp_mcp_server/docs/deployment.md
@@ -376,7 +376,7 @@ After PR is merged:
   [docs/CONTRIBUTING.md](https://github.com/dougborg/frontapp-openapi-client/blob/main/docs/CONTRIBUTING.md) -
   Commit message format
 - **MCP Documentation Index**:
-  [frontapp_mcp_server/docs/README.md](https://github.com/dougborg/frontapp-openapi-client/blob/main/frontapp_mcp_server/docs/README.md) -
+  [frontapp_mcp_server/docs/index.md](https://github.com/dougborg/frontapp-openapi-client/blob/main/frontapp_mcp_server/docs/index.md) -
   All MCP documentation
 
 ## Related Links

--- a/frontapp_mcp_server/docs/deployment.md
+++ b/frontapp_mcp_server/docs/deployment.md
@@ -369,15 +369,15 @@ After PR is merged:
 
 ## Related Documentation
 
-- **Main Release Guide**: [docs/RELEASE.md](../docs/RELEASE.md) - Monorepo release
-  process
 - **Monorepo Semantic-Release**:
-  [docs/MONOREPO_SEMANTIC_RELEASE.md](../docs/MONOREPO_SEMANTIC_RELEASE.md) -
+  [docs/MONOREPO_SEMANTIC_RELEASE.md](https://github.com/dougborg/frontapp-openapi-client/blob/main/docs/MONOREPO_SEMANTIC_RELEASE.md) -
   Comprehensive guide
-- **Contributing**: [docs/CONTRIBUTING.md](../docs/CONTRIBUTING.md) - Commit message
-  format
-- **MCP Documentation Index**: [docs/mcp-server/README.md](../docs/mcp-server/README.md)
-  \- All MCP documentation
+- **Contributing**:
+  [docs/CONTRIBUTING.md](https://github.com/dougborg/frontapp-openapi-client/blob/main/docs/CONTRIBUTING.md) -
+  Commit message format
+- **MCP Documentation Index**:
+  [frontapp_mcp_server/docs/README.md](https://github.com/dougborg/frontapp-openapi-client/blob/main/frontapp_mcp_server/docs/README.md) -
+  All MCP documentation
 
 ## Related Links
 

--- a/frontapp_mcp_server/docs/development.md
+++ b/frontapp_mcp_server/docs/development.md
@@ -360,9 +360,9 @@ This allows testing `_update_conversation_impl` directly with mocks.
 - **mcp-hmr GitHub**: https://github.com/mizchi/mcp-hmr
 - **MCP Specification**: https://modelcontextprotocol.io
 - **Project README**:
-  [../frontapp_mcp_server/README.md](../../frontapp_mcp_server/README.md)
+  [frontapp_mcp_server/README.md](https://github.com/dougborg/frontapp-openapi-client/blob/main/frontapp_mcp_server/README.md)
 - **Testing Guide**:
-  [Client Testing Guide](../../frontapp_public_api_client/docs/testing.md)
+  [Client Testing Guide](https://github.com/dougborg/frontapp-openapi-client/blob/main/frontapp_public_api_client/docs/testing.md)
 
 ## Getting Help
 

--- a/frontapp_public_api_client/docs/README.md
+++ b/frontapp_public_api_client/docs/README.md
@@ -19,8 +19,10 @@ package.
 
 ## Quick Links
 
-- **[Main Repository README](../../README.md)** - Project overview
-- **[Contributing Guide](../../docs/CONTRIBUTING.md)** - How to contribute
+- **[Main Repository README](https://github.com/dougborg/frontapp-openapi-client/blob/main/README.md)** -
+  Project overview
+- **[Contributing Guide](https://github.com/dougborg/frontapp-openapi-client/blob/main/docs/CONTRIBUTING.md)** -
+  How to contribute
 - **[API Documentation](https://dougborg.github.io/frontapp-openapi-client/)** - Live
   docs site
 
@@ -28,5 +30,5 @@ package.
 
 This monorepo also contains:
 
-- **[frontapp-mcp-server](../../frontapp_mcp_server/docs/README.md)** - MCP server for
-  Claude Code integration
+- **[frontapp-mcp-server](https://github.com/dougborg/frontapp-openapi-client/blob/main/frontapp_mcp_server/docs/README.md)** -
+  MCP server for Claude Code integration

--- a/frontapp_public_api_client/docs/adr/0001-transport-layer-resilience.md
+++ b/frontapp_public_api_client/docs/adr/0001-transport-layer-resilience.md
@@ -42,7 +42,7 @@ Specifically:
   changes
 
 Implementation in
-[frontapp_client.py](../../frontapp_public_api_client/frontapp_client.py):
+[frontapp_client.py](https://github.com/dougborg/frontapp-openapi-client/blob/main/frontapp_public_api_client/frontapp_client.py):
 
 ```python
 class ResilientAsyncTransport:
@@ -174,7 +174,8 @@ class RetryMiddleware:
 
 - [httpx Transports Documentation](https://www.python-httpx.org/advanced/#custom-transports)
 - [httpx-retries Library](https://github.com/karpetrosyan/httpx-retries)
-- [`frontapp_client.py`](../../frontapp_client.py) — implementation
+- [`frontapp_client.py`](https://github.com/dougborg/frontapp-openapi-client/blob/main/frontapp_public_api_client/frontapp_client.py)
+  — implementation
 - [ADR-003: Transparent Pagination](0003-transparent-pagination.md) — pagination built
   on this transport stack
 - [ADR-006: Response Unwrapping Utilities](0006-response-unwrapping-utilities.md) —

--- a/frontapp_public_api_client/docs/adr/0002-openapi-code-generation.md
+++ b/frontapp_public_api_client/docs/adr/0002-openapi-code-generation.md
@@ -223,8 +223,9 @@ Custom enhancements live in clearly-separated files that the regeneration never 
 - [Front Developer Portal](https://dev.frontapp.com/reference/introduction)
 - [frontapp/front-api-specs](https://github.com/frontapp/front-api-specs) — upstream
   OpenAPI spec
-- [`scripts/vendor_spec.py`](../../../scripts/vendor_spec.py) — upstream download +
-  sanitization
-- [`scripts/regenerate_client.py`](../../../scripts/regenerate_client.py) — generator
-  driver
-- [`docs/frontapp-openapi.yaml`](../../../docs/frontapp-openapi.yaml) — vendored spec
+- [`scripts/vendor_spec.py`](https://github.com/dougborg/frontapp-openapi-client/blob/main/scripts/vendor_spec.py)
+  — upstream download + sanitization
+- [`scripts/regenerate_client.py`](https://github.com/dougborg/frontapp-openapi-client/blob/main/scripts/regenerate_client.py)
+  — generator driver
+- [`docs/frontapp-openapi.yaml`](https://github.com/dougborg/frontapp-openapi-client/blob/main/docs/frontapp-openapi.yaml)
+  — vendored spec

--- a/frontapp_public_api_client/docs/adr/0003-transparent-pagination.md
+++ b/frontapp_public_api_client/docs/adr/0003-transparent-pagination.md
@@ -246,5 +246,5 @@ Auto-pagination: reached max_items=500, stopping
 - [ADR-006: Response Unwrapping Utilities](0006-response-unwrapping-utilities.md) —
   `unwrap(response)` + `getattr(..., "field_results")`
 - [Front pagination docs](https://dev.frontapp.com/docs/pagination)
-- [`helpers/conversations.py`](../../helpers/conversations.py) — current manual cursor
-  support
+- [`helpers/conversations.py`](https://github.com/dougborg/frontapp-openapi-client/blob/main/frontapp_public_api_client/helpers/conversations.py)
+  — current manual cursor support

--- a/frontapp_public_api_client/docs/adr/0004-defer-observability-to-httpx.md
+++ b/frontapp_public_api_client/docs/adr/0004-defer-observability-to-httpx.md
@@ -282,4 +282,5 @@ Link users to:
 - [httpx Advanced Features](https://www.python-httpx.org/advanced/)
 - [httpx Event Hooks](https://www.python-httpx.org/advanced/#event-hooks)
 - [OpenTelemetry httpx Instrumentation](https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/httpx/httpx.html)
-- [`_logging.py`](../../_logging.py) — sensitive-data redaction filter
+- [`_logging.py`](https://github.com/dougborg/frontapp-openapi-client/blob/main/frontapp_public_api_client/_logging.py)
+  — sensitive-data redaction filter

--- a/frontapp_public_api_client/docs/adr/0005-sync-async-apis.md
+++ b/frontapp_public_api_client/docs/adr/0005-sync-async-apis.md
@@ -255,16 +255,6 @@ class FrontappClient(AuthenticatedClient):
         )
 ```
 
-### Examples Provided
-
-Both patterns documented:
-
-- `examples/basic_usage.py` - Async examples
-- `examples/sync_usage.py` - Sync examples
-
 ## References
 
 - [httpx Async Support](https://www.python-httpx.org/async/)
-- [examples/basic_usage.py](../../examples/basic_usage.py)
-- [examples/sync_usage.py](../../examples/sync_usage.py)
--

--- a/frontapp_public_api_client/docs/adr/0006-response-unwrapping-utilities.md
+++ b/frontapp_public_api_client/docs/adr/0006-response-unwrapping-utilities.md
@@ -261,9 +261,11 @@ per-field details; 429 carries `Retry-After` in headers rather than the body).
 
 ## References
 
-- [`utils.py`](../../utils.py) — implementation
+- [`utils.py`](https://github.com/dougborg/frontapp-openapi-client/blob/main/frontapp_public_api_client/utils.py)
+  — implementation
 - [ADR-001: Transport-Layer Resilience](0001-transport-layer-resilience.md) — retries
   layer underneath
 - [ADR-0011: Pydantic Domain Models](0011-pydantic-domain-models.md) — domain layer on
   top
-- [CLAUDE.md](../../../CLAUDE.md) — Known Pitfalls including `field_results` gotcha
+- [CLAUDE.md](https://github.com/dougborg/frontapp-openapi-client/blob/main/CLAUDE.md) —
+  Known Pitfalls including `field_results` gotcha

--- a/frontapp_public_api_client/docs/adr/0008-avoid-builder-pattern.md
+++ b/frontapp_public_api_client/docs/adr/0008-avoid-builder-pattern.md
@@ -197,7 +197,7 @@ result = await convs.list(q="status:open")
 **Adopted** — this is exactly what the `client.conversations` helper is. Bound clients
 give us the builder-like ergonomics of "set context once, call many times" without the
 method-chaining surface. See
-[`helpers/conversations.py`](../../helpers/conversations.py).
+[`helpers/conversations.py`](https://github.com/dougborg/frontapp-openapi-client/blob/main/frontapp_public_api_client/helpers/conversations.py).
 
 ## What we do instead
 
@@ -256,5 +256,6 @@ the bar for reintroducing a second API layer.
   layer
 - [Front search syntax](https://dev.frontapp.com/docs/search-syntax) — Front's built-in
   DSL
-- [`helpers/conversations.py`](../../helpers/conversations.py) — example of the pattern
+- [`helpers/conversations.py`](https://github.com/dougborg/frontapp-openapi-client/blob/main/frontapp_public_api_client/helpers/conversations.py)
+  — example of the pattern
 - [`cookbook.md`](../cookbook.md)

--- a/frontapp_public_api_client/docs/adr/0011-pydantic-domain-models.md
+++ b/frontapp_public_api_client/docs/adr/0011-pydantic-domain-models.md
@@ -221,4 +221,5 @@ objects.
 - [ADR-002: Generate Client from OpenAPI Specification](0002-openapi-code-generation.md)
 - [ADR-006: Response Unwrapping Utilities](0006-response-unwrapping-utilities.md)
 - [Pydantic v2 Documentation](https://docs.pydantic.dev/latest/)
-- [`domain/conversation.py`](../../domain/conversation.py) — current implementation
+- [`domain/conversation.py`](https://github.com/dougborg/frontapp-openapi-client/blob/main/frontapp_public_api_client/domain/conversation.py)
+  — current implementation

--- a/frontapp_public_api_client/docs/adr/0012-validation-tiers-for-agent-workflows.md
+++ b/frontapp_public_api_client/docs/adr/0012-validation-tiers-for-agent-workflows.md
@@ -141,8 +141,9 @@ for a specific workflow stage:
 
 ## References
 
-- [AGENT_WORKFLOW.md](../../../AGENT_WORKFLOW.md) — complete agent workflow guide
-- [CLAUDE.md](../../../CLAUDE.md) — Essential Commands table referencing the validation
-  tiers
-- [ADR-009: Migrate from Poetry to uv](../../../docs/adr/0009-migrate-from-poetry-to-uv.md)
+- [AGENT_WORKFLOW.md](https://github.com/dougborg/frontapp-openapi-client/blob/main/AGENT_WORKFLOW.md)
+  — complete agent workflow guide
+- [CLAUDE.md](https://github.com/dougborg/frontapp-openapi-client/blob/main/CLAUDE.md) —
+  Essential Commands table referencing the validation tiers
+- [ADR-009: Migrate from Poetry to uv](https://github.com/dougborg/frontapp-openapi-client/blob/main/docs/adr/0009-migrate-from-poetry-to-uv.md)
   — package manager choice that enabled fast validation

--- a/frontapp_public_api_client/docs/adr/README.md
+++ b/frontapp_public_api_client/docs/adr/README.md
@@ -36,5 +36,5 @@ We use the format proposed by Michael Nygard in
 
 - [Testing Guide](../testing.md)
 - [Client Guide](../guide.md)
-- [Contributing Guide](../../../docs/CONTRIBUTING.md)
-- [Monorepo ADRs](../../../docs/adr/README.md)
+- [Contributing Guide](https://github.com/dougborg/frontapp-openapi-client/blob/main/docs/CONTRIBUTING.md)
+- [Monorepo ADRs](https://github.com/dougborg/frontapp-openapi-client/blob/main/docs/adr/README.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -125,6 +125,15 @@ markdown_extensions:
       custom_checkbox: true
   - pymdownx.tilde
 
+# Exclude top-level meta-readmes (which describe the docs folder for repo
+# readers) from the site build. mkdocs would otherwise warn about them
+# conflicting with the corresponding ``index.md`` (which is the actual site
+# content). Globs are anchored so deeper README.md files (e.g.
+# ``client/adr/README.md``) stay included.
+exclude_docs: |
+  /README.md
+  /mcp-server/README.md
+
 nav:
   - Home: index.md
   - Python Client:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -472,7 +472,7 @@ validate-openapi-redocly = "npx @redocly/cli lint docs/frontapp-openapi.yaml"
 # -----------------------------------------------------------------------------
 # Documentation Tasks
 # -----------------------------------------------------------------------------
-docs-build = "mkdocs build"
+docs-build = "mkdocs build --strict"
 docs-clean = "rm -rf site"
 docs-serve = "mkdocs serve"
 docs-autobuild = "mkdocs serve --watch docs --watch frontapp_public_api_client"


### PR DESCRIPTION
Closes #11.

## Summary

`uv run mkdocs build --strict` now passes — was emitting 49 warnings, now 0.

## Approach

**Option 1 from the issue**: convert broken relative refs to absolute GitHub URLs.

The warnings came from package-local docs (e.g. \`frontapp_public_api_client/docs/adr/X.md\`) using relative links to sibling files (\`../../frontapp_client.py\`). These resolve correctly on github.com via the package path, but mkdocs serves the same files through the \`docs/client/\` symlink, and \`..\` resolves to a different directory in that context. Absolute GitHub URLs work identically in both renderings.

## Changes

- **~47 link rewrites** across 22 ADRs and package READMEs — all to \`https://github.com/dougborg/frontapp-openapi-client/blob/main/<path>\` URLs that resolve to real files in the repo (verified by walking the URL list against \`git ls-files\`).
- **\`mkdocs.yml\`**: added \`exclude_docs\` (anchored globs) for the two top-level meta-READMEs that conflict with their \`index.md\` siblings. Deeper READMEs (\`client/adr/README.md\` etc.) stay included.
- **\`pyproject.toml\`**: \`docs-build = "mkdocs build --strict"\`. \`full-check\` already invokes \`docs-build\`, so future doc regressions now fail validation.
- **ADR-005**: dropped references to \`examples/basic_usage.py\` / \`examples/sync_usage.py\` — those example files don't exist anywhere in the repo (broken in the original).

## Test plan

- [x] \`uv run mkdocs build --strict\` exits 0
- [x] \`uv run poe full-check\` exits 0 (lint + typecheck + tests + facts-check + strict docs build)
- [x] All 35 generated GitHub URLs verified to resolve to real files via \`git ls-files\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)