### PR TITLE
chore(tests): lift mock_transport / mcp_tool_capture to shared fixtures

### DIFF
--- a/frontapp_mcp_server/tests/test_contacts_tools.py
+++ b/frontapp_mcp_server/tests/test_contacts_tools.py
@@ -13,27 +13,9 @@ from frontapp_public_api_client.domain import Contact
 from .conftest import create_mock_context
 
 
-def _make_mcp() -> tuple[object, dict]:
-    captured: dict[str, object] = {}
-
-    class FakeMCP:
-        def tool(self, **kwargs: object):
-            name = kwargs["name"]
-
-            def decorator(fn):
-                captured[name] = fn
-                return fn
-
-            return decorator
-
-    return FakeMCP(), captured
-
-
 @pytest.fixture
-def contacts_tools() -> dict[str, object]:
-    mcp, captured = _make_mcp()
-    register_tools(mcp)  # type: ignore[arg-type]
-    return captured
+def contacts_tools(mcp_tool_capture) -> dict[str, object]:
+    return mcp_tool_capture(register_tools)
 
 
 # ---------------------------------------------------------------------------

--- a/frontapp_mcp_server/tests/test_drafts_tools.py
+++ b/frontapp_mcp_server/tests/test_drafts_tools.py
@@ -19,29 +19,10 @@ from frontapp_public_api_client.domain import Draft
 from .conftest import create_mock_context
 
 
-def _make_mcp() -> tuple[object, dict]:
-    """Build a fake FastMCP that captures registered tool functions by name."""
-    captured: dict[str, object] = {}
-
-    class FakeMCP:
-        def tool(self, **kwargs: object):
-            name = kwargs["name"]
-
-            def decorator(fn):
-                captured[name] = fn
-                return fn
-
-            return decorator
-
-    return FakeMCP(), captured
-
-
 @pytest.fixture
-def drafts_tools() -> dict[str, object]:
+def drafts_tools(mcp_tool_capture) -> dict[str, object]:
     """Register all draft tools and return the captured function dict."""
-    mcp, captured = _make_mcp()
-    register_tools(mcp)  # type: ignore[arg-type]
-    return captured
+    return mcp_tool_capture(register_tools)
 
 
 # ---------------------------------------------------------------------------

--- a/frontapp_mcp_server/tests/test_inboxes_tools.py
+++ b/frontapp_mcp_server/tests/test_inboxes_tools.py
@@ -13,27 +13,9 @@ from frontapp_public_api_client.domain import Inbox
 from .conftest import create_mock_context
 
 
-def _make_mcp() -> tuple[object, dict]:
-    captured: dict[str, object] = {}
-
-    class FakeMCP:
-        def tool(self, **kwargs: object):
-            name = kwargs["name"]
-
-            def decorator(fn):
-                captured[name] = fn
-                return fn
-
-            return decorator
-
-    return FakeMCP(), captured
-
-
 @pytest.fixture
-def inboxes_tools() -> dict[str, object]:
-    mcp, captured = _make_mcp()
-    register_tools(mcp)  # type: ignore[arg-type]
-    return captured
+def inboxes_tools(mcp_tool_capture) -> dict[str, object]:
+    return mcp_tool_capture(register_tools)
 
 
 # ---------------------------------------------------------------------------

--- a/frontapp_mcp_server/tests/test_messages_tools.py
+++ b/frontapp_mcp_server/tests/test_messages_tools.py
@@ -13,27 +13,9 @@ from frontapp_public_api_client.models.seen_receipt_response import SeenReceiptR
 from .conftest import create_mock_context
 
 
-def _make_mcp() -> tuple[object, dict]:
-    captured: dict[str, object] = {}
-
-    class FakeMCP:
-        def tool(self, **kwargs: object):
-            name = kwargs["name"]
-
-            def decorator(fn):
-                captured[name] = fn
-                return fn
-
-            return decorator
-
-    return FakeMCP(), captured
-
-
 @pytest.fixture
-def messages_tools() -> dict[str, object]:
-    mcp, captured = _make_mcp()
-    register_tools(mcp)  # type: ignore[arg-type]
-    return captured
+def messages_tools(mcp_tool_capture) -> dict[str, object]:
+    return mcp_tool_capture(register_tools)
 
 
 # ---------------------------------------------------------------------------

--- a/frontapp_mcp_server/tests/test_tags_tools.py
+++ b/frontapp_mcp_server/tests/test_tags_tools.py
@@ -13,27 +13,9 @@ from frontapp_public_api_client.domain import Tag
 from .conftest import create_mock_context
 
 
-def _make_mcp() -> tuple[object, dict]:
-    captured: dict[str, object] = {}
-
-    class FakeMCP:
-        def tool(self, **kwargs: object):
-            name = kwargs["name"]
-
-            def decorator(fn):
-                captured[name] = fn
-                return fn
-
-            return decorator
-
-    return FakeMCP(), captured
-
-
 @pytest.fixture
-def tags_tools() -> dict[str, object]:
-    mcp, captured = _make_mcp()
-    register_tools(mcp)  # type: ignore[arg-type]
-    return captured
+def tags_tools(mcp_tool_capture) -> dict[str, object]:
+    return mcp_tool_capture(register_tools)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_contacts.py
+++ b/tests/test_contacts.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-import httpx
+import json
+
 import pydantic
 import pytest
 
@@ -101,49 +102,21 @@ class TestContactNoteDomain:
 
 
 class TestContactsHelper:
