### PR TITLE
test: real coverage for conversations vertical + transport contract (#7)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"d0b5d2e3-2d7d-4305-9011-73e5f03dedda","pid":81121,"procStart":"Sun Apr 26 20:46:43 2026","acquiredAt":1777244049967}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"d0b5d2e3-2d7d-4305-9011-73e5f03dedda","pid":81121,"procStart":"Sun Apr 26 20:46:43 2026","acquiredAt":1777244049967}

--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,4 @@ node_modules/
 # Some users have `tags` (ctags) globally ignored, which silently drops the
 # generated `api/tags/` package — this negation keeps it tracked.
 !frontapp_public_api_client/api/tags/
+.claude/scheduled_tasks.lock

--- a/frontapp_mcp_server/tests/conftest.py
+++ b/frontapp_mcp_server/tests/conftest.py
@@ -76,3 +76,31 @@ def create_mock_context(elicit_confirm: bool = True):
 def mock_context():
     """Mock FastMCP context fixture."""
     return create_mock_context()
+
+
+@pytest.fixture
+def mcp_tool_capture():
+    """Factory: register a tools module against a fake FastMCP and return
+    the captured ``{name: callable}`` dict.
+
+    Replaces the per-file ``_make_mcp`` + ``register_tools`` boilerplate
+    that was duplicated across every MCP tool test module.
+    """
+
+    def factory(register_tools_fn) -> dict[str, object]:
+        captured: dict[str, object] = {}
+
+        class FakeMCP:
+            def tool(self, **kwargs: object):
+                name = kwargs["name"]
+
+                def decorator(fn):
+                    captured[name] = fn
+                    return fn
+
+                return decorator
+
+        register_tools_fn(FakeMCP())
+        return captured
+
+    return factory

--- a/frontapp_mcp_server/tests/conftest.py
+++ b/frontapp_mcp_server/tests/conftest.py
@@ -83,8 +83,11 @@ def mcp_tool_capture():
     """Factory: register a tools module against a fake FastMCP and return
     the captured ``{name: callable}`` dict.
 
-    Replaces the per-file ``_make_mcp`` + ``register_tools`` boilerplate
-    that was duplicated across every MCP tool test module.
+    New tool test files should use this fixture. Existing per-vertical
+    test files (test_contacts_tools, test_drafts_tools, test_messages_tools,
+    test_tags_tools, test_inboxes_tools) still define their own copy of
+    the same pattern — migration is tracked as follow-up cleanup so this
+    PR doesn't churn 5 working test files.
     """
 
     def factory(register_tools_fn) -> dict[str, object]:

--- a/frontapp_mcp_server/tests/conftest.py
+++ b/frontapp_mcp_server/tests/conftest.py
@@ -42,16 +42,33 @@ async def frontapp_context():
     yield context
 
 
-def create_mock_context(elicit_confirm: bool = True):
+def create_mock_context(
+    elicit_confirm: bool = True, *, elicit_action: str | None = None
+):
     """Build a mock FastMCP context for unit tests.
 
+    The three values of ``ConfirmationResult`` map to elicit-result shape:
+
+    - CONFIRMED: ``action='accept'`` + ``data.confirm=True``
+    - DECLINED:  ``action='accept'`` + ``data.confirm=False``
+    - CANCELLED: ``action != 'accept'`` (typically ``'decline'``)
+
     Args:
-        elicit_confirm: If True, elicit() returns an accepted confirm=True result.
-                       If False, elicit() returns a declined result.
+        elicit_confirm: If True, the elicitation models user-confirmation
+            (CONFIRMED). If False, by default the elicitation is cancelled
+            (action='decline' → CANCELLED) — that's the historical
+            behavior.
+        elicit_action: Override the ``action`` field explicitly. Pass
+            ``'accept'`` together with ``elicit_confirm=False`` to
+            exercise the DECLINED branch (where the elicitation succeeds
+            but the user un-checks the confirm flag).
 
     Returns:
         Tuple of (context, lifespan_context).
     """
+    if elicit_action is None:
+        elicit_action = "accept" if elicit_confirm else "decline"
+
     context = MagicMock()
     mock_request_context = MagicMock()
     mock_lifespan_context = MagicMock()
@@ -59,12 +76,11 @@ def create_mock_context(elicit_confirm: bool = True):
     mock_request_context.lifespan_context = mock_lifespan_context
 
     mock_elicit_result = MagicMock()
-    if elicit_confirm:
-        mock_elicit_result.action = "accept"
+    mock_elicit_result.action = elicit_action
+    if elicit_action == "accept":
         mock_elicit_result.data = MagicMock()
-        mock_elicit_result.data.confirm = True
+        mock_elicit_result.data.confirm = elicit_confirm
     else:
-        mock_elicit_result.action = "decline"
         mock_elicit_result.data = None
 
     context.elicit = AsyncMock(return_value=mock_elicit_result)

--- a/frontapp_mcp_server/tests/test_conversations_tools.py
+++ b/frontapp_mcp_server/tests/test_conversations_tools.py
@@ -123,8 +123,12 @@ class TestReadTools:
 class TestUpdateConversation:
     async def test_preview_does_not_call_helper(self, conversations_tools):
         context, lifespan = create_mock_context()
-        lifespan.client = AsyncMock(
-            side_effect=AssertionError("client invoked on preview")
+        # ``side_effect`` on ``lifespan.client`` itself doesn't propagate
+        # to ``lifespan.client.conversations.update``; assign the trap to
+        # the deepest method we expect *not* to be awaited.
+        lifespan.client = AsyncMock()
+        lifespan.client.conversations.update = AsyncMock(
+            side_effect=AssertionError("helper invoked on preview")
         )
 
         result = await conversations_tools["update_conversation"](
@@ -134,6 +138,7 @@ class TestUpdateConversation:
         assert result["confirmed"] is False
         assert result["preview"]["changes"] == {"status": "archived"}
         context.elicit.assert_not_called()
+        lifespan.client.conversations.update.assert_not_awaited()
 
     async def test_no_changes_short_circuits(self, conversations_tools):
         """Empty changes dict returns early with ``no_changes_requested``
@@ -149,10 +154,12 @@ class TestUpdateConversation:
         assert result["confirmed"] is False
         context.elicit.assert_not_called()
 
-    async def test_declined_does_not_call_helper(self, conversations_tools):
-        context, lifespan = create_mock_context(elicit_confirm=False)
-        lifespan.client = AsyncMock(
-            side_effect=AssertionError("client invoked after decline")
+    async def test_cancelled_does_not_call_helper(self, conversations_tools):
+        """User cancelled the elicitation (``action='decline'``) → CANCELLED."""
+        context, lifespan = create_mock_context(elicit_action="decline")
+        lifespan.client = AsyncMock()
+        lifespan.client.conversations.update = AsyncMock(
+            side_effect=AssertionError("helper invoked after cancel")
         )
 
         result = await conversations_tools["update_conversation"](
@@ -162,6 +169,26 @@ class TestUpdateConversation:
         assert result["confirmed"] is False
         assert result["result"] == "cancelled"
         context.elicit.assert_called_once()
+        lifespan.client.conversations.update.assert_not_awaited()
+
+    async def test_declined_does_not_call_helper(self, conversations_tools):
+        """User accepted the elicitation but unchecked confirm → DECLINED."""
+        context, lifespan = create_mock_context(
+            elicit_confirm=False, elicit_action="accept"
+        )
+        lifespan.client = AsyncMock()
+        lifespan.client.conversations.update = AsyncMock(
+            side_effect=AssertionError("helper invoked after decline")
+        )
+
+        result = await conversations_tools["update_conversation"](
+            context, conversation_id="cnv_a", status="archived", confirm=True
+        )
+
+        assert result["confirmed"] is False
+        assert result["result"] == "declined"
+        context.elicit.assert_called_once()
+        lifespan.client.conversations.update.assert_not_awaited()
 
     async def test_confirmed_calls_helper(self, conversations_tools):
         context, lifespan = create_mock_context()
@@ -209,8 +236,9 @@ class TestAddConversationComment:
     async def test_preview_includes_truncated_body(self, conversations_tools):
         context, lifespan = create_mock_context()
         long_body = "x" * 250
-        lifespan.client = AsyncMock(
-            side_effect=AssertionError("client invoked on preview")
+        lifespan.client = AsyncMock()
+        lifespan.client.conversations.add_comment = AsyncMock(
+            side_effect=AssertionError("helper invoked on preview")
         )
 
         result = await conversations_tools["add_conversation_comment"](
@@ -220,6 +248,7 @@ class TestAddConversationComment:
         # Truncated to 200 chars + ellipsis.
         assert result["preview"]["body_preview"].endswith("…")
         assert len(result["preview"]["body_preview"]) == 201
+        lifespan.client.conversations.add_comment.assert_not_awaited()
 
     async def test_short_body_not_truncated(self, conversations_tools):
         context, _ = create_mock_context()
@@ -228,10 +257,12 @@ class TestAddConversationComment:
         )
         assert result["preview"]["body_preview"] == "Short"
 
-    async def test_declined_does_not_call_helper(self, conversations_tools):
-        context, lifespan = create_mock_context(elicit_confirm=False)
-        lifespan.client = AsyncMock(
-            side_effect=AssertionError("client invoked after decline")
+    async def test_cancelled_does_not_call_helper(self, conversations_tools):
+        """User cancelled the elicitation (``action='decline'``) → CANCELLED."""
+        context, lifespan = create_mock_context(elicit_action="decline")
+        lifespan.client = AsyncMock()
+        lifespan.client.conversations.add_comment = AsyncMock(
+            side_effect=AssertionError("helper invoked after cancel")
         )
 
         result = await conversations_tools["add_conversation_comment"](
@@ -240,6 +271,25 @@ class TestAddConversationComment:
 
         assert result["confirmed"] is False
         assert result["result"] == "cancelled"
+        lifespan.client.conversations.add_comment.assert_not_awaited()
+
+    async def test_declined_does_not_call_helper(self, conversations_tools):
+        """User accepted the elicitation but unchecked confirm → DECLINED."""
+        context, lifespan = create_mock_context(
+            elicit_confirm=False, elicit_action="accept"
+        )
+        lifespan.client = AsyncMock()
+        lifespan.client.conversations.add_comment = AsyncMock(
+            side_effect=AssertionError("helper invoked after decline")
+        )
+
+        result = await conversations_tools["add_conversation_comment"](
+            context, conversation_id="cnv_a", body="Note", confirm=True
+        )
+
+        assert result["confirmed"] is False
+        assert result["result"] == "declined"
+        lifespan.client.conversations.add_comment.assert_not_awaited()
 
     async def test_confirmed_calls_helper(self, conversations_tools):
         context, lifespan = create_mock_context()

--- a/frontapp_mcp_server/tests/test_conversations_tools.py
+++ b/frontapp_mcp_server/tests/test_conversations_tools.py
@@ -94,6 +94,10 @@ class TestReadTools:
             context, conversation_id="cnv_a"
         )
 
+        # Assert .to_dict() was called per item, so removing the projection
+        # logic from the tool would fail this test (not just the equality).
+        msg1.to_dict.assert_called_once()
+        msg2.to_dict.assert_called_once()
         assert len(result) == 2
         assert result[0] == {"id": "msg_1", "type": "email"}
 

--- a/frontapp_mcp_server/tests/test_conversations_tools.py
+++ b/frontapp_mcp_server/tests/test_conversations_tools.py
@@ -1,0 +1,258 @@
+"""Tests for MCP conversations tools — 5 reads + 2 mutations."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from frontapp_mcp.projections import ConversationSummary
+from frontapp_mcp.tools.conversations import register_tools
+
+from frontapp_public_api_client.domain import Conversation
+
+from .conftest import create_mock_context
+
+
+@pytest.fixture
+def conversations_tools(mcp_tool_capture):
+    return mcp_tool_capture(register_tools)
+
+
+# ---------------------------------------------------------------------------
+# Read tools — list / get / search / list_messages / list_comments
+# ---------------------------------------------------------------------------
+
+
+class TestReadTools:
+    async def test_list_conversations_projects_each(self, conversations_tools):
+        context, lifespan = create_mock_context()
+        convs = [
+            Conversation.model_validate({"id": "cnv_1", "subject": "A"}),
+            Conversation.model_validate({"id": "cnv_2", "subject": "B"}),
+        ]
+        lifespan.client = AsyncMock()
+        lifespan.client.conversations.list = AsyncMock(return_value=convs)
+
+        result = await conversations_tools["list_conversations"](context)
+
+        assert len(result) == 2
+        assert all(isinstance(s, ConversationSummary) for s in result)
+        assert [s.id for s in result] == ["cnv_1", "cnv_2"]
+
+    async def test_list_conversations_passes_q_limit_token(self, conversations_tools):
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock()
+        lifespan.client.conversations.list = AsyncMock(return_value=[])
+
+        await conversations_tools["list_conversations"](
+            context, q="status:open", limit=25, page_token="cursor_abc"
+        )
+
+        lifespan.client.conversations.list.assert_awaited_once_with(
+            q="status:open", limit=25, page_token="cursor_abc"
+        )
+
+    async def test_get_conversation_returns_summary(self, conversations_tools):
+        context, lifespan = create_mock_context()
+        conv = Conversation.model_validate({"id": "cnv_a", "subject": "Hi"})
+        lifespan.client = AsyncMock()
+        lifespan.client.conversations.get = AsyncMock(return_value=conv)
+
+        result = await conversations_tools["get_conversation"](
+            context, conversation_id="cnv_a"
+        )
+
+        assert isinstance(result, ConversationSummary)
+        assert result.id == "cnv_a"
+        assert result.subject == "Hi"
+
+    async def test_search_conversations_passes_query(self, conversations_tools):
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock()
+        lifespan.client.conversations.search = AsyncMock(return_value=[])
+
+        await conversations_tools["search_conversations"](
+            context, query="status:open AND tag:vip"
+        )
+
+        lifespan.client.conversations.search.assert_awaited_once_with(
+            "status:open AND tag:vip", limit=None, page_token=None
+        )
+
+    async def test_list_conversation_messages_returns_dicts(self, conversations_tools):
+        context, lifespan = create_mock_context()
+        msg1 = MagicMock()
+        msg1.to_dict.return_value = {"id": "msg_1", "type": "email"}
+        msg2 = MagicMock()
+        msg2.to_dict.return_value = {"id": "msg_2", "type": "email"}
+        lifespan.client = AsyncMock()
+        lifespan.client.conversations.list_messages = AsyncMock(
+            return_value=[msg1, msg2]
+        )
+
+        result = await conversations_tools["list_conversation_messages"](
+            context, conversation_id="cnv_a"
+        )
+
+        assert len(result) == 2
+        assert result[0] == {"id": "msg_1", "type": "email"}
+
+    async def test_list_conversation_comments_returns_dicts(self, conversations_tools):
+        context, lifespan = create_mock_context()
+        comment = MagicMock()
+        comment.to_dict.return_value = {"id": "com_1", "body": "Note"}
+        lifespan.client = AsyncMock()
+        lifespan.client.conversations.list_comments = AsyncMock(return_value=[comment])
+
+        result = await conversations_tools["list_conversation_comments"](
+            context, conversation_id="cnv_a"
+        )
+
+        assert result == [{"id": "com_1", "body": "Note"}]
+
+
+# ---------------------------------------------------------------------------
+# Mutation: update_conversation — preview / no-changes / confirm / decline
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateConversation:
+    async def test_preview_does_not_call_helper(self, conversations_tools):
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock(
+            side_effect=AssertionError("client invoked on preview")
+        )
+
+        result = await conversations_tools["update_conversation"](
+            context, conversation_id="cnv_a", status="archived", confirm=False
+        )
+
+        assert result["confirmed"] is False
+        assert result["preview"]["changes"] == {"status": "archived"}
+        context.elicit.assert_not_called()
+
+    async def test_no_changes_short_circuits(self, conversations_tools):
+        """Empty changes dict returns early with ``no_changes_requested``
+        even when confirm=True is passed — protects against no-op mutations."""
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock()
+
+        result = await conversations_tools["update_conversation"](
+            context, conversation_id="cnv_a", confirm=True
+        )
+
+        assert result["result"] == "no_changes_requested"
+        assert result["confirmed"] is False
+        context.elicit.assert_not_called()
+
+    async def test_declined_does_not_call_helper(self, conversations_tools):
+        context, lifespan = create_mock_context(elicit_confirm=False)
+        lifespan.client = AsyncMock(
+            side_effect=AssertionError("client invoked after decline")
+        )
+
+        result = await conversations_tools["update_conversation"](
+            context, conversation_id="cnv_a", status="archived", confirm=True
+        )
+
+        assert result["confirmed"] is False
+        assert result["result"] == "cancelled"
+        context.elicit.assert_called_once()
+
+    async def test_confirmed_calls_helper(self, conversations_tools):
+        context, lifespan = create_mock_context()
+        response = MagicMock()
+        response.status_code = 204
+        lifespan.client = AsyncMock()
+        lifespan.client.conversations.update = AsyncMock(return_value=response)
+
+        result = await conversations_tools["update_conversation"](
+            context,
+            conversation_id="cnv_a",
+            status="archived",
+            assignee_id="tea_xyz",
+            confirm=True,
+        )
+
+        lifespan.client.conversations.update.assert_awaited_once_with(
+            "cnv_a",
+            status="archived",
+            assignee_id="tea_xyz",
+            inbox_id=None,
+            tag_ids=None,
+        )
+        assert result == {"confirmed": True, "status_code": 204}
+
+    async def test_tag_ids_documented_as_replace(self, conversations_tools):
+        """The preview should make it clear update_conversation REPLACES
+        the full tag set (vs the delta methods on the tags vertical)."""
+        context, _ = create_mock_context()
+        result = await conversations_tools["update_conversation"](
+            context,
+            conversation_id="cnv_a",
+            tag_ids=["tag_1", "tag_2"],
+            confirm=False,
+        )
+        assert result["preview"]["changes"] == {"tag_ids": ["tag_1", "tag_2"]}
+
+
+# ---------------------------------------------------------------------------
+# Mutation: add_conversation_comment — preview / decline / confirm
+# ---------------------------------------------------------------------------
+
+
+class TestAddConversationComment:
+    async def test_preview_includes_truncated_body(self, conversations_tools):
+        context, lifespan = create_mock_context()
+        long_body = "x" * 250
+        lifespan.client = AsyncMock(
+            side_effect=AssertionError("client invoked on preview")
+        )
+
+        result = await conversations_tools["add_conversation_comment"](
+            context, conversation_id="cnv_a", body=long_body, confirm=False
+        )
+
+        # Truncated to 200 chars + ellipsis.
+        assert result["preview"]["body_preview"].endswith("…")
+        assert len(result["preview"]["body_preview"]) == 201
+
+    async def test_short_body_not_truncated(self, conversations_tools):
+        context, _ = create_mock_context()
+        result = await conversations_tools["add_conversation_comment"](
+            context, conversation_id="cnv_a", body="Short", confirm=False
+        )
+        assert result["preview"]["body_preview"] == "Short"
+
+    async def test_declined_does_not_call_helper(self, conversations_tools):
+        context, lifespan = create_mock_context(elicit_confirm=False)
+        lifespan.client = AsyncMock(
+            side_effect=AssertionError("client invoked after decline")
+        )
+
+        result = await conversations_tools["add_conversation_comment"](
+            context, conversation_id="cnv_a", body="Note", confirm=True
+        )
+
+        assert result["confirmed"] is False
+        assert result["result"] == "cancelled"
+
+    async def test_confirmed_calls_helper(self, conversations_tools):
+        context, lifespan = create_mock_context()
+        response = MagicMock()
+        response.status_code = 201
+        lifespan.client = AsyncMock()
+        lifespan.client.conversations.add_comment = AsyncMock(return_value=response)
+
+        result = await conversations_tools["add_conversation_comment"](
+            context,
+            conversation_id="cnv_a",
+            body="VIP customer",
+            author_id="tea_xyz",
+            confirm=True,
+        )
+
+        lifespan.client.conversations.add_comment.assert_awaited_once_with(
+            "cnv_a", body="VIP customer", author_id="tea_xyz"
+        )
+        assert result == {"confirmed": True, "status_code": 201}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,70 @@ def mock_transport(mock_transport_handler):
 
 
 @pytest.fixture
+def make_mock_transport():
+    """Factory: build an ``httpx.MockTransport`` that returns a fixed payload.
+
+    ``payload=None`` sends an empty body (use for 204 No Content). Used by
+    every helper test that wants to assert the helper's unwrap/decode path
+    without recording the request.
+    """
+
+    def factory(payload, status: int = 200) -> httpx.MockTransport:
+        def handler(_request: httpx.Request) -> httpx.Response:
+            if payload is None:
+                return httpx.Response(status, content=b"")
+            return httpx.Response(status, json=payload)
+
+        return httpx.MockTransport(handler)
+
+    return factory
+
+
+@pytest.fixture
+def make_recording_transport():
+    """Factory: build an ``httpx.MockTransport`` that records every request.
+
+    Returns ``(transport, recorded_list)``. Use when a test needs to inspect
+    the URL, method, or body the helper sent.
+    """
+
+    def factory(
+        payload, status: int = 200
+    ) -> tuple[httpx.MockTransport, list[httpx.Request]]:
+        recorded: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            recorded.append(request)
+            if payload is None:
+                return httpx.Response(status, content=b"")
+            return httpx.Response(status, json=payload)
+
+        return httpx.MockTransport(handler), recorded
+
+    return factory
+
+
+@pytest.fixture
+def attach_transport(mock_api_credentials):
+    """Helper: install a mock transport on a freshly-built FrontappClient.
+
+    Returns a callable ``(transport) -> FrontappClient`` so each test can
+    construct its own client with the chosen mock plumbing.
+    """
+
+    def attach(transport: httpx.MockTransport):
+        client = FrontappClient(**mock_api_credentials)
+        client.set_async_httpx_client(
+            httpx.AsyncClient(
+                transport=transport, base_url=mock_api_credentials["base_url"]
+            )
+        )
+        return client
+
+    return attach
+
+
+@pytest.fixture
 def frontapp_client_with_mock_transport(mock_api_credentials, mock_transport):
     """Create a FrontappClient with MockTransport for testing."""
     # Create a FrontappClient

--- a/tests/test_conversation_domain.py
+++ b/tests/test_conversation_domain.py
@@ -70,25 +70,21 @@ class TestTimestampValidator:
 
 
 class TestExtraFields:
-    def test_unknown_fields_silently_ignored(self):
-        """extra=ignore — Front's response includes _links, metadata, scheduled_reminders
-        etc. that aren't in the projection."""
+    def test_unknown_fields_silently_dropped(self):
+        """extra=ignore — Front's response includes _links, metadata,
+        scheduled_reminders etc. that aren't in the projection. Extras
+        must accept silently AND not appear as instance attrs."""
         c = Conversation.model_validate(
             {
                 "id": "cnv_a",
                 "_links": {"self": "https://x"},
                 "metadata": {"headers": {}},
                 "scheduled_reminders": [],
-                "ticket_ids": ["tic_1"],  # Not in projection — ignored.
+                "ticket_ids": ["tic_1"],
                 "totally_made_up_field": 42,
             }
         )
         assert c.id == "cnv_a"
-        # Should not raise; not assertable that the extras are absent —
-        # extra="ignore" silently drops them.
-
-    def test_no_unknown_attribute_appears_on_instance(self):
-        c = Conversation.model_validate({"id": "cnv_a", "totally_made_up_field": 42})
         with pytest.raises(AttributeError):
             _ = c.totally_made_up_field  # type: ignore[attr-defined]
 

--- a/tests/test_conversation_domain.py
+++ b/tests/test_conversation_domain.py
@@ -1,0 +1,161 @@
+"""Tests for the ``Conversation`` Pydantic domain model.
+
+The domain model is the boundary where Front's wire shape (epoch
+timestamps, attrs ``UNSET`` sentinels, mixed-case status strings) gets
+normalized for application code. These tests pin the contract:
+
+- unix-seconds floats convert to UTC-aware ``datetime``s
+- already-parsed ``datetime`` and ISO strings pass through
+- unknown fields are silently dropped (``extra="ignore"``)
+- the model is immutable after construction (``frozen=True``)
+- nested ``TagSummary`` / ``TeammateSummary`` / ``RecipientSummary``
+  validate correctly from generated-API to-dict output
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pydantic
+import pytest
+
+from frontapp_public_api_client.domain import (
+    Conversation,
+    RecipientSummary,
+    TagSummary,
+    TeammateSummary,
+)
+
+
+class TestTimestampValidator:
+    def test_unix_seconds_converts_to_aware_datetime(self):
+        c = Conversation.model_validate({"id": "cnv_a", "created_at": 1701292639})
+        assert isinstance(c.created_at, datetime)
+        assert c.created_at == datetime.fromtimestamp(1701292639, tz=UTC)
+        assert c.created_at.tzinfo is UTC
+
+    def test_unix_seconds_float_works(self):
+        c = Conversation.model_validate({"id": "cnv_a", "updated_at": 1701292639.5})
+        assert isinstance(c.updated_at, datetime)
+
+    def test_already_parsed_datetime_passes_through(self):
+        existing = datetime(2024, 1, 1, 12, 0, tzinfo=UTC)
+        c = Conversation.model_validate({"id": "cnv_a", "created_at": existing})
+        assert c.created_at == existing
+
+    def test_iso_string_parses(self):
+        c = Conversation.model_validate(
+            {"id": "cnv_a", "created_at": "2024-01-01T12:00:00+00:00"}
+        )
+        assert c.created_at == datetime(2024, 1, 1, 12, 0, tzinfo=UTC)
+
+    def test_none_remains_none(self):
+        c = Conversation.model_validate({"id": "cnv_a"})
+        assert c.created_at is None
+        assert c.updated_at is None
+        assert c.waiting_since is None
+
+    def test_validator_runs_on_all_three_timestamp_fields(self):
+        c = Conversation.model_validate(
+            {
+                "id": "cnv_a",
+                "created_at": 1700000000,
+                "updated_at": 1700001000,
+                "waiting_since": 1700002000,
+            }
+        )
+        assert isinstance(c.created_at, datetime)
+        assert isinstance(c.updated_at, datetime)
+        assert isinstance(c.waiting_since, datetime)
+
+
+class TestExtraFields:
+    def test_unknown_fields_silently_ignored(self):
+        """extra=ignore — Front's response includes _links, metadata, scheduled_reminders
+        etc. that aren't in the projection."""
+        c = Conversation.model_validate(
+            {
+                "id": "cnv_a",
+                "_links": {"self": "https://x"},
+                "metadata": {"headers": {}},
+                "scheduled_reminders": [],
+                "ticket_ids": ["tic_1"],  # Not in projection — ignored.
+                "totally_made_up_field": 42,
+            }
+        )
+        assert c.id == "cnv_a"
+        # Should not raise; not assertable that the extras are absent —
+        # extra="ignore" silently drops them.
+
+    def test_no_unknown_attribute_appears_on_instance(self):
+        c = Conversation.model_validate({"id": "cnv_a", "totally_made_up_field": 42})
+        with pytest.raises(AttributeError):
+            _ = c.totally_made_up_field  # type: ignore[attr-defined]
+
+
+class TestImmutability:
+    def test_frozen_blocks_id_assignment(self):
+        c = Conversation.model_validate({"id": "cnv_a"})
+        with pytest.raises(pydantic.ValidationError):
+            c.id = "cnv_b"  # type: ignore[misc]
+
+    def test_frozen_blocks_status_assignment(self):
+        c = Conversation.model_validate({"id": "cnv_a", "status": "archived"})
+        with pytest.raises(pydantic.ValidationError):
+            c.status = "open"  # type: ignore[misc]
+
+
+class TestNestedTypes:
+    def test_assignee_projects_to_teammate_summary(self):
+        c = Conversation.model_validate(
+            {
+                "id": "cnv_a",
+                "assignee": {
+                    "id": "tea_a",
+                    "username": "alice",
+                    "first_name": "Alice",
+                    "is_admin": False,
+                    "is_available": True,
+                },
+            }
+        )
+        assert isinstance(c.assignee, TeammateSummary)
+        assert c.assignee.id == "tea_a"
+        assert c.assignee.username == "alice"
+
+    def test_tags_project_to_tag_summary_list(self):
+        c = Conversation.model_validate(
+            {
+                "id": "cnv_a",
+                "tags": [
+                    {"id": "tag_1", "name": "urgent", "highlight": "red"},
+                    {"id": "tag_2", "name": "vip"},
+                ],
+            }
+        )
+        assert len(c.tags) == 2
+        assert all(isinstance(t, TagSummary) for t in c.tags)
+        assert c.tags[0].name == "urgent"
+        assert c.tags[0].highlight == "red"
+
+    def test_recipient_projects_to_recipient_summary(self):
+        c = Conversation.model_validate(
+            {
+                "id": "cnv_a",
+                "recipient": {
+                    "name": "Bob",
+                    "handle": "b@example.com",
+                    "role": "to",
+                },
+            }
+        )
+        assert isinstance(c.recipient, RecipientSummary)
+        assert c.recipient.handle == "b@example.com"
+
+    def test_empty_tags_default_to_empty_list(self):
+        c = Conversation.model_validate({"id": "cnv_a"})
+        assert c.tags == []
+
+    def test_optional_assignee_can_be_none(self):
+        c = Conversation.model_validate({"id": "cnv_a"})
+        assert c.assignee is None

--- a/tests/test_conversations.py
+++ b/tests/test_conversations.py
@@ -23,6 +23,11 @@ from frontapp_public_api_client.helpers.conversations import _extract_page_token
 
 # ---------------------------------------------------------------------------
 # Payload helpers — minimal-valid responses for the strict from_dict path
+#
+# Many generated response models mark fields like _links / assignee /
+# recipient / metadata as required (Front's spec is overly strict). These
+# helpers build minimum-valid payloads so test bodies can stay focused on
+# the assertion under test rather than schema-satisfaction scaffolding.
 # ---------------------------------------------------------------------------
 
 
@@ -55,8 +60,12 @@ def _recipient_payload(**overrides: Any) -> dict[str, Any]:
     return base
 
 
-def _conversation_payload(**overrides: Any) -> dict[str, Any]:
-    """Minimal valid ``ConversationResponse``-shaped dict."""
+def conversation_payload(**overrides: Any) -> dict[str, Any]:
+    """Minimal valid ``ConversationResponse``-shaped dict.
+
+    Public (no underscore) so future per-vertical test files can import
+    it directly until we promote it to a shared helper module.
+    """
     base: dict[str, Any] = {
         "_links": {"self": "https://x", "related": {}},
         "id": "cnv_abc",
@@ -76,7 +85,7 @@ def _conversation_payload(**overrides: Any) -> dict[str, Any]:
     return base
 
 
-def _comment_payload(**overrides: Any) -> dict[str, Any]:
+def comment_payload(**overrides: Any) -> dict[str, Any]:
     """Minimal valid ``CommentResponse``-shaped dict."""
     base: dict[str, Any] = {
         "_links": {"related": {}},
@@ -128,8 +137,8 @@ class TestListAndSearch:
             make_mock_transport(
                 {
                     "_results": [
-                        _conversation_payload(id="cnv_1", subject="Hello"),
-                        _conversation_payload(id="cnv_2", subject="World"),
+                        conversation_payload(id="cnv_1", subject="Hello"),
+                        conversation_payload(id="cnv_2", subject="World"),
                     ],
                     "_pagination": {},
                     "_links": {},
@@ -200,7 +209,7 @@ class TestListAndSearch:
     ):
         client = attach_transport(
             make_mock_transport(
-                _conversation_payload(
+                conversation_payload(
                     id="cnv_abc", subject="Order #1234", created_at=1701292639
                 )
             )
@@ -268,7 +277,7 @@ class TestListSubResources:
         client = attach_transport(
             make_mock_transport(
                 {
-                    "_results": [_comment_payload(id="com_1", body="Note 1")],
+                    "_results": [comment_payload(id="com_1", body="Note 1")],
                     "_pagination": {},
                     "_links": {},
                 }
@@ -338,7 +347,7 @@ class TestMutations:
     ):
         # add_comment returns 201 with the created comment; send a minimally
         # valid CommentResponse-shaped payload.
-        transport, recorded = make_recording_transport(_comment_payload(), status=201)
+        transport, recorded = make_recording_transport(comment_payload(), status=201)
         client = attach_transport(transport)
 
         await client.conversations.add_comment("cnv_abc", body="Internal note")
@@ -348,7 +357,7 @@ class TestMutations:
     async def test_add_comment_with_author_id(
         self, attach_transport, make_recording_transport
     ):
-        transport, recorded = make_recording_transport(_comment_payload(), status=201)
+        transport, recorded = make_recording_transport(comment_payload(), status=201)
         client = attach_transport(transport)
 
         await client.conversations.add_comment(

--- a/tests/test_conversations.py
+++ b/tests/test_conversations.py
@@ -1,0 +1,423 @@
+"""Tests for the conversations vertical: Conversations helper.
+
+The conversations vertical is the canonical template — every other
+vertical mirrors its shape. These tests cover both reads (list / search /
+get / list_messages / list_comments) and mutations (reply / add_comment /
+update), plus the ``_extract_page_token`` URL-parser helper.
+
+Most of the generated response models have many required fields (Front's
+spec marks status/recipient/assignee/etc. as required even though they
+can be UNSET in practice). The ``_minimal_*_payload`` helpers below
+build dicts that satisfy the strict ``from_dict`` schema while keeping
+test cases readable.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+
+from frontapp_public_api_client.domain import Conversation
+from frontapp_public_api_client.helpers.conversations import _extract_page_token
+
+# ---------------------------------------------------------------------------
+# Payload helpers — minimal-valid responses for the strict from_dict path
+# ---------------------------------------------------------------------------
+
+
+def _teammate_payload(**overrides: Any) -> dict[str, Any]:
+    base = {
+        "_links": {"self": "https://x", "related": {}},
+        "id": "tea_1",
+        "email": "a@example.com",
+        "username": "alice",
+        "first_name": "Alice",
+        "last_name": "Adams",
+        "is_admin": False,
+        "is_available": True,
+        "is_blocked": False,
+        "type": "user",
+        "custom_fields": {},
+    }
+    base.update(overrides)
+    return base
+
+
+def _recipient_payload(**overrides: Any) -> dict[str, Any]:
+    base = {
+        "_links": {"related": {}},
+        "name": None,
+        "handle": "customer@example.com",
+        "role": "to",
+    }
+    base.update(overrides)
+    return base
+
+
+def _conversation_payload(**overrides: Any) -> dict[str, Any]:
+    """Minimal valid ``ConversationResponse``-shaped dict."""
+    base: dict[str, Any] = {
+        "_links": {"self": "https://x", "related": {}},
+        "id": "cnv_abc",
+        "subject": "Hello",
+        "status": "assigned",
+        "ticket_ids": [],
+        "assignee": _teammate_payload(),
+        "recipient": _recipient_payload(),
+        "tags": [],
+        "links": [],
+        "custom_fields": {},
+        "is_private": False,
+        "scheduled_reminders": [],
+        "metadata": {},
+    }
+    base.update(overrides)
+    return base
+
+
+def _comment_payload(**overrides: Any) -> dict[str, Any]:
+    """Minimal valid ``CommentResponse``-shaped dict."""
+    base: dict[str, Any] = {
+        "_links": {"related": {}},
+        "id": "com_1",
+        "author": _teammate_payload(),
+        "body": "Internal note",
+        "attachments": [],
+        "is_pinned": False,
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# _extract_page_token — pagination cursor parsing
+# ---------------------------------------------------------------------------
+
+
+class TestExtractPageToken:
+    def test_returns_none_for_no_url(self):
+        assert _extract_page_token(None) is None
+        assert _extract_page_token("") is None
+
+    def test_extracts_page_token_query_param(self):
+        url = "https://api.frontapp.com/conversations?page_token=abc123&limit=50"
+        assert _extract_page_token(url) == "abc123"
+
+    def test_returns_none_when_no_page_token(self):
+        assert _extract_page_token("https://api.frontapp.com/conversations") is None
+        assert (
+            _extract_page_token("https://api.frontapp.com/conversations?limit=50")
+            is None
+        )
+
+    def test_handles_malformed_url_gracefully(self):
+        assert _extract_page_token("not a url") is None
+
+
+# ---------------------------------------------------------------------------
+# list / search / get
+# ---------------------------------------------------------------------------
+
+
+class TestListAndSearch:
+    async def test_list_unwraps_field_results(
+        self, attach_transport, make_mock_transport
+    ):
+        client = attach_transport(
+            make_mock_transport(
+                {
+                    "_results": [
+                        _conversation_payload(id="cnv_1", subject="Hello"),
+                        _conversation_payload(id="cnv_2", subject="World"),
+                    ],
+                    "_pagination": {},
+                    "_links": {},
+                }
+            )
+        )
+
+        convs = await client.conversations.list()
+        assert len(convs) == 2
+        assert all(isinstance(c, Conversation) for c in convs)
+        assert [c.id for c in convs] == ["cnv_1", "cnv_2"]
+        assert convs[0].subject == "Hello"
+
+    async def test_list_passes_q_and_limit(
+        self, attach_transport, make_recording_transport
+    ):
+        transport, recorded = make_recording_transport(
+            {"_results": [], "_pagination": {}, "_links": {}}
+        )
+        client = attach_transport(transport)
+
+        await client.conversations.list(q="status:open tag:urgent", limit=25)
+        assert len(recorded) == 1
+        assert recorded[0].url.params.get("q") == "status:open tag:urgent"
+        assert recorded[0].url.params.get("limit") == "25"
+
+    async def test_list_passes_sort_order_as_enum(
+        self, attach_transport, make_recording_transport
+    ):
+        """``sort_order`` is a string at the helper boundary; the helper
+        converts it to the generated ``ListConversationsSortOrder`` enum."""
+        transport, recorded = make_recording_transport(
+            {"_results": [], "_pagination": {}, "_links": {}}
+        )
+        client = attach_transport(transport)
+
+        await client.conversations.list(sort_order="desc", sort_by="id")
+        assert recorded[0].url.params.get("sort_order") == "desc"
+        assert recorded[0].url.params.get("sort_by") == "id"
+
+    async def test_list_returns_empty_on_no_results(
+        self, attach_transport, make_mock_transport
+    ):
+        client = attach_transport(
+            make_mock_transport({"_pagination": {}, "_links": {}})
+        )
+
+        convs = await client.conversations.list()
+        assert convs == []
+
+    async def test_search_uses_path_query(
+        self, attach_transport, make_recording_transport
+    ):
+        """``search()`` puts the query in the URL path, not the q= param."""
+        transport, recorded = make_recording_transport(
+            {"_results": [], "_pagination": {}, "_links": {}}
+        )
+        client = attach_transport(transport)
+
+        await client.conversations.search("status:open AND tag:vip")
+        # Path-encoded: "status:open AND tag:vip" → status%3Aopen%20AND%20tag%3Avip
+        assert "/conversations/search/" in str(recorded[0].url)
+        assert "status%3Aopen" in str(recorded[0].url)
+        assert "tag%3Avip" in str(recorded[0].url)
+
+    async def test_get_returns_domain_conversation(
+        self, attach_transport, make_mock_transport
+    ):
+        client = attach_transport(
+            make_mock_transport(
+                _conversation_payload(
+                    id="cnv_abc", subject="Order #1234", created_at=1701292639
+                )
+            )
+        )
+
+        conv = await client.conversations.get("cnv_abc")
+        assert isinstance(conv, Conversation)
+        assert conv.id == "cnv_abc"
+        assert conv.subject == "Order #1234"
+        # Unix-seconds → AwareDatetime via the validator on the Pydantic
+        # ``Conversation`` model.
+        assert isinstance(conv.created_at, datetime)
+        assert conv.created_at == datetime.fromtimestamp(1701292639, tz=UTC)
+
+
+# ---------------------------------------------------------------------------
+# list_messages / list_comments — both return raw attrs (no projection)
+# ---------------------------------------------------------------------------
+
+
+class TestListSubResources:
+    async def test_list_messages_returns_raw_attrs(
+        self, attach_transport, make_mock_transport
+    ):
+        # MessageResponse has only optional fields, so a minimal dict works.
+        client = attach_transport(
+            make_mock_transport(
+                {
+                    "_results": [
+                        {"id": "msg_1", "type": "email", "is_inbound": True},
+                        {"id": "msg_2", "type": "email", "is_inbound": False},
+                    ],
+                    "_pagination": {},
+                    "_links": {},
+                }
+            )
+        )
+
+        messages = await client.conversations.list_messages("cnv_abc")
+        assert len(messages) == 2
+        assert messages[0].id == "msg_1"
+
+    async def test_list_messages_unset_results_returns_empty(
+        self, attach_transport, make_mock_transport
+    ):
+        client = attach_transport(
+            make_mock_transport({"_pagination": {}, "_links": {}})
+        )
+        messages = await client.conversations.list_messages("cnv_abc")
+        assert messages == []
+
+    async def test_list_messages_passes_limit_param(
+        self, attach_transport, make_recording_transport
+    ):
+        transport, recorded = make_recording_transport(
+            {"_results": [], "_pagination": {}, "_links": {}}
+        )
+        client = attach_transport(transport)
+        await client.conversations.list_messages("cnv_abc", limit=10)
+        assert recorded[0].url.params.get("limit") == "10"
+
+    async def test_list_comments_returns_raw_attrs(
+        self, attach_transport, make_mock_transport
+    ):
+        client = attach_transport(
+            make_mock_transport(
+                {
+                    "_results": [_comment_payload(id="com_1", body="Note 1")],
+                    "_pagination": {},
+                    "_links": {},
+                }
+            )
+        )
+
+        comments = await client.conversations.list_comments("cnv_abc")
+        assert len(comments) == 1
+        assert comments[0].id == "com_1"
+
+
+# ---------------------------------------------------------------------------
+# Mutations: reply / add_comment / update
+# ---------------------------------------------------------------------------
+
+
+class TestMutations:
+    async def test_reply_sends_required_body_fields(
+        self, attach_transport, make_recording_transport
+    ):
+        # 202 response carries `{status, message_uid}` — both optional but
+        # the parser still calls .json(), so we send a valid empty JSON body.
+        transport, recorded = make_recording_transport({}, status=202)
+        client = attach_transport(transport)
+
+        await client.conversations.reply(
+            "cnv_abc", body="Thanks for reaching out.", author_id="tea_xyz"
+        )
+        assert recorded[0].method == "POST"
+        body = json.loads(recorded[0].content)
+        assert body["body"] == "Thanks for reaching out."
+        assert body["author_id"] == "tea_xyz"
+        assert "subject" not in body  # optional, omitted
+
+    async def test_reply_omits_optional_fields(
+        self, attach_transport, make_recording_transport
+    ):
+        transport, recorded = make_recording_transport({}, status=202)
+        client = attach_transport(transport)
+
+        await client.conversations.reply("cnv_abc", body="Plain")
+        body = json.loads(recorded[0].content)
+        assert body == {"body": "Plain"}
+
+    async def test_reply_includes_recipients_when_provided(
+        self, attach_transport, make_recording_transport
+    ):
+        transport, recorded = make_recording_transport({}, status=202)
+        client = attach_transport(transport)
+
+        await client.conversations.reply(
+            "cnv_abc",
+            body="Hi",
+            to=["a@x.com"],
+            cc=["b@x.com"],
+            bcc=["c@x.com"],
+            subject="Re: Order",
+        )
+        body = json.loads(recorded[0].content)
+        assert body["to"] == ["a@x.com"]
+        assert body["cc"] == ["b@x.com"]
+        assert body["bcc"] == ["c@x.com"]
+        assert body["subject"] == "Re: Order"
+
+    async def test_add_comment_minimum_body(
+        self, attach_transport, make_recording_transport
+    ):
+        # add_comment returns 201 with the created comment; send a minimally
+        # valid CommentResponse-shaped payload.
+        transport, recorded = make_recording_transport(_comment_payload(), status=201)
+        client = attach_transport(transport)
+
+        await client.conversations.add_comment("cnv_abc", body="Internal note")
+        body = json.loads(recorded[0].content)
+        assert body == {"body": "Internal note"}
+
+    async def test_add_comment_with_author_id(
+        self, attach_transport, make_recording_transport
+    ):
+        transport, recorded = make_recording_transport(_comment_payload(), status=201)
+        client = attach_transport(transport)
+
+        await client.conversations.add_comment(
+            "cnv_abc", body="VIP customer", author_id="tea_xyz"
+        )
+        body = json.loads(recorded[0].content)
+        assert body == {"body": "VIP customer", "author_id": "tea_xyz"}
+
+    async def test_update_with_status_serializes_enum(
+        self, attach_transport, make_recording_transport
+    ):
+        """Helper accepts plain string ``"archived"`` and converts to the
+        generated ``UpdateConversationStatus`` enum."""
+        transport, recorded = make_recording_transport(None, status=204)
+        client = attach_transport(transport)
+
+        await client.conversations.update("cnv_abc", status="archived")
+        body = json.loads(recorded[0].content)
+        assert body == {"status": "archived"}
+
+    async def test_update_with_assignee_and_inbox(
+        self, attach_transport, make_recording_transport
+    ):
+        transport, recorded = make_recording_transport(None, status=204)
+        client = attach_transport(transport)
+
+        await client.conversations.update(
+            "cnv_abc", assignee_id="tea_xyz", inbox_id="inb_def"
+        )
+        body = json.loads(recorded[0].content)
+        assert body["assignee_id"] == "tea_xyz"
+        assert body["inbox_id"] == "inb_def"
+        assert "status" not in body
+
+    async def test_update_with_tag_ids_replaces_full_set(
+        self, attach_transport, make_recording_transport
+    ):
+        """Important contrast with ``apply_to_conversation`` /
+        ``remove_from_conversation`` on the tags vertical — ``update(tag_ids=...)``
+        REPLACES the full set."""
+        transport, recorded = make_recording_transport(None, status=204)
+        client = attach_transport(transport)
+
+        await client.conversations.update("cnv_abc", tag_ids=["tag_1", "tag_2"])
+        body = json.loads(recorded[0].content)
+        assert body == {"tag_ids": ["tag_1", "tag_2"]}
+
+    async def test_update_with_no_changes_still_calls_api_with_empty_body(
+        self, attach_transport, make_recording_transport
+    ):
+        """Helper doesn't validate emptiness — that's the MCP tool's job."""
+        transport, recorded = make_recording_transport(None, status=204)
+        client = attach_transport(transport)
+
+        await client.conversations.update("cnv_abc")
+        body = json.loads(recorded[0].content)
+        assert body == {}
+
+
+# ---------------------------------------------------------------------------
+# Property — lazy and cached
+# ---------------------------------------------------------------------------
+
+
+class TestConversationsProperty:
+    def test_property_lazy_caches(self, mock_api_credentials):
+        from frontapp_public_api_client import FrontappClient
+
+        client = FrontappClient(**mock_api_credentials)
+        first = client.conversations
+        second = client.conversations
+        assert first is second

--- a/tests/test_frontapp_client.py
+++ b/tests/test_frontapp_client.py
@@ -5,6 +5,12 @@ order: explicit ``api_key`` param > ``FRONTAPP_API_KEY`` env var (which
 includes ``.env`` via load_dotenv) > ``~/.netrc``. These tests pin that
 ordering and the related config knobs (base_url, timeout, max_retries,
 max_pages).
+
+Note: ``__init__`` calls ``load_dotenv()``, which walks up from CWD
+looking for a ``.env`` file. Tests that need to assert the *absence* of
+an env var (netrc fallback, no-credentials failure) ``chdir`` to a
+fresh ``tmp_path`` first so a contributor's local ``.env`` at the repo
+root doesn't pollute the result.
 """
 
 from __future__ import annotations
@@ -31,6 +37,8 @@ class TestAuthResolutionOrdering:
 
     def test_netrc_used_when_no_param_or_env(self, monkeypatch, tmp_path):
         monkeypatch.delenv("FRONTAPP_API_KEY", raising=False)
+        # Isolate from any local .env at the repo root that load_dotenv() finds.
+        monkeypatch.chdir(tmp_path)
 
         netrc_file = tmp_path / ".netrc"
         netrc_file.write_text(
@@ -42,13 +50,13 @@ class TestAuthResolutionOrdering:
             client = FrontappClient(base_url="https://api2.frontapp.com")
         assert client.token == "netrc-token"
 
-    def test_raises_value_error_when_no_credentials(self, monkeypatch):
+    def test_raises_value_error_when_no_credentials(self, monkeypatch, tmp_path):
         """No param, no env, no .env, no netrc → fail fast."""
         monkeypatch.delenv("FRONTAPP_API_KEY", raising=False)
+        monkeypatch.chdir(tmp_path)
 
-        # Point home at an empty dir so netrc can't find anything.
         with (
-            patch.object(Path, "home", return_value=Path("/nonexistent-test-home-xyz")),
+            patch.object(Path, "home", return_value=tmp_path),
             pytest.raises(ValueError, match="API key required"),
         ):
             FrontappClient()

--- a/tests/test_frontapp_client.py
+++ b/tests/test_frontapp_client.py
@@ -1,0 +1,123 @@
+"""Tests for ``FrontappClient`` initialization — auth resolution + config plumbing.
+
+The client's ``__init__`` resolves credentials from four sources, in this
+order: explicit ``api_key`` param > ``FRONTAPP_API_KEY`` env var (which
+includes ``.env`` via load_dotenv) > ``~/.netrc``. These tests pin that
+ordering and the related config knobs (base_url, timeout, max_retries,
+max_pages).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from frontapp_public_api_client import FrontappClient
+
+
+class TestAuthResolutionOrdering:
+    def test_explicit_api_key_wins_over_env(self, monkeypatch):
+        monkeypatch.setenv("FRONTAPP_API_KEY", "from-env")
+        client = FrontappClient(api_key="from-param")
+        assert client.token == "from-param"
+
+    def test_env_var_used_when_no_param(self, monkeypatch):
+        monkeypatch.setenv("FRONTAPP_API_KEY", "env-token-xyz")
+        client = FrontappClient()
+        assert client.token == "env-token-xyz"
+
+    def test_netrc_used_when_no_param_or_env(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("FRONTAPP_API_KEY", raising=False)
+
+        netrc_file = tmp_path / ".netrc"
+        netrc_file.write_text(
+            "machine api2.frontapp.com login api password netrc-token\n"
+        )
+        netrc_file.chmod(0o600)
+
+        with patch.object(Path, "home", return_value=tmp_path):
+            client = FrontappClient(base_url="https://api2.frontapp.com")
+        assert client.token == "netrc-token"
+
+    def test_raises_value_error_when_no_credentials(self, monkeypatch):
+        """No param, no env, no .env, no netrc → fail fast."""
+        monkeypatch.delenv("FRONTAPP_API_KEY", raising=False)
+
+        # Point home at an empty dir so netrc can't find anything.
+        with (
+            patch.object(Path, "home", return_value=Path("/nonexistent-test-home-xyz")),
+            pytest.raises(ValueError, match="API key required"),
+        ):
+            FrontappClient()
+
+
+class TestBaseUrlOverride:
+    def test_explicit_base_url_wins(self, monkeypatch):
+        monkeypatch.setenv("FRONTAPP_BASE_URL", "https://from-env.invalid")
+        client = FrontappClient(api_key="x", base_url="https://from-param.invalid")
+        # AuthenticatedClient stores _base_url
+        assert client._base_url == "https://from-param.invalid"
+
+    def test_env_base_url_used_when_no_param(self, monkeypatch):
+        monkeypatch.setenv("FRONTAPP_BASE_URL", "https://from-env.invalid")
+        client = FrontappClient(api_key="x")
+        assert client._base_url == "https://from-env.invalid"
+
+    def test_default_base_url_when_no_param_or_env(self, monkeypatch):
+        monkeypatch.delenv("FRONTAPP_BASE_URL", raising=False)
+        client = FrontappClient(api_key="x")
+        assert client._base_url == "https://api2.frontapp.com"
+
+
+class TestConfigPlumbing:
+    def test_max_pages_default(self):
+        client = FrontappClient(api_key="x", base_url="https://test.invalid")
+        assert client.max_pages == 100
+
+    def test_max_pages_override(self):
+        client = FrontappClient(
+            api_key="x", base_url="https://test.invalid", max_pages=5
+        )
+        assert client.max_pages == 5
+
+    def test_logger_defaults_to_module_logger(self):
+        client = FrontappClient(api_key="x", base_url="https://test.invalid")
+        assert isinstance(client.logger, logging.Logger)
+
+    def test_custom_logger_accepted(self):
+        custom = logging.getLogger("custom-test")
+        client = FrontappClient(
+            api_key="x", base_url="https://test.invalid", logger=custom
+        )
+        assert client.logger is custom
+
+    def test_token_kwarg_alias_accepted(self):
+        """Backwards compatibility — older callers passed ``token=`` instead
+        of ``api_key=``."""
+        client = FrontappClient(token="legacy-name")
+        assert client.token == "legacy-name"
+
+    def test_token_and_api_key_both_set_raises(self):
+        with pytest.raises(ValueError, match="Cannot specify both"):
+            FrontappClient(api_key="a", token="b")
+
+
+class TestSslVerifyWarning:
+    def test_verify_false_emits_warning(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            FrontappClient(api_key="x", base_url="https://test.invalid", verify=False)
+        assert any(
+            "SSL certificate verification is disabled" in r.message
+            for r in caplog.records
+        )
+
+    def test_verify_true_no_warning(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            FrontappClient(api_key="x", base_url="https://test.invalid", verify=True)
+        ssl_warnings = [
+            r for r in caplog.records if "SSL certificate verification" in r.message
+        ]
+        assert ssl_warnings == []

--- a/tests/test_rate_limit_retry.py
+++ b/tests/test_rate_limit_retry.py
@@ -1,0 +1,169 @@
+"""Tests for ``RateLimitAwareRetry`` — the load-bearing retry-policy contract.
+
+Per ADR-001 and CLAUDE.md, the contract is:
+
+- POST/PATCH retried on 429 (rate-limit response means "not processed")
+- POST/PATCH NOT retried on 5xx (could have been processed; retry would
+  duplicate the request)
+- Idempotent methods (GET/HEAD/PUT/DELETE/OPTIONS/TRACE) retried on both
+  429 and 5xx
+- Status codes outside the forcelist are never retried
+- ``increment()`` returns a new instance with the current method
+  preserved (so the policy applies consistently across retry attempts)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from frontapp_public_api_client.frontapp_client import RateLimitAwareRetry
+
+
+@pytest.fixture
+def retry() -> RateLimitAwareRetry:
+    """Build a RateLimitAwareRetry with the same config the FrontappClient uses."""
+    return RateLimitAwareRetry(
+        total=3,
+        backoff_factor=1.0,
+        respect_retry_after_header=True,
+        status_forcelist=[429, 502, 503, 504],
+        allowed_methods=[
+            "HEAD",
+            "GET",
+            "PUT",
+            "DELETE",
+            "OPTIONS",
+            "TRACE",
+            "POST",
+            "PATCH",
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# is_retryable_method — accepts everything in allowed_methods, stores method
+# ---------------------------------------------------------------------------
+
+
+class TestIsRetryableMethod:
+    def test_post_in_allowed_methods_returns_true(self, retry):
+        assert retry.is_retryable_method("POST") is True
+        assert retry._current_method == "POST"
+
+    def test_get_returns_true_and_stores_uppercase(self, retry):
+        assert retry.is_retryable_method("get") is True
+        assert retry._current_method == "GET"
+
+    def test_unknown_method_returns_false(self, retry):
+        # Configure a retry with a restrictive allowed_methods list
+        restricted = RateLimitAwareRetry(
+            total=3,
+            status_forcelist=[429],
+            allowed_methods=["GET"],
+        )
+        assert restricted.is_retryable_method("POST") is False
+
+
+# ---------------------------------------------------------------------------
+# is_retryable_status_code — the core matrix from ADR-001
+# ---------------------------------------------------------------------------
+
+
+class TestRetryMatrix:
+    """The contract: 429 retries every method; 5xx only retries idempotent."""
+
+    @pytest.mark.parametrize(
+        "method,status,expected",
+        [
+            # 429 retries every method (rate-limit means "not processed")
+            ("GET", 429, True),
+            ("HEAD", 429, True),
+            ("PUT", 429, True),
+            ("DELETE", 429, True),
+            ("OPTIONS", 429, True),
+            ("TRACE", 429, True),
+            ("POST", 429, True),
+            ("PATCH", 429, True),
+            # 5xx retries ONLY idempotent methods
+            ("GET", 502, True),
+            ("HEAD", 502, True),
+            ("PUT", 503, True),
+            ("DELETE", 504, True),
+            ("OPTIONS", 502, True),
+            ("TRACE", 503, True),
+            # Non-idempotent methods do NOT retry on 5xx
+            ("POST", 502, False),
+            ("POST", 503, False),
+            ("POST", 504, False),
+            ("PATCH", 502, False),
+            ("PATCH", 503, False),
+            ("PATCH", 504, False),
+        ],
+    )
+    def test_retry_matrix(self, retry, method, status, expected):
+        # is_retryable_method primes _current_method (real RetryTransport flow).
+        retry.is_retryable_method(method)
+        assert retry.is_retryable_status_code(status) is expected, (
+            f"{method} on {status} should {'retry' if expected else 'not retry'}"
+        )
+
+    def test_status_outside_forcelist_never_retries(self, retry):
+        """200, 4xx (other than 429), and 1xx/3xx are not in status_forcelist."""
+        retry.is_retryable_method("GET")
+        for status in [200, 201, 204, 301, 302, 400, 401, 403, 404, 422]:
+            assert retry.is_retryable_status_code(status) is False, (
+                f"GET on {status} should not retry"
+            )
+
+    def test_no_method_known_falls_back_to_default(self, retry):
+        """If is_retryable_method wasn't called first, behave permissively
+        (parent's default)."""
+        # Don't call is_retryable_method — _current_method is None
+        retry._current_method = None
+        # 502 is in forcelist; with no method known, returns True (parent default)
+        assert retry.is_retryable_status_code(502) is True
+
+
+# ---------------------------------------------------------------------------
+# increment() — preserves _current_method across retry attempts
+# ---------------------------------------------------------------------------
+
+
+class TestIncrement:
+    def test_increment_preserves_current_method(self, retry):
+        retry.is_retryable_method("POST")
+        assert retry._current_method == "POST"
+
+        next_retry = retry.increment()
+        assert next_retry._current_method == "POST"
+
+    def test_increment_returns_new_instance(self, retry):
+        """Each retry attempt gets its own instance (httpx-retries pattern)."""
+        retry.is_retryable_method("GET")
+        next_retry = retry.increment()
+        assert next_retry is not retry
+
+    def test_increment_returns_correct_subclass(self, retry):
+        """``super().increment()`` cast to RateLimitAwareRetry — must
+        return our subclass to keep the per-method dispatch working
+        across retry chains."""
+        retry.is_retryable_method("POST")
+        next_retry = retry.increment()
+        assert isinstance(next_retry, RateLimitAwareRetry)
+
+
+# ---------------------------------------------------------------------------
+# IDEMPOTENT_METHODS — class constant must include exactly the right set
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotentMethodsConstant:
+    def test_includes_standard_idempotent_methods(self):
+        idempotent = RateLimitAwareRetry.IDEMPOTENT_METHODS
+        for method in ["HEAD", "GET", "PUT", "DELETE", "OPTIONS", "TRACE"]:
+            assert method in idempotent
+
+    def test_excludes_non_idempotent_methods(self):
+        idempotent = RateLimitAwareRetry.IDEMPOTENT_METHODS
+        for method in ["POST", "PATCH", "CONNECT"]:
+            assert method not in idempotent

--- a/tests/test_rate_limit_retry.py
+++ b/tests/test_rate_limit_retry.py
@@ -151,6 +151,16 @@ class TestIncrement:
         next_retry = retry.increment()
         assert isinstance(next_retry, RateLimitAwareRetry)
 
+    def test_method_preserved_across_chained_increments(self, retry):
+        """Real retry chains call increment() repeatedly — every link
+        must keep the original method so the 5xx-vs-429 dispatch stays
+        consistent across attempts (without this, attempt #2 of a POST/5xx
+        could silently switch to permissive mode)."""
+        retry.is_retryable_method("POST")
+        chain = retry.increment().increment().increment()
+        assert chain._current_method == "POST"
+        assert isinstance(chain, RateLimitAwareRetry)
+
 
 # ---------------------------------------------------------------------------
 # IDEMPOTENT_METHODS — class constant must include exactly the right set

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -141,6 +141,12 @@ class TestUnwrap:
             unwrap(_resp(403, parsed=SimpleNamespace()))
         assert "Front API returned status 403" in str(exc.value)
 
+    def test_synthesizes_error_message_when_message_is_empty_string(self):
+        """Empty string is falsy; treated the same as a missing attribute."""
+        with pytest.raises(APIError) as exc:
+            unwrap(_resp(403, parsed=SimpleNamespace(message="")))
+        assert "Front API returned status 403" in str(exc.value)
+
 
 # ---------------------------------------------------------------------------
 # unwrap_as — type-asserted unwrap

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,265 @@
+"""Tests for ``frontapp_public_api_client.utils`` — response unwrapping + typed errors.
+
+The unwrap utilities are the boundary where every helper turns a
+generated ``Response`` into either parsed data or a typed exception.
+The dispatch happens by HTTP status code (per ADR-006), not by parsed
+type — so these tests cover each branch of that dispatch matrix.
+"""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from frontapp_public_api_client.utils import (
+    APIError,
+    AuthenticationError,
+    RateLimitError,
+    ServerError,
+    ValidationError,
+    get_error_message,
+    handle_response,
+    is_error,
+    is_success,
+    unwrap,
+    unwrap_as,
+    unwrap_data,
+)
+
+
+def _resp(status: int, parsed: Any) -> Any:
+    """Build a minimal Response-like object with status_code + parsed.
+
+    Uses ``HTTPStatus`` when the value is a defined member, otherwise the
+    raw int — keeps tests against odd-but-valid 2xx codes (e.g. 299) working.
+    """
+    try:
+        code: Any = HTTPStatus(status)
+    except ValueError:
+        code = status
+    return SimpleNamespace(status_code=code, parsed=parsed)
+
+
+# ---------------------------------------------------------------------------
+# is_success / is_error
+# ---------------------------------------------------------------------------
+
+
+class TestStatusPredicates:
+    @pytest.mark.parametrize("status", [200, 201, 202, 204, 299])
+    def test_is_success_true_for_2xx(self, status):
+        assert is_success(_resp(status, parsed={})) is True
+
+    @pytest.mark.parametrize("status", [400, 401, 422, 429, 500, 502])
+    def test_is_success_false_for_non_2xx(self, status):
+        assert is_success(_resp(status, parsed={})) is False
+
+    @pytest.mark.parametrize("status", [400, 401, 422, 429, 500, 502])
+    def test_is_error_true_for_4xx_5xx(self, status):
+        assert is_error(_resp(status, parsed={})) is True
+
+    @pytest.mark.parametrize("status", [200, 201, 204, 301, 302])
+    def test_is_error_false_for_2xx_3xx(self, status):
+        assert is_error(_resp(status, parsed={})) is False
+
+
+# ---------------------------------------------------------------------------
+# unwrap — typed-error dispatch by status code
+# ---------------------------------------------------------------------------
+
+
+class TestUnwrap:
+    def test_returns_parsed_on_2xx(self):
+        body = {"id": "cnv_a"}
+        result = unwrap(_resp(200, parsed=body))
+        assert result is body
+
+    def test_raises_authentication_error_on_401(self):
+        with pytest.raises(AuthenticationError) as exc:
+            unwrap(_resp(401, parsed=SimpleNamespace(message="bad token")))
+        assert exc.value.status_code == 401
+        assert "bad token" in str(exc.value)
+
+    def test_raises_validation_error_on_422(self):
+        parsed = SimpleNamespace(message="invalid", errors={"name": ["required"]})
+        with pytest.raises(ValidationError) as exc:
+            unwrap(_resp(422, parsed=parsed))
+        assert exc.value.status_code == 422
+        assert exc.value.validation_errors == {"name": ["required"]}
+
+    def test_validation_error_str_includes_field_errors(self):
+        parsed = SimpleNamespace(
+            message="invalid",
+            errors={"name": ["required"], "email": ["bad format", "too long"]},
+        )
+        with pytest.raises(ValidationError) as exc:
+            unwrap(_resp(422, parsed=parsed))
+        formatted = str(exc.value)
+        assert "name: required" in formatted
+        assert "email: bad format; too long" in formatted
+
+    def test_raises_rate_limit_error_on_429(self):
+        with pytest.raises(RateLimitError) as exc:
+            unwrap(_resp(429, parsed=SimpleNamespace(message="slow down")))
+        assert exc.value.status_code == 429
+
+    @pytest.mark.parametrize("status", [500, 502, 503, 504])
+    def test_raises_server_error_on_5xx(self, status):
+        with pytest.raises(ServerError) as exc:
+            unwrap(_resp(status, parsed=SimpleNamespace(message="oops")))
+        assert exc.value.status_code == status
+
+    @pytest.mark.parametrize("status", [400, 403, 404, 409])
+    def test_raises_generic_api_error_on_other_4xx(self, status):
+        with pytest.raises(APIError) as exc:
+            unwrap(_resp(status, parsed=SimpleNamespace(message="nope")))
+        assert exc.value.status_code == status
+        # Not a more-specific subclass.
+        assert not isinstance(
+            exc.value,
+            (AuthenticationError, ValidationError, RateLimitError, ServerError),
+        )
+
+    def test_raises_when_parsed_is_none_and_raise_on_error(self):
+        with pytest.raises(APIError) as exc:
+            unwrap(_resp(404, parsed=None))
+        assert "No parsed response data" in str(exc.value)
+
+    def test_returns_none_when_parsed_is_none_and_no_raise(self):
+        assert unwrap(_resp(404, parsed=None), raise_on_error=False) is None
+
+    def test_returns_none_for_error_when_no_raise(self):
+        assert (
+            unwrap(_resp(429, parsed=SimpleNamespace()), raise_on_error=False) is None
+        )
+
+    def test_synthesizes_error_message_when_parsed_has_no_message(self):
+        with pytest.raises(APIError) as exc:
+            unwrap(_resp(403, parsed=SimpleNamespace()))
+        assert "Front API returned status 403" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# unwrap_as — type-asserted unwrap
+# ---------------------------------------------------------------------------
+
+
+class TestUnwrapAs:
+    def test_returns_typed_value_when_match(self):
+        class Foo:
+            pass
+
+        foo = Foo()
+        result = unwrap_as(_resp(200, parsed=foo), Foo)
+        assert result is foo
+
+    def test_raises_type_error_on_mismatch(self):
+        class Foo:
+            pass
+
+        with pytest.raises(TypeError, match="Expected Foo, got dict"):
+            unwrap_as(_resp(200, parsed={}), Foo)
+
+    def test_returns_none_when_no_raise_and_none_parsed(self):
+        class Foo:
+            pass
+
+        assert unwrap_as(_resp(404, parsed=None), Foo, raise_on_error=False) is None
+
+
+# ---------------------------------------------------------------------------
+# unwrap_data — list-shape extraction
+# ---------------------------------------------------------------------------
+
+
+class TestUnwrapData:
+    def test_returns_list_when_parsed_is_list(self):
+        result = unwrap_data(_resp(200, parsed=[1, 2, 3]))
+        assert result == [1, 2, 3]
+
+    def test_extracts_data_attribute(self):
+        result = unwrap_data(_resp(200, parsed=SimpleNamespace(data=["a", "b"])))
+        assert result == ["a", "b"]
+
+    def test_returns_default_when_parsed_is_none_no_raise(self):
+        assert (
+            unwrap_data(_resp(404, parsed=None), raise_on_error=False, default=[]) == []
+        )
+
+    def test_returns_default_on_error_when_no_raise(self):
+        result = unwrap_data(
+            _resp(429, parsed=SimpleNamespace()),
+            raise_on_error=False,
+            default=[1, 2],
+        )
+        assert result == [1, 2]
+
+    def test_raises_on_error_by_default(self):
+        with pytest.raises(RateLimitError):
+            unwrap_data(_resp(429, parsed=SimpleNamespace(message="slow")))
+
+
+# ---------------------------------------------------------------------------
+# get_error_message
+# ---------------------------------------------------------------------------
+
+
+class TestGetErrorMessage:
+    def test_returns_none_for_2xx(self):
+        assert (
+            get_error_message(_resp(200, parsed=SimpleNamespace(message="x"))) is None
+        )
+
+    def test_returns_none_when_parsed_is_none(self):
+        assert get_error_message(_resp(404, parsed=None)) is None
+
+    def test_returns_message_string_when_present(self):
+        result = get_error_message(
+            _resp(401, parsed=SimpleNamespace(message="bad token"))
+        )
+        assert result == "bad token"
+
+    def test_returns_none_when_message_attribute_missing(self):
+        assert get_error_message(_resp(401, parsed=SimpleNamespace())) is None
+
+    def test_returns_none_when_message_is_empty_string(self):
+        assert get_error_message(_resp(401, parsed=SimpleNamespace(message=""))) is None
+
+
+# ---------------------------------------------------------------------------
+# handle_response — callback-style dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestHandleResponse:
+    def test_calls_on_success_with_parsed_data(self):
+        body = {"id": "cnv_a"}
+        result = handle_response(
+            _resp(200, parsed=body), on_success=lambda d: ("ok", d)
+        )
+        assert result == ("ok", body)
+
+    def test_returns_data_when_no_on_success(self):
+        body = {"id": "cnv_a"}
+        result = handle_response(_resp(200, parsed=body))
+        assert result is body
+
+    def test_calls_on_error_for_4xx(self):
+        result = handle_response(
+            _resp(404, parsed=SimpleNamespace(message="not found")),
+            on_error=lambda e: ("err", e.status_code),
+        )
+        assert result == ("err", 404)
+
+    def test_returns_none_on_error_when_no_callback(self):
+        assert handle_response(_resp(404, parsed=SimpleNamespace())) is None
+
+    def test_raises_when_raise_on_error_true(self):
+        with pytest.raises(APIError):
+            handle_response(
+                _resp(429, parsed=SimpleNamespace(message="slow")),
+                raise_on_error=True,
+            )


### PR DESCRIPTION
Closes #7.

Closes the v0.1.0 gap noted in the issue: the conversations helper, MCP tools, and the load-bearing \`RateLimitAwareRetry\` class shipped without any real tests. **152 new tests added (173 → 325).**

## Conftest fixtures (lifted to shared modules)

- \`make_mock_transport(payload, status=200)\` — factory for an \`httpx.MockTransport\` returning a fixed payload (None body for 204).
- \`make_recording_transport(payload, status=200)\` — same, but records every request so tests can assert URL/method/body.
- \`attach_transport(transport)\` — install a mock transport on a fresh \`FrontappClient\`. Replaces the per-test \`FrontappClient\` construction + \`set_async_httpx_client\` boilerplate.
- \`mcp_tool_capture(register_fn)\` — registers a tools module against a fake \`FastMCP\` and returns the captured \`{name: callable}\` dict.

Existing per-vertical test files (test_contacts/drafts/messages/tags/inboxes + their \`*_tools.py\` counterparts) still define their own copies. Migration is a follow-up cleanup PR — refactoring 10 working test files in this PR risks regression for marginal gain.

## New test files

| File | Tests | Covers |
|---|---|---|
| \`tests/test_conversations.py\` | 24 | Conversations helper end-to-end: list/search/get/list_messages/list_comments + reply/add_comment/update + \`_extract_page_token\` parser |
| \`tests/test_conversation_domain.py\` | 14 | \`Conversation\` Pydantic: epoch→AwareDatetime validator, extra=ignore, frozen=True, nested TagSummary/RecipientSummary/TeammateSummary projection |
| \`frontapp_mcp_server/tests/test_conversations_tools.py\` | 15 | Every MCP conversations tool: preview/decline/confirm + no-changes guard + truncation behavior |
| \`tests/test_rate_limit_retry.py\` | 31 | Every branch of the retry matrix from ADR-001: POST retried on 429 ✓, POST not retried on 5xx ✗, GET/PUT/DELETE retried on both ✓, status outside forcelist never retries, \`increment()\` preserves \`_current_method\` across chains |
| \`tests/test_frontapp_client.py\` | 15 | Auth resolution ordering (param > FRONTAPP_API_KEY env > ~/.netrc), base_url override, max_pages plumbing, token-kwarg alias, SSL-verify warning |
| \`tests/test_utils.py\` | 58 | unwrap/unwrap_as/unwrap_data typed-error dispatch by status code, ValidationError formatting, is_success/is_error predicates, get_error_message, handle_response callback dispatch |

## Coverage status

- \`helpers/conversations.py\`: **93%** ✓ (was 0%)
- \`frontapp_mcp/tools/conversations.py\`: **100%** ✓ (was 0%)
- \`domain/conversation.py\`: **100%** ✓
- \`utils.py\`: **95%** ✓ (was 46%)
- \`frontapp_client.py\`: **37%** — auth/config layer is now well-covered; the transport-stack machinery (\`ResilientAsyncTransport\`, observability hooks, signal handling) needs end-to-end integration tests via MockTransport. Tracked as follow-up.

## Test plan

- [x] \`uv run poe test\` runs 325 tests, all pass (was 173)
- [x] \`uv run poe full-check\` exits 0
- [x] /simplify pass applied — fixed: load_dotenv pollution in netrc tests (\`monkeypatch.chdir(tmp_path)\`), tightened mock-only test to assert \`.to_dict()\` was called, added empty-string message test, added chained-increment test, merged a redundant extra-fields test

🤖 Generated with [Claude Code](https://claude.com/claude-code)