-    """Helper-level integration via httpx.MockTransport.
+    """Helper-level integration via the shared transport fixtures."""
 
-    Mirrors tests/test_drafts.py — uses set_async_httpx_client to inject
-    a MockTransport so we exercise the full request-construction path
-    without hitting the network.
-    """
-
-    def _mock_response(
-        self, payload: dict | list, status: int = 200
-    ) -> httpx.MockTransport:
-        def handler(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(status, json=payload)
-
-        return httpx.MockTransport(handler)
-
-    def _mock_recording(
-        self, payload: dict | list, status: int = 200
-    ) -> tuple[httpx.MockTransport, list[httpx.Request]]:
-        recorded: list[httpx.Request] = []
-
-        def handler(request: httpx.Request) -> httpx.Response:
-            recorded.append(request)
-            return httpx.Response(status, json=payload)
-
-        return httpx.MockTransport(handler), recorded
-
-    async def test_list_unwraps_field_results(self, mock_api_credentials):
-        from frontapp_public_api_client import FrontappClient
-
-        client = FrontappClient(**mock_api_credentials)
-        client.set_async_httpx_client(
-            httpx.AsyncClient(
-                transport=self._mock_response(
-                    {
-                        "_results": [
-                            {"id": "crd_1", "name": "Alice"},
-                            {"id": "crd_2", "name": "Bob"},
-                        ],
-                        "_pagination": {},
-                        "_links": {},
-                    }
-                ),
-                base_url=mock_api_credentials["base_url"],
+    async def test_list_unwraps_field_results(
+        self, attach_transport, make_mock_transport
+    ):
+        client = attach_transport(
+            make_mock_transport(
+                {
+                    "_results": [
+                        {"id": "crd_1", "name": "Alice"},
+                        {"id": "crd_2", "name": "Bob"},
+                    ],
+                    "_pagination": {},
+                    "_links": {},
+                }
             )
         )
 
@@ -151,37 +124,28 @@ class TestContactsHelper:
         assert [c.id for c in contacts] == ["crd_1", "crd_2"]
         assert all(isinstance(c, Contact) for c in contacts)
 
-    async def test_search_by_email_passes_q_param(self, mock_api_credentials):
-        from frontapp_public_api_client import FrontappClient
-
-        client = FrontappClient(**mock_api_credentials)
-        transport, recorded = self._mock_recording(
+    async def test_search_by_email_passes_q_param(
+        self, attach_transport, make_recording_transport
+    ):
+        transport, recorded = make_recording_transport(
             {"_results": [], "_pagination": {}, "_links": {}}
         )
-        client.set_async_httpx_client(
-            httpx.AsyncClient(
-                transport=transport, base_url=mock_api_credentials["base_url"]
-            )
-        )
+        client = attach_transport(transport)
 
         await client.contacts.search_by_email("a@example.com")
         assert len(recorded) == 1
         assert recorded[0].url.params.get("q") == "a@example.com"
 
-    async def test_get_returns_domain_contact(self, mock_api_credentials):
-        from frontapp_public_api_client import FrontappClient
-
-        client = FrontappClient(**mock_api_credentials)
-        client.set_async_httpx_client(
-            httpx.AsyncClient(
-                transport=self._mock_response(
-                    {
-                        "id": "crd_abc",
-                        "name": "Alice",
-                        "handles": [{"handle": "a@example.com", "source": "email"}],
-                    }
-                ),
-                base_url=mock_api_credentials["base_url"],
+    async def test_get_returns_domain_contact(
+        self, attach_transport, make_mock_transport
+    ):
+        client = attach_transport(
+            make_mock_transport(
+                {
+                    "id": "crd_abc",
+                    "name": "Alice",
+                    "handles": [{"handle": "a@example.com", "source": "email"}],
+                }
             )
         )
 
@@ -190,18 +154,13 @@ class TestContactsHelper:
         assert contact.id == "crd_abc"
         assert contact.handles[0].handle == "a@example.com"
 
-    async def test_create_sends_handles_and_returns_contact(self, mock_api_credentials):
-        from frontapp_public_api_client import FrontappClient
-
-        client = FrontappClient(**mock_api_credentials)
-        transport, recorded = self._mock_recording(
+    async def test_create_sends_handles_and_returns_contact(
+        self, attach_transport, make_recording_transport
+    ):
+        transport, recorded = make_recording_transport(
             {"id": "crd_new", "name": "Alice", "handles": []}, status=201
         )
-        client.set_async_httpx_client(
-            httpx.AsyncClient(
-                transport=transport, base_url=mock_api_credentials["base_url"]
-            )
-        )
+        client = attach_transport(transport)
 
         contact = await client.contacts.create(
             handles=[{"handle": "a@example.com", "source": "email"}],
@@ -209,127 +168,83 @@ class TestContactsHelper:
         )
         assert isinstance(contact, Contact)
         assert contact.id == "crd_new"
-        # Body should round-trip the handle structure.
-        import json
-
         body = json.loads(recorded[0].content)
         assert body["handles"] == [{"handle": "a@example.com", "source": "email"}]
         assert body["name"] == "Alice"
 
-    async def test_create_handles_tuple_form(self, mock_api_credentials):
-        from frontapp_public_api_client import FrontappClient
-
-        client = FrontappClient(**mock_api_credentials)
-        transport, recorded = self._mock_recording({"id": "crd_new"}, status=201)
-        client.set_async_httpx_client(
-            httpx.AsyncClient(
-                transport=transport, base_url=mock_api_credentials["base_url"]
-            )
-        )
+    async def test_create_handles_tuple_form(
+        self, attach_transport, make_recording_transport
+    ):
+        transport, recorded = make_recording_transport({"id": "crd_new"}, status=201)
+        client = attach_transport(transport)
 
         await client.contacts.create(
             handles=[("a@example.com", "email"), ("+15551234", "phone")]
         )
-        import json
-
         body = json.loads(recorded[0].content)
         assert len(body["handles"]) == 2
 
-    async def test_create_handles_rejects_bad_shape(self, mock_api_credentials):
-        from frontapp_public_api_client import FrontappClient
-
-        client = FrontappClient(**mock_api_credentials)
-        client.set_async_httpx_client(
-            httpx.AsyncClient(
-                transport=self._mock_response({}),
-                base_url=mock_api_credentials["base_url"],
-            )
-        )
+    async def test_create_handles_rejects_bad_shape(
+        self, attach_transport, make_mock_transport
+    ):
+        client = attach_transport(make_mock_transport({}))
 
         with pytest.raises(TypeError):
             await client.contacts.create(handles=["just a string"])
 
-    async def test_update_skips_handles(self, mock_api_credentials):
-        from frontapp_public_api_client import FrontappClient
-
-        client = FrontappClient(**mock_api_credentials)
-        transport, recorded = self._mock_recording({}, status=204)
-        client.set_async_httpx_client(
-            httpx.AsyncClient(
-                transport=transport, base_url=mock_api_credentials["base_url"]
-            )
-        )
+    async def test_update_skips_handles(
+        self, attach_transport, make_recording_transport
+    ):
+        transport, recorded = make_recording_transport({}, status=204)
+        client = attach_transport(transport)
 
         success = await client.contacts.update(
             "crd_abc", name="Alice Updated", description="VIP"
         )
         assert success is True
-        import json
-
         body = json.loads(recorded[0].content)
         assert body == {"name": "Alice Updated", "description": "VIP"}
         assert "handles" not in body
 
-    async def test_merge_returns_contact(self, mock_api_credentials):
-        from frontapp_public_api_client import FrontappClient
-
-        client = FrontappClient(**mock_api_credentials)
-        transport, recorded = self._mock_recording(
+    async def test_merge_returns_contact(
+        self, attach_transport, make_recording_transport
+    ):
+        transport, recorded = make_recording_transport(
             {"id": "crd_target", "name": "Merged"}, status=200
         )
-        client.set_async_httpx_client(
-            httpx.AsyncClient(
-                transport=transport, base_url=mock_api_credentials["base_url"]
-            )
-        )
+        client = attach_transport(transport)
 
         contact = await client.contacts.merge(
             contact_ids=["crd_1", "crd_2"], target_contact_id="crd_target"
         )
         assert isinstance(contact, Contact)
         assert contact.id == "crd_target"
-        import json
-
         body = json.loads(recorded[0].content)
         assert body["contact_ids"] == ["crd_1", "crd_2"]
         assert body["target_contact_id"] == "crd_target"
 
-    async def test_add_handle_serializes_source_enum(self, mock_api_credentials):
-        from frontapp_public_api_client import FrontappClient
-
-        client = FrontappClient(**mock_api_credentials)
-        transport, recorded = self._mock_recording({}, status=204)
-        client.set_async_httpx_client(
-            httpx.AsyncClient(
-                transport=transport, base_url=mock_api_credentials["base_url"]
-            )
-        )
+    async def test_add_handle_serializes_source_enum(
+        self, attach_transport, make_recording_transport
+    ):
+        transport, recorded = make_recording_transport({}, status=204)
+        client = attach_transport(transport)
 
         success = await client.contacts.add_handle(
             "crd_abc", handle="b@example.com", source="email"
         )
         assert success is True
-        import json
-
         body = json.loads(recorded[0].content)
         assert body == {"handle": "b@example.com", "source": "email"}
 
-    async def test_delete_handle_with_force(self, mock_api_credentials):
-        from frontapp_public_api_client import FrontappClient
-
-        client = FrontappClient(**mock_api_credentials)
-        transport, recorded = self._mock_recording({}, status=204)
-        client.set_async_httpx_client(
-            httpx.AsyncClient(
-                transport=transport, base_url=mock_api_credentials["base_url"]
-            )
-        )
+    async def test_delete_handle_with_force(
+        self, attach_transport, make_recording_transport
+    ):
+        transport, recorded = make_recording_transport({}, status=204)
+        client = attach_transport(transport)
 
         await client.contacts.delete_handle(
             "crd_abc", handle="b@example.com", source="email", force=True
         )
-        import json
-
         body = json.loads(recorded[0].content)
         assert body == {
             "handle": "b@example.com",
@@ -337,58 +252,39 @@ class TestContactsHelper:
             "force": True,
         }
 
-    async def test_add_note_requires_author(self, mock_api_credentials):
-        from frontapp_public_api_client import FrontappClient
-
-        client = FrontappClient(**mock_api_credentials)
+    async def test_add_note_requires_author(
+        self, attach_transport, make_recording_transport
+    ):
         # Status 200 (not 201) skips _parse_response so we don't have to mock
         # the full nested ContactNoteResponses shape; this test asserts the
         # request body only.
-        transport, recorded = self._mock_recording({}, status=200)
-        client.set_async_httpx_client(
-            httpx.AsyncClient(
-                transport=transport, base_url=mock_api_credentials["base_url"]
-            )
-        )
+        transport, recorded = make_recording_transport({}, status=200)
+        client = attach_transport(transport)
 
         await client.contacts.add_note(
             "crd_abc", body="VIP customer", author_id="tea_xyz"
         )
-        import json
-
         body = json.loads(recorded[0].content)
         assert body == {"author_id": "tea_xyz", "body": "VIP customer"}
 
-    async def test_list_notes_handles_202_status(self, mock_api_credentials):
+    async def test_list_notes_handles_202_status(
+        self, attach_transport, make_mock_transport
+    ):
         """list_notes returns HTTP 202, not 200 — verify unwrap dispatches correctly."""
-        from frontapp_public_api_client import FrontappClient
-
-        client = FrontappClient(**mock_api_credentials)
-        client.set_async_httpx_client(
-            httpx.AsyncClient(
-                transport=self._mock_response(
-                    {"_results": [], "_pagination": {}, "_links": {}},
-                    status=202,
-                ),
-                base_url=mock_api_credentials["base_url"],
+        client = attach_transport(
+            make_mock_transport(
+                {"_results": [], "_pagination": {}, "_links": {}},
+                status=202,
             )
         )
 
         notes = await client.contacts.list_notes("crd_abc")
         assert notes == []
 
-    async def test_delete_returns_true_on_204(self, mock_api_credentials):
-        from frontapp_public_api_client import FrontappClient
-
-        client = FrontappClient(**mock_api_credentials)
-        client.set_async_httpx_client(
-            httpx.AsyncClient(
-                transport=httpx.MockTransport(
-                    lambda req: httpx.Response(204, content=b"")
-                ),
-                base_url=mock_api_credentials["base_url"],
-            )
-        )
+    async def test_delete_returns_true_on_204(
+        self, attach_transport, make_mock_transport
+    ):
+        client = attach_transport(make_mock_transport(None, status=204))
 
         success = await client.contacts.delete("crd_abc")
         assert success is True

--- a/tests/test_drafts.py
+++ b/tests/test_drafts.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-import httpx
 import pydantic
 import pytest
 
@@ -98,52 +97,24 @@ class TestDraftDomain:
 
 
 class TestDraftsHelper:
-    """Helper-level integration via httpx.MockTransport.
-
-    The drafts vertical is the first to add helper tests under tests/; the
-    conversations vertical landed without unit tests. Future verticals should
-    follow this pattern.
-    """
-
-    def _mock_response(
-        self, payload: list[dict] | dict, status: int = 200
-    ) -> httpx.MockTransport:
-        """Build a MockTransport that returns ``payload`` for every request."""
-
-        def handler(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(status, json=payload)
-
-        return httpx.MockTransport(handler)
-
-    @pytest.fixture
-    def drafts_client(self, mock_api_credentials):
-        """A FrontappClient whose transport will be patched per test."""
-        from frontapp_public_api_client import FrontappClient
-
-        return FrontappClient(**mock_api_credentials)
+    """Helper-level integration via the shared transport fixtures."""
 
     async def test_list_for_conversation_unwraps_field_results(
-        self, mock_api_credentials
+        self, attach_transport, make_mock_transport
     ):
         """list_conversation_drafts returns the standard field_results wrapper
         of ListConversationDraftsResponse200, like every other Front list
         endpoint."""
-        from frontapp_public_api_client import FrontappClient
-
-        client = FrontappClient(**mock_api_credentials)
-        client.set_async_httpx_client(
-            httpx.AsyncClient(
-                transport=self._mock_response(
-                    {
-                        "_results": [
-                            {"id": "msg_1", "type": "email", "is_inbound": False},
-                            {"id": "msg_2", "type": "email", "is_inbound": False},
-                        ],
-                        "_pagination": {},
-                        "_links": {},
-                    }
-                ),
-                base_url=mock_api_credentials["base_url"],
+        client = attach_transport(
+            make_mock_transport(
+                {
+                    "_results": [
+                        {"id": "msg_1", "type": "email", "is_inbound": False},
+                        {"id": "msg_2", "type": "email", "is_inbound": False},
+                    ],
+                    "_pagination": {},
+                    "_links": {},
+                }
             )
         )
 
@@ -151,41 +122,31 @@ class TestDraftsHelper:
         assert len(drafts) == 2
         assert [d.id for d in drafts] == ["msg_1", "msg_2"]
 
-    async def test_list_for_conversation_empty(self, mock_api_credentials):
-        from frontapp_public_api_client import FrontappClient
-
-        client = FrontappClient(**mock_api_credentials)
-        client.set_async_httpx_client(
-            httpx.AsyncClient(
-                transport=self._mock_response(
-                    {"_results": [], "_pagination": {}, "_links": {}}
-                ),
-                base_url=mock_api_credentials["base_url"],
-            )
+    async def test_list_for_conversation_empty(
+        self, attach_transport, make_mock_transport
+    ):
+        client = attach_transport(
+            make_mock_transport({"_results": [], "_pagination": {}, "_links": {}})
         )
 
         drafts = await client.drafts.list_for_conversation("cnv_abc")
         assert drafts == []
 
-    async def test_create_on_channel_returns_domain_draft(self, mock_api_credentials):
-        from frontapp_public_api_client import FrontappClient
-
-        client = FrontappClient(**mock_api_credentials)
-        client.set_async_httpx_client(
-            httpx.AsyncClient(
-                transport=self._mock_response(
-                    {
-                        "id": "msg_new",
-                        "type": "email",
-                        "is_inbound": False,
-                        "draft_mode": "shared",
-                        "subject": "Hello",
-                        "body": "<p>Hi there</p>",
-                        "blurb": "Hi there",
-                        "created_at": 1701292639,
-                    }
-                ),
-                base_url=mock_api_credentials["base_url"],
+    async def test_create_on_channel_returns_domain_draft(
+        self, attach_transport, make_mock_transport
+    ):
+        client = attach_transport(
+            make_mock_transport(
+                {
+                    "id": "msg_new",
+                    "type": "email",
+                    "is_inbound": False,
+                    "draft_mode": "shared",
+                    "subject": "Hello",
+                    "body": "<p>Hi there</p>",
+                    "blurb": "Hi there",
+                    "created_at": 1701292639,
+                }
             )
         )
 
@@ -201,18 +162,10 @@ class TestDraftsHelper:
         # Unix-seconds → AwareDatetime via the validator.
         assert isinstance(draft.created_at, datetime)
 
-    async def test_delete_returns_true_on_204(self, mock_api_credentials):
-        from frontapp_public_api_client import FrontappClient
-
-        client = FrontappClient(**mock_api_credentials)
-        client.set_async_httpx_client(
-            httpx.AsyncClient(
-                transport=httpx.MockTransport(
-                    lambda req: httpx.Response(204, content=b"")
-                ),
-                base_url=mock_api_credentials["base_url"],
-            )
-        )
+    async def test_delete_returns_true_on_204(
+        self, attach_transport, make_mock_transport
+    ):
+        client = attach_transport(make_mock_transport(None, status=204))
 
         success = await client.drafts.delete("msg_abc")
         assert success is True

--- a/tests/test_inboxes.py
+++ b/tests/test_inboxes.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 
-import httpx
 import pydantic
 import pytest
 
@@ -52,46 +51,19 @@ class TestInboxDomain:
 
 
 class TestInboxesHelper:
-    def _mock_response(
-        self, payload: dict | list | None, status: int = 200
-    ) -> httpx.MockTransport:
-        def handler(_request: httpx.Request) -> httpx.Response:
-            if payload is None:
-                return httpx.Response(status, content=b"")
-            return httpx.Response(status, json=payload)
-
-        return httpx.MockTransport(handler)
-
-    def _mock_recording(
-        self, payload: dict | list | None, status: int = 200
-    ) -> tuple[httpx.MockTransport, list[httpx.Request]]:
-        recorded: list[httpx.Request] = []
-
-        def handler(request: httpx.Request) -> httpx.Response:
-            recorded.append(request)
-            if payload is None:
-                return httpx.Response(status, content=b"")
-            return httpx.Response(status, json=payload)
-
-        return httpx.MockTransport(handler), recorded
-
-    async def test_list_returns_domain_inboxes(self, mock_api_credentials):
-        from frontapp_public_api_client import FrontappClient
-
-        client = FrontappClient(**mock_api_credentials)
-        client.set_async_httpx_client(
-            httpx.AsyncClient(
-                transport=self._mock_response(
-                    {
-                        "_results": [
-                            {"id": "inb_1", "name": "Support"},
-                            {"id": "inb_2", "name": "Sales"},
-                        ],
-                        "_pagination": {},
-                        "_links": {},
-                    }
-                ),
-                base_url=mock_api_credentials["base_url"],
+    async def test_list_returns_domain_inboxes(
+        self, attach_transport, make_mock_transport
+    ):
+        client = attach_transport(
+            make_mock_transport(
+                {
+                    "_results": [
+                        {"id": "inb_1", "name": "Support"},
+                        {"id": "inb_2", "name": "Sales"},
+                    ],
+                    "_pagination": {},
+                    "_links": {},
+                }
             )
         )
 
@@ -100,21 +72,15 @@ class TestInboxesHelper:
         assert all(isinstance(i, Inbox) for i in inboxes)
         assert [i.name for i in inboxes] == ["Support", "Sales"]
 
-    async def test_get_returns_inbox(self, mock_api_credentials):
-        from frontapp_public_api_client import FrontappClient
-
-        client = FrontappClient(**mock_api_credentials)
-        client.set_async_httpx_client(
-            httpx.AsyncClient(
-                transport=self._mock_response(
-                    {
-                        "id": "inb_abc",
-                        "name": "Support",
-                        "is_private": False,
-                        "is_public": True,
-                    }
-                ),
-                base_url=mock_api_credentials["base_url"],
+    async def test_get_returns_inbox(self, attach_transport, make_mock_transport):
+        client = attach_transport(
+            make_mock_transport(
+                {
+                    "id": "inb_abc",
+                    "name": "Support",
+                    "is_private": False,
+                    "is_public": True,
+                }
             )
         )
 
@@ -122,18 +88,13 @@ class TestInboxesHelper:
         assert inbox.id == "inb_abc"
         assert inbox.is_public is True
 
-    async def test_create_sends_full_body(self, mock_api_credentials):
-        from frontapp_public_api_client import FrontappClient
-
-        client = FrontappClient(**mock_api_credentials)
-        transport, recorded = self._mock_recording(
+    async def test_create_sends_full_body(
+        self, attach_transport, make_recording_transport
+    ):
+        transport, recorded = make_recording_transport(
             {"id": "inb_new", "name": "Triage"}, status=201
         )
-        client.set_async_httpx_client(
-            httpx.AsyncClient(
-                transport=transport, base_url=mock_api_credentials["base_url"]
-            )
-        )
+        client = attach_transport(transport)
 
         inbox = await client.inboxes.create(
             name="Triage", teammate_ids=["tea_1", "tea_2"], is_public=False
@@ -144,16 +105,11 @@ class TestInboxesHelper:
         assert body["teammate_ids"] == ["tea_1", "tea_2"]
         assert body["is_public"] is False
 
-    async def test_grant_access_sends_teammate_ids(self, mock_api_credentials):
-        from frontapp_public_api_client import FrontappClient
-
-        client = FrontappClient(**mock_api_credentials)
-        transport, recorded = self._mock_recording(None, status=204)
-        client.set_async_httpx_client(
-            httpx.AsyncClient(
-                transport=transport, base_url=mock_api_credentials["base_url"]
-            )
-        )
+    async def test_grant_access_sends_teammate_ids(
+        self, attach_transport, make_recording_transport
+    ):
+        transport, recorded = make_recording_transport(None, status=204)
+        client = attach_transport(transport)
 
         success = await client.inboxes.grant_access(
             "inb_abc", teammate_ids=["tea_1", "tea_2"]
@@ -163,17 +119,12 @@ class TestInboxesHelper:
         assert body == {"teammate_ids": ["tea_1", "tea_2"]}
         assert recorded[0].method == "POST"
 
-    async def test_revoke_access_uses_delete_method(self, mock_api_credentials):
+    async def test_revoke_access_uses_delete_method(
+        self, attach_transport, make_recording_transport
+    ):
         """Wraps the awkwardly-named generated module ``removes_inbox_access``."""
-        from frontapp_public_api_client import FrontappClient
-
-        client = FrontappClient(**mock_api_credentials)
-        transport, recorded = self._mock_recording(None, status=204)
-        client.set_async_httpx_client(
-            httpx.AsyncClient(
-                transport=transport, base_url=mock_api_credentials["base_url"]
-            )
-        )
+        transport, recorded = make_recording_transport(None, status=204)
+        client = attach_transport(transport)
 
         success = await client.inboxes.revoke_access("inb_abc", teammate_ids=["tea_1"])
         assert success is True

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import json
 
-import httpx
 import pytest
 
 from frontapp_public_api_client.models.message_response import MessageResponse
@@ -18,57 +17,26 @@ from frontapp_public_api_client.utils import APIError
 
 
 class TestMessagesHelper:
-    """Helper-level integration via ``httpx.MockTransport``.
-
-    Mirrors tests/test_drafts.py — uses ``set_async_httpx_client`` to inject
-    a mock transport so we exercise the full request-construction path
-    without hitting the network.
-    """
-
-    def _mock_response(
-        self, payload: dict | list | None, status: int = 200
-    ) -> httpx.MockTransport:
-        def handler(_request: httpx.Request) -> httpx.Response:
-            if payload is None:
-                return httpx.Response(status, content=b"")
-            return httpx.Response(status, json=payload)
-
-        return httpx.MockTransport(handler)
-
-    def _mock_recording(
-        self, payload: dict | list | None, status: int = 200
-    ) -> tuple[httpx.MockTransport, list[httpx.Request]]:
-        recorded: list[httpx.Request] = []
-
-        def handler(request: httpx.Request) -> httpx.Response:
-            recorded.append(request)
-            if payload is None:
-                return httpx.Response(status, content=b"")
-            return httpx.Response(status, json=payload)
-
-        return httpx.MockTransport(handler), recorded
+    """Helper-level integration via the shared ``attach_transport`` /
+    ``make_*_transport`` fixtures from ``tests/conftest.py``."""
 
     # -- get ----------------------------------------------------------------
 
-    async def test_get_returns_message_response(self, mock_api_credentials):
-        from frontapp_public_api_client import FrontappClient
-
-        client = FrontappClient(**mock_api_credentials)
-        client.set_async_httpx_client(
-            httpx.AsyncClient(
-                transport=self._mock_response(
-                    {
-                        "id": "msg_abc",
-                        "type": "email",
-                        "is_inbound": True,
-                        "subject": "Hello",
-                        "blurb": "Hi there",
-                        "body": "<p>Hi there</p>",
-                        "text": "Hi there",
-                        "created_at": 1701292639,
-                    }
-                ),
-                base_url=mock_api_credentials["base_url"],
+    async def test_get_returns_message_response(
+        self, attach_transport, make_mock_transport
+    ):
+        client = attach_transport(
+            make_mock_transport(
+                {
+                    "id": "msg_abc",
+                    "type": "email",
+                    "is_inbound": True,
+                    "subject": "Hello",
+                    "blurb": "Hi there",
+                    "body": "<p>Hi there</p>",
+                    "text": "Hi there",
+                    "created_at": 1701292639,
+                }
             )
         )
 
@@ -78,16 +46,10 @@ class TestMessagesHelper:
         assert message.subject == "Hello"
         assert message.is_inbound is True
 
-    async def test_get_raises_on_404(self, mock_api_credentials):
-        from frontapp_public_api_client import FrontappClient
-
-        client = FrontappClient(**mock_api_credentials)
-        client.set_async_httpx_client(
-            httpx.AsyncClient(
-                transport=self._mock_response(
-                    {"_error": {"status": 404, "message": "Not found"}}, status=404
-                ),
-                base_url=mock_api_credentials["base_url"],
+    async def test_get_raises_on_404(self, attach_transport, make_mock_transport):
+        client = attach_transport(
+            make_mock_transport(
+                {"_error": {"status": 404, "message": "Not found"}}, status=404
             )
         )
 
@@ -96,37 +58,33 @@ class TestMessagesHelper:
 
     # -- seen_status --------------------------------------------------------
 
-    async def test_seen_status_returns_list_of_receipts(self, mock_api_credentials):
-        from frontapp_public_api_client import FrontappClient
-
-        client = FrontappClient(**mock_api_credentials)
-        client.set_async_httpx_client(
-            httpx.AsyncClient(
-                transport=self._mock_response(
-                    {
-                        "_results": [
-                            {
-                                "_links": {"related": {"message": "..."}},
-                                "first_seen_at": "2024-01-01T12:00:00Z",
-                                "seen_by": {
-                                    "handle": "a@example.com",
-                                    "source": "email",
-                                },
+    async def test_seen_status_returns_list_of_receipts(
+        self, attach_transport, make_mock_transport
+    ):
+        client = attach_transport(
+            make_mock_transport(
+                {
+                    "_results": [
+                        {
+                            "_links": {"related": {"message": "..."}},
+                            "first_seen_at": "2024-01-01T12:00:00Z",
+                            "seen_by": {
+                                "handle": "a@example.com",
+                                "source": "email",
                             },
-                            {
-                                "_links": {"related": {"message": "..."}},
-                                "first_seen_at": "2024-01-01T12:05:00Z",
-                                "seen_by": {
-                                    "handle": "b@example.com",
-                                    "source": "email",
-                                },
+                        },
+                        {
+                            "_links": {"related": {"message": "..."}},
+                            "first_seen_at": "2024-01-01T12:05:00Z",
+                            "seen_by": {
+                                "handle": "b@example.com",
+                                "source": "email",
                             },
-                        ],
-                        "_pagination": {},
-                        "_links": {},
-                    }
-                ),
-                base_url=mock_api_credentials["base_url"],
+                        },
+                    ],
+                    "_pagination": {},
+                    "_links": {},
+                }
             )
         )
 
@@ -137,18 +95,12 @@ class TestMessagesHelper:
         assert receipts[1].seen_by.handle == "b@example.com"
 
     async def test_seen_status_returns_empty_list_when_unset(
-        self, mock_api_credentials
+        self, attach_transport, make_mock_transport
     ):
-        from frontapp_public_api_client import FrontappClient
-
-        client = FrontappClient(**mock_api_credentials)
-        client.set_async_httpx_client(
-            httpx.AsyncClient(
-                transport=self._mock_response(
-                    {"_pagination": {}, "_links": {}}  # no _results key → UNSET
-                ),
-                base_url=mock_api_credentials["base_url"],
-            )
+        client = attach_transport(
+            make_mock_transport(
+                {"_pagination": {}, "_links": {}}
+            )  # no _results → UNSET
         )
 
         receipts = await client.messages.seen_status("msg_abc")
@@ -157,17 +109,10 @@ class TestMessagesHelper:
     # -- mark_seen ----------------------------------------------------------
 
     async def test_mark_seen_no_teammate_id_sends_empty_body(
-        self, mock_api_credentials
+        self, attach_transport, make_recording_transport
     ):
-        from frontapp_public_api_client import FrontappClient
-
-        client = FrontappClient(**mock_api_credentials)
-        transport, recorded = self._mock_recording(None, status=204)
-        client.set_async_httpx_client(
-            httpx.AsyncClient(
-                transport=transport, base_url=mock_api_credentials["base_url"]
-            )
-        )
+        transport, recorded = make_recording_transport(None, status=204)
+        client = attach_transport(transport)
 
         success = await client.messages.mark_seen("msg_abc")
         assert success is True
@@ -176,41 +121,31 @@ class TestMessagesHelper:
         assert recorded[0].url.path.endswith("/messages/msg_abc/seen")
         assert json.loads(recorded[0].content) == {}
 
-    async def test_mark_seen_with_teammate_id_includes_it(self, mock_api_credentials):
-        from frontapp_public_api_client import FrontappClient
-
-        client = FrontappClient(**mock_api_credentials)
-        transport, recorded = self._mock_recording(None, status=204)
-        client.set_async_httpx_client(
-            httpx.AsyncClient(
-                transport=transport, base_url=mock_api_credentials["base_url"]
-            )
-        )
+    async def test_mark_seen_with_teammate_id_includes_it(
+        self, attach_transport, make_recording_transport
+    ):
+        transport, recorded = make_recording_transport(None, status=204)
+        client = attach_transport(transport)
 
         success = await client.messages.mark_seen("msg_abc", teammate_id="tea_xyz")
         assert success is True
         body = json.loads(recorded[0].content)
         assert body == {"teammate_id": "tea_xyz"}
 
-    async def test_mark_seen_returns_false_on_non_204(self, mock_api_credentials):
+    async def test_mark_seen_returns_false_on_non_204(
+        self, attach_transport, make_mock_transport
+    ):
         """``is_success`` is True for any 2xx; an unexpected non-2xx returns False."""
-        from frontapp_public_api_client import FrontappClient
-
-        client = FrontappClient(**mock_api_credentials)
-        # 429 from the rate limiter — Front documents 10 req/msg/hour
-        client.set_async_httpx_client(
-            httpx.AsyncClient(
-                transport=self._mock_response(
-                    {"_error": {"status": 429, "message": "Too many requests"}},
-                    status=429,
-                ),
-                base_url=mock_api_credentials["base_url"],
-            )
-        )
-
         # 429 is wrapped as RateLimitError by unwrap, but mark_seen uses
         # is_success which only inspects the status — confirm the helper
         # surfaces a False return rather than raising.
+        client = attach_transport(
+            make_mock_transport(
+                {"_error": {"status": 429, "message": "Too many requests"}},
+                status=429,
+            )
+        )
+
         success = await client.messages.mark_seen("msg_abc")
         assert success is False
 

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 from datetime import UTC, datetime
 
-import httpx
 import pydantic
 import pytest
 
@@ -55,65 +54,35 @@ class TestTagDomain:
 # ---------------------------------------------------------------------------
 
 
+def _tag_payload(**overrides) -> dict:
+    """Minimal valid TagResponse-shaped dict."""
+    base = {
+        "_links": {"self": "https://x", "related": {}},
+        "id": "tag_abc",
+        "name": "urgent",
+        "description": None,
+        "highlight": None,
+        "is_private": False,
+        "is_visible_in_conversation_lists": False,
+    }
+    base.update(overrides)
+    return base
+
+
 class TestTagsHelper:
-    """Helper-level integration via ``httpx.MockTransport``."""
-
-    def _mock_response(
-        self, payload: dict | list | None, status: int = 200
-    ) -> httpx.MockTransport:
-        def handler(_request: httpx.Request) -> httpx.Response:
-            if payload is None:
-                return httpx.Response(status, content=b"")
-            return httpx.Response(status, json=payload)
-
-        return httpx.MockTransport(handler)
-
-    def _mock_recording(
-        self, payload: dict | list | None, status: int = 200
-    ) -> tuple[httpx.MockTransport, list[httpx.Request]]:
-        recorded: list[httpx.Request] = []
-
-        def handler(request: httpx.Request) -> httpx.Response:
-            recorded.append(request)
-            if payload is None:
-                return httpx.Response(status, content=b"")
-            return httpx.Response(status, json=payload)
-
-        return httpx.MockTransport(handler), recorded
-
-    async def test_list_returns_domain_tags(self, mock_api_credentials):
-        from frontapp_public_api_client import FrontappClient
-
-        client = FrontappClient(**mock_api_credentials)
-        client.set_async_httpx_client(
-            httpx.AsyncClient(
-                transport=self._mock_response(
-                    {
-                        "_results": [
-                            {
-                                "_links": {"self": "https://x", "related": {}},
-                                "id": "tag_1",
-                                "name": "urgent",
-                                "description": None,
-                                "highlight": None,
-                                "is_private": False,
-                                "is_visible_in_conversation_lists": False,
-                            },
-                            {
-                                "_links": {"self": "https://x", "related": {}},
-                                "id": "tag_2",
-                                "name": "vip",
-                                "description": None,
-                                "highlight": None,
-                                "is_private": False,
-                                "is_visible_in_conversation_lists": False,
-                            },
-                        ],
-                        "_pagination": {},
-                        "_links": {},
-                    }
-                ),
-                base_url=mock_api_credentials["base_url"],
+    async def test_list_returns_domain_tags(
+        self, attach_transport, make_mock_transport
+    ):
+        client = attach_transport(
+            make_mock_transport(
+                {
+                    "_results": [
+                        _tag_payload(id="tag_1", name="urgent"),
+                        _tag_payload(id="tag_2", name="vip"),
+                    ],
+                    "_pagination": {},
+                    "_links": {},
+                }
             )
         )
 
@@ -122,26 +91,17 @@ class TestTagsHelper:
         assert all(isinstance(t, Tag) for t in tags)
         assert [t.name for t in tags] == ["urgent", "vip"]
 
-    async def test_get_returns_tag_with_timestamps(self, mock_api_credentials):
-        from frontapp_public_api_client import FrontappClient
-
-        client = FrontappClient(**mock_api_credentials)
-        client.set_async_httpx_client(
-            httpx.AsyncClient(
-                transport=self._mock_response(
-                    {
-                        "_links": {"self": "https://x", "related": {}},
-                        "id": "tag_abc",
-                        "name": "urgent",
-                        "description": None,
-                        "highlight": "red",
-                        "is_private": False,
-                        "is_visible_in_conversation_lists": True,
-                        "created_at": 1701292639,
-                        "updated_at": 1701292700,
-                    }
-                ),
-                base_url=mock_api_credentials["base_url"],
+    async def test_get_returns_tag_with_timestamps(
+        self, attach_transport, make_mock_transport
+    ):
+        client = attach_transport(
+            make_mock_transport(
+                _tag_payload(
+                    highlight="red",
+                    is_visible_in_conversation_lists=True,
+                    created_at=1701292639,
+                    updated_at=1701292700,
+                )
             )
         )
 
@@ -151,27 +111,14 @@ class TestTagsHelper:
         assert tag.is_visible_in_conversation_lists is True
         assert isinstance(tag.created_at, datetime)
 
-    async def test_create_serializes_highlight_enum(self, mock_api_credentials):
-        from frontapp_public_api_client import FrontappClient
-
-        client = FrontappClient(**mock_api_credentials)
-        transport, recorded = self._mock_recording(
-            {
-                "_links": {"self": "https://x", "related": {}},
-                "id": "tag_new",
-                "name": "urgent",
-                "description": None,
-                "highlight": "red",
-                "is_private": False,
-                "is_visible_in_conversation_lists": False,
-            },
+    async def test_create_serializes_highlight_enum(
+        self, attach_transport, make_recording_transport
+    ):
+        transport, recorded = make_recording_transport(
+            _tag_payload(id="tag_new", highlight="red"),
             status=201,
         )
-        client.set_async_httpx_client(
-            httpx.AsyncClient(
-                transport=transport, base_url=mock_api_credentials["base_url"]
-            )
-        )
+        client = attach_transport(transport)
 
         tag = await client.tags.create(name="urgent", highlight="red")
         assert tag.id == "tag_new"
@@ -179,46 +126,30 @@ class TestTagsHelper:
         assert body["name"] == "urgent"
         assert body["highlight"] == "red"
 
-    async def test_update_skips_unset_fields(self, mock_api_credentials):
-        from frontapp_public_api_client import FrontappClient
-
-        client = FrontappClient(**mock_api_credentials)
-        transport, recorded = self._mock_recording(None, status=204)
-        client.set_async_httpx_client(
-            httpx.AsyncClient(
-                transport=transport, base_url=mock_api_credentials["base_url"]
-            )
-        )
+    async def test_update_skips_unset_fields(
+        self, attach_transport, make_recording_transport
+    ):
+        transport, recorded = make_recording_transport(None, status=204)
+        client = attach_transport(transport)
 
         success = await client.tags.update("tag_abc", name="renamed")
         assert success is True
         body = json.loads(recorded[0].content)
         assert body == {"name": "renamed"}
 
-    async def test_delete_returns_true_on_204(self, mock_api_credentials):
-        from frontapp_public_api_client import FrontappClient
-
-        client = FrontappClient(**mock_api_credentials)
-        client.set_async_httpx_client(
-            httpx.AsyncClient(
-                transport=self._mock_response(None, status=204),
-                base_url=mock_api_credentials["base_url"],
-            )
-        )
+    async def test_delete_returns_true_on_204(
+        self, attach_transport, make_mock_transport
+    ):
+        client = attach_transport(make_mock_transport(None, status=204))
 
         success = await client.tags.delete("tag_abc")
         assert success is True
 
-    async def test_apply_to_conversation_sends_tag_ids_list(self, mock_api_credentials):
-        from frontapp_public_api_client import FrontappClient
-
-        client = FrontappClient(**mock_api_credentials)
-        transport, recorded = self._mock_recording(None, status=204)
-        client.set_async_httpx_client(
-            httpx.AsyncClient(
-                transport=transport, base_url=mock_api_credentials["base_url"]
-            )
-        )
+    async def test_apply_to_conversation_sends_tag_ids_list(
+        self, attach_transport, make_recording_transport
+    ):
+        transport, recorded = make_recording_transport(None, status=204)
+        client = attach_transport(transport)
 
         success = await client.tags.apply_to_conversation(
             "cnv_abc", tag_ids=["tag_1", "tag_2"]
@@ -229,16 +160,11 @@ class TestTagsHelper:
         assert recorded[0].method == "POST"
         assert recorded[0].url.path.endswith("/conversations/cnv_abc/tags")
 
-    async def test_remove_from_conversation_uses_delete(self, mock_api_credentials):
-        from frontapp_public_api_client import FrontappClient
-
-        client = FrontappClient(**mock_api_credentials)
-        transport, recorded = self._mock_recording(None, status=204)
-        client.set_async_httpx_client(
-            httpx.AsyncClient(
-                transport=transport, base_url=mock_api_credentials["base_url"]
-            )
-        )
+    async def test_remove_from_conversation_uses_delete(
+        self, attach_transport, make_recording_transport
+    ):
+        transport, recorded = make_recording_transport(None, status=204)
+        client = attach_transport(transport)
 
         success = await client.tags.remove_from_conversation(
             "cnv_abc", tag_ids=["tag_1"]


### PR DESCRIPTION
Follow-up B from #7 — completes the conftest lift that was deferred when #7 shipped to keep that PR's diff focused.

## Refactoring

Replaced per-file boilerplate with shared conftest fixtures across all 10 existing per-vertical test files:

| Was | Now |
|---|---|
| \`self._mock_response(payload, status)\` | \`make_mock_transport(payload, status)\` |
| \`self._mock_recording(payload, status)\` | \`make_recording_transport(payload, status)\` |
| 4-line FrontappClient + set_async_httpx_client + base_url block | \`attach_transport(transport)\` |
| 14-line \`_make_mcp()\` + per-file fixture | \`mcp_tool_capture(register_tools)\` |

## Files refactored

**Helper tests:** \`tests/test_{contacts,drafts,messages,tags,inboxes}.py\`
**MCP tool tests:** \`frontapp_mcp_server/tests/test_{contacts,drafts,messages,tags,inboxes}_tools.py\`

## Stats

- **Net 430-line reduction** (1022 → 592) across 10 files
- All 348 tests still pass; zero behavior change
- New verticals will use the shared fixtures from the start

## Test plan

- [x] \`uv run poe full-check\` exits 0
- [x] \`uv run poe test\`: 348 passed (same as before refactor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)