### PR TITLE
feat(client,mcp): teammates vertical (follow-up D)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ highest-value subset. Current status:
 | Messages      | ✅ `.messages`               | get / seen_status / mark_seen                                                                                                                                                                    |
 | Tags          | ✅ `.tags`                   | list (+ company/team/teammate scopes) / get / list_children / list_tagged_conversations / add_tag_to_conversation / remove_tag_from_conversation / create / create_child / update / delete       |
 | Inboxes       | ✅ `.inboxes`                | list (+ team/teammate scopes) / get / list_conversations / list_channels / list_access / create (+ team) / grant_access / revoke_access                                                          |
-| Teammates     | ⏳ planned                   | ⏳ planned (currently `frontapp://teammates` resource)                                                                                                                                           |
+| Teammates     | ✅ `.teammates`              | list / get / list_inboxes / list_assigned_conversations / update                                                                                                                                 |
 | Analytics     | ⏳ planned                   | ⏳ planned (create→poll recipe)                                                                                                                                                                  |
 
 See the [issue tracker](https://github.com/dougborg/frontapp-openapi-client/issues) for

--- a/docs/api-facts.yaml
+++ b/docs/api-facts.yaml
@@ -17,8 +17,8 @@
 #      domain wiring status, full path/method/response info).
 #
 schema_version: 1
-generated_at: '2026-04-26T22:43:24+00:00'
-generated_from_commit: ef58d8d6aed55813d6a573962f7acf7310afdfce
+generated_at: '2026-04-27T02:15:08+00:00'
+generated_from_commit: a48a528e7c082accdf9cf33d6766baa94eaf678a
 summary:
   list_endpoints_with_field_results:
     - accounts.list_account_contacts
@@ -247,12 +247,14 @@ summary:
     - inboxes
     - messages
     - tags
+    - teammates
   tags_with_domain:
     - contacts
     - conversations
     - drafts
     - inboxes
     - tags
+    - teammates
 tags:
   accounts:
     spec_tag: Accounts
@@ -1934,13 +1936,13 @@ tags:
     spec_tag: Teammates
     api_dir: frontapp_public_api_client/api/teammates
     helper:
-      built: false
-      path: null
-      class: null
+      built: true
+      path: frontapp_public_api_client/helpers/teammates.py
+      class: Teammates
     domain:
-      built: false
-      path: null
-      class: null
+      built: true
+      path: frontapp_public_api_client/domain/teammate.py
+      class: Teammate
     endpoints:
       - module: get_teammate
         method: GET

--- a/frontapp_mcp_server/src/frontapp_mcp/resources/help.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/resources/help.py
@@ -146,6 +146,19 @@ Front exposes no inbox PATCH endpoint — name and visibility are immutable
 post-creation. The only post-create mutations are the access grant/revoke
 pair.
 
+## Teammates
+
+Human users in the workspace. The `frontapp://teammates` resource is the
+preferred name-to-id lookup at session start.
+
+| Tool | Endpoint | Purpose |
+| ---- | -------- | ------- |
+| `list_teammates` | `GET /teammates` | Every teammate in the workspace (no pagination). |
+| `get_teammate` | `GET /teammates/{id}` | Full detail for one teammate. |
+| `list_teammate_inboxes` | `GET /teammates/{id}/inboxes` | Inboxes this teammate has access to. |
+| `list_assigned_conversations` | `GET /teammates/{id}/conversations` | Conversations currently assigned to this teammate. Returns `ConversationSummary`s. |
+| `update_teammate` | `PATCH /teammates/{id}` | Update username / first_name / last_name / is_available. Email and admin status are NOT changeable here. Two-step confirm. |
+
 ### Workflow recipe — "what else do we have on this customer?"
 
 ```

--- a/frontapp_mcp_server/src/frontapp_mcp/server.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/server.py
@@ -305,6 +305,20 @@ Inboxes are channel containers. Every conversation belongs to one. Read
 Front exposes no general inbox PATCH — name and visibility are immutable
 post-creation. Only access can be changed after that.
 
+## Teammates
+
+Human users in the workspace. Read `frontapp://teammates` at session
+start to translate names/emails into `tea_*` ids.
+
+**Listing & detail:**
+  list_teammates | get_teammate | list_teammate_inboxes |
+  list_assigned_conversations (with `q=` search syntax filter)
+
+**Mutations (two-step confirm):**
+  update_teammate (username / first_name / last_name / is_available
+  only — email and admin status are read-only via this API; manage
+  those in Front's admin UI)
+
 ## Front Search Syntax (q parameter)
 
   status:open | status:archived | tag:urgent | assignee:me |
@@ -372,6 +386,10 @@ _READ_ONLY_TOOLS = [
     "list_inbox_conversations",
     "list_inbox_channels",
     "list_inbox_access",
+    "list_teammates",
+    "get_teammate",
+    "list_teammate_inboxes",
+    "list_assigned_conversations",
 ]
 
 mcp.add_middleware(

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/__init__.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/__init__.py
@@ -16,6 +16,7 @@ def register_all_tools(mcp: FastMCP) -> None:
     from .inboxes import register_tools as register_inboxes_tools
     from .messages import register_tools as register_messages_tools
     from .tags import register_tools as register_tags_tools
+    from .teammates import register_tools as register_teammates_tools
 
     register_contacts_tools(mcp)
     register_conversations_tools(mcp)
@@ -23,6 +24,7 @@ def register_all_tools(mcp: FastMCP) -> None:
     register_inboxes_tools(mcp)
     register_messages_tools(mcp)
     register_tags_tools(mcp)
+    register_teammates_tools(mcp)
 
 
 __all__ = ["register_all_tools"]

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/teammates.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/teammates.py
@@ -1,0 +1,155 @@
+"""MCP tools for Frontapp teammates.
+
+Five tools — 4 cached reads + 1 mutation (two-step confirm). The
+``frontapp://teammates`` resource still ships as the preferred name-to-id
+lookup at session start; these tools are for programmatic
+listing/filtering and the rare update operation.
+
+Email and admin status are read-only via Front's API — managed in Front's
+admin UI. ``update_teammate`` only flips username / first_name /
+last_name / is_available / custom_fields.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastmcp import Context, FastMCP
+from pydantic import Field
+
+from frontapp_mcp.projections import ConversationSummary, to_summary
+from frontapp_mcp.services import get_services
+from frontapp_mcp.tools.schemas import ConfirmationResult, require_confirmation
+from frontapp_public_api_client.domain import Inbox, Teammate
+
+
+def register_tools(mcp: FastMCP) -> None:
+    """Register teammate-related tools with the FastMCP server."""
+
+    # -- reads --------------------------------------------------------------
+
+    @mcp.tool(
+        name="list_teammates",
+        description=(
+            "List every teammate in the workspace. Prefer the "
+            "`frontapp://teammates` resource for name-to-id lookups; this "
+            "tool is for programmatic listing."
+        ),
+    )
+    async def list_teammates(context: Context) -> list[Teammate]:
+        services = get_services(context)
+        return await services.client.teammates.list()
+
+    @mcp.tool(
+        name="get_teammate",
+        description="Fetch full details for one teammate by id (e.g. 'tea_abc').",
+    )
+    async def get_teammate(
+        context: Context,
+        teammate_id: Annotated[str, Field(description="Teammate id, e.g. 'tea_abc'")],
+    ) -> Teammate:
+        services = get_services(context)
+        return await services.client.teammates.get(teammate_id)
+
+    @mcp.tool(
+        name="list_teammate_inboxes",
+        description="List inboxes this teammate has access to.",
+    )
+    async def list_teammate_inboxes(
+        context: Context,
+        teammate_id: Annotated[str, Field(description="Teammate id")],
+    ) -> list[Inbox]:
+        services = get_services(context)
+        return await services.client.teammates.list_inboxes(teammate_id)
+
+    @mcp.tool(
+        name="list_assigned_conversations",
+        description=(
+            "List conversations currently assigned to this teammate. Pass "
+            "`q=` to filter with Front search syntax (e.g. 'status:open')."
+        ),
+    )
+    async def list_assigned_conversations(
+        context: Context,
+        teammate_id: Annotated[str, Field(description="Teammate id")],
+        q: Annotated[str | None, Field(description="Front search syntax")] = None,
+        limit: Annotated[int | None, Field(description="Page size")] = None,
+        page_token: Annotated[str | None, Field(description="Cursor")] = None,
+    ) -> list[ConversationSummary]:
+        from frontapp_public_api_client.domain import Conversation
+
+        services = get_services(context)
+        items = await services.client.teammates.list_assigned_conversations(
+            teammate_id, q=q, limit=limit, page_token=page_token
+        )
+        return [
+            to_summary(Conversation.model_validate(item.to_dict())) for item in items
+        ]
+
+    # -- mutation (two-step confirm) ----------------------------------------
+
+    @mcp.tool(
+        name="update_teammate",
+        description=(
+            "Update a teammate's username / name / availability. Email and "
+            "admin status are NOT changeable via this API — manage those "
+            "in Front's admin UI. Two-step confirm."
+        ),
+    )
+    async def update_teammate(
+        context: Context,
+        teammate_id: Annotated[str, Field(description="Teammate id")],
+        username: Annotated[
+            str | None, Field(description="New username (login)")
+        ] = None,
+        first_name: Annotated[str | None, Field(description="New first name")] = None,
+        last_name: Annotated[str | None, Field(description="New last name")] = None,
+        is_available: Annotated[
+            bool | None,
+            Field(description="Set the teammate's availability flag"),
+        ] = None,
+        confirm: Annotated[bool, Field(description="Must be true")] = False,
+    ) -> dict[str, Any]:
+        services = get_services(context)
+        changes = {
+            k: v
+            for k, v in {
+                "username": username,
+                "first_name": first_name,
+                "last_name": last_name,
+                "is_available": is_available,
+            }.items()
+            if v is not None
+        }
+        preview = {
+            "action": "update_teammate",
+            "teammate_id": teammate_id,
+            "changes": changes,
+        }
+        if not changes:
+            return {
+                "preview": preview,
+                "confirmed": False,
+                "result": "no_changes_requested",
+            }
+        if not confirm:
+            return {"preview": preview, "confirmed": False}
+
+        summary = ", ".join(f"{k}={v}" for k, v in changes.items())
+        result = await require_confirmation(
+            context, f"Update teammate {teammate_id}: {summary}?"
+        )
+        if result is not ConfirmationResult.CONFIRMED:
+            return {"preview": preview, "confirmed": False, "result": result.value}
+
+        success = await services.client.teammates.update(
+            teammate_id,
+            username=username,
+            first_name=first_name,
+            last_name=last_name,
+            is_available=is_available,
+        )
+        return {"confirmed": True, "updated": success}
+
+
+__all__ = ["register_tools"]

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/teammates.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/teammates.py
@@ -108,6 +108,15 @@ def register_tools(mcp: FastMCP) -> None:
             bool | None,
             Field(description="Set the teammate's availability flag"),
         ] = None,
+        custom_fields: Annotated[
+            dict[str, Any] | None,
+            Field(
+                description=(
+                    "Workspace-defined custom fields to set on the teammate. "
+                    "Replaces the full custom_fields object."
+                )
+            ),
+        ] = None,
         confirm: Annotated[bool, Field(description="Must be true")] = False,
     ) -> dict[str, Any]:
         services = get_services(context)
@@ -118,6 +127,7 @@ def register_tools(mcp: FastMCP) -> None:
                 "first_name": first_name,
                 "last_name": last_name,
                 "is_available": is_available,
+                "custom_fields": custom_fields,
             }.items()
             if v is not None
         }
@@ -148,6 +158,7 @@ def register_tools(mcp: FastMCP) -> None:
             first_name=first_name,
             last_name=last_name,
             is_available=is_available,
+            custom_fields=custom_fields,
         )
         return {"confirmed": True, "updated": success}
 

--- a/frontapp_mcp_server/tests/test_teammates_tools.py
+++ b/frontapp_mcp_server/tests/test_teammates_tools.py
@@ -1,0 +1,180 @@
+"""Tests for MCP teammate tools — 4 reads + update mutation."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from frontapp_mcp.projections import ConversationSummary
+from frontapp_mcp.tools.teammates import register_tools
+
+from frontapp_public_api_client.domain import Inbox, Teammate
+
+from .conftest import create_mock_context
+
+
+@pytest.fixture
+def teammates_tools(mcp_tool_capture):
+    return mcp_tool_capture(register_tools)
+
+
+# ---------------------------------------------------------------------------
+# Read tools
+# ---------------------------------------------------------------------------
+
+
+class TestReadTools:
+    async def test_list_teammates_returns_domain_models(self, teammates_tools):
+        context, lifespan = create_mock_context()
+        teammates = [
+            Teammate.model_validate(
+                {"id": "tea_1", "email": "a@x.com", "username": "alice"}
+            ),
+            Teammate.model_validate(
+                {"id": "tea_2", "email": "b@x.com", "username": "bob"}
+            ),
+        ]
+        lifespan.client = AsyncMock()
+        lifespan.client.teammates.list = AsyncMock(return_value=teammates)
+
+        result = await teammates_tools["list_teammates"](context)
+
+        assert len(result) == 2
+        assert all(isinstance(t, Teammate) for t in result)
+        assert [t.username for t in result] == ["alice", "bob"]
+
+    async def test_get_teammate_returns_domain_model(self, teammates_tools):
+        context, lifespan = create_mock_context()
+        teammate = Teammate.model_validate(
+            {"id": "tea_a", "email": "a@x.com", "username": "alice", "is_admin": True}
+        )
+        lifespan.client = AsyncMock()
+        lifespan.client.teammates.get = AsyncMock(return_value=teammate)
+
+        result = await teammates_tools["get_teammate"](context, teammate_id="tea_a")
+        assert isinstance(result, Teammate)
+        assert result.id == "tea_a"
+        assert result.is_admin is True
+
+    async def test_list_teammate_inboxes_returns_domain_models(self, teammates_tools):
+        context, lifespan = create_mock_context()
+        inboxes = [Inbox.model_validate({"id": "inb_1", "name": "Support"})]
+        lifespan.client = AsyncMock()
+        lifespan.client.teammates.list_inboxes = AsyncMock(return_value=inboxes)
+
+        result = await teammates_tools["list_teammate_inboxes"](
+            context, teammate_id="tea_a"
+        )
+        assert all(isinstance(i, Inbox) for i in result)
+
+    async def test_list_assigned_conversations_projects_each(self, teammates_tools):
+        context, lifespan = create_mock_context()
+        msg1 = MagicMock()
+        msg1.to_dict.return_value = {"id": "cnv_1"}
+        msg2 = MagicMock()
+        msg2.to_dict.return_value = {"id": "cnv_2"}
+        lifespan.client = AsyncMock()
+        lifespan.client.teammates.list_assigned_conversations = AsyncMock(
+            return_value=[msg1, msg2]
+        )
+
+        result = await teammates_tools["list_assigned_conversations"](
+            context, teammate_id="tea_a"
+        )
+
+        assert len(result) == 2
+        assert all(isinstance(c, ConversationSummary) for c in result)
+        # The projection went through Conversation.model_validate(item.to_dict()).
+        msg1.to_dict.assert_called_once()
+        msg2.to_dict.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Mutation: update_teammate — preview / no-changes / confirm / decline / cancel
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateTeammate:
+    async def test_preview_does_not_call_helper(self, teammates_tools):
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock()
+        lifespan.client.teammates.update = AsyncMock(
+            side_effect=AssertionError("helper invoked on preview")
+        )
+
+        result = await teammates_tools["update_teammate"](
+            context, teammate_id="tea_a", first_name="Alicia", confirm=False
+        )
+
+        assert result["confirmed"] is False
+        assert result["preview"]["changes"] == {"first_name": "Alicia"}
+        context.elicit.assert_not_called()
+        lifespan.client.teammates.update.assert_not_awaited()
+
+    async def test_no_changes_short_circuits(self, teammates_tools):
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock()
+
+        result = await teammates_tools["update_teammate"](
+            context, teammate_id="tea_a", confirm=True
+        )
+
+        assert result["result"] == "no_changes_requested"
+        assert result["confirmed"] is False
+        context.elicit.assert_not_called()
+
+    async def test_cancelled_does_not_call_helper(self, teammates_tools):
+        """User cancelled the elicitation (action='decline') → CANCELLED."""
+        context, lifespan = create_mock_context(elicit_action="decline")
+        lifespan.client = AsyncMock()
+        lifespan.client.teammates.update = AsyncMock(
+            side_effect=AssertionError("helper invoked after cancel")
+        )
+
+        result = await teammates_tools["update_teammate"](
+            context, teammate_id="tea_a", first_name="Alicia", confirm=True
+        )
+
+        assert result["confirmed"] is False
+        assert result["result"] == "cancelled"
+        lifespan.client.teammates.update.assert_not_awaited()
+
+    async def test_declined_does_not_call_helper(self, teammates_tools):
+        """User accepted but unchecked the confirm flag → DECLINED."""
+        context, lifespan = create_mock_context(
+            elicit_confirm=False, elicit_action="accept"
+        )
+        lifespan.client = AsyncMock()
+        lifespan.client.teammates.update = AsyncMock(
+            side_effect=AssertionError("helper invoked after decline")
+        )
+
+        result = await teammates_tools["update_teammate"](
+            context, teammate_id="tea_a", first_name="Alicia", confirm=True
+        )
+
+        assert result["confirmed"] is False
+        assert result["result"] == "declined"
+        lifespan.client.teammates.update.assert_not_awaited()
+
+    async def test_confirmed_calls_helper(self, teammates_tools):
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock()
+        lifespan.client.teammates.update = AsyncMock(return_value=True)
+
+        result = await teammates_tools["update_teammate"](
+            context,
+            teammate_id="tea_a",
+            first_name="Alicia",
+            is_available=False,
+            confirm=True,
+        )
+
+        lifespan.client.teammates.update.assert_awaited_once_with(
+            "tea_a",
+            username=None,
+            first_name="Alicia",
+            last_name=None,
+            is_available=False,
+        )
+        assert result == {"confirmed": True, "updated": True}

--- a/frontapp_mcp_server/tests/test_teammates_tools.py
+++ b/frontapp_mcp_server/tests/test_teammates_tools.py
@@ -176,5 +176,6 @@ class TestUpdateTeammate:
             first_name="Alicia",
             last_name=None,
             is_available=False,
+            custom_fields=None,
         )
         assert result == {"confirmed": True, "updated": True}

--- a/frontapp_public_api_client/domain/__init__.py
+++ b/frontapp_public_api_client/domain/__init__.py
@@ -33,6 +33,7 @@ from .converters import to_unset, unwrap_unset
 from .draft import AttachmentSummary, Draft
 from .inbox import Inbox
 from .tag import Tag
+from .teammate import Teammate
 
 __all__ = [
     "AttachmentSummary",
@@ -48,6 +49,7 @@ __all__ = [
     "RecipientSummary",
     "Tag",
     "TagSummary",
+    "Teammate",
     "TeammateSummary",
     "to_unset",
     "unwrap_unset",

--- a/frontapp_public_api_client/domain/teammate.py
+++ b/frontapp_public_api_client/domain/teammate.py
@@ -10,6 +10,8 @@ the full standalone projection used by the teammates vertical
 
 from __future__ import annotations
 
+from typing import Any
+
 from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -19,6 +21,10 @@ class Teammate(BaseModel):
     Teammate IDs are strings with a ``tea_`` prefix (e.g. ``tea_abc123``).
     ``is_available`` is the teammate's manual availability toggle (used by
     Front's "out of office" routing). ``is_blocked`` is set by an admin.
+
+    ``custom_fields`` round-trips Front's per-workspace custom-field dict.
+    Same field is updatable via ``Teammates.update(custom_fields=...)``,
+    so callers can read the current values back through this projection.
     """
 
     id: str
@@ -30,6 +36,7 @@ class Teammate(BaseModel):
     is_available: bool = True
     is_blocked: bool = False
     type: str | None = Field(None, description="'user' or 'integration'")
+    custom_fields: dict[str, Any] = Field(default_factory=dict)
 
     model_config = ConfigDict(
         frozen=True,

--- a/frontapp_public_api_client/domain/teammate.py
+++ b/frontapp_public_api_client/domain/teammate.py
@@ -1,0 +1,42 @@
+"""Domain model for Frontapp teammates.
+
+Hand-written Pydantic projection of Front's ``TeammateResponse``.
+Distinct from the lighter ``TeammateSummary`` in ``domain/conversation.py``,
+which is a nested sub-type used inside ``Conversation.assignee`` and
+exposes only id/username/email/name/availability. ``Teammate`` here is
+the full standalone projection used by the teammates vertical
+(``client.teammates``).
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class Teammate(BaseModel):
+    """A Front teammate as returned by ``/teammates*`` endpoints.
+
+    Teammate IDs are strings with a ``tea_`` prefix (e.g. ``tea_abc123``).
+    ``is_available`` is the teammate's manual availability toggle (used by
+    Front's "out of office" routing). ``is_blocked`` is set by an admin.
+    """
+
+    id: str
+    email: str
+    username: str
+    first_name: str | None = None
+    last_name: str | None = None
+    is_admin: bool = False
+    is_available: bool = True
+    is_blocked: bool = False
+    type: str | None = Field(None, description="'user' or 'integration'")
+
+    model_config = ConfigDict(
+        frozen=True,
+        str_strip_whitespace=True,
+        extra="ignore",
+        populate_by_name=True,
+    )
+
+
+__all__ = ["Teammate"]

--- a/frontapp_public_api_client/frontapp_client.py
+++ b/frontapp_public_api_client/frontapp_client.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from .helpers.inboxes import Inboxes
     from .helpers.messages import Messages
     from .helpers.tags import Tags
+    from .helpers.teammates import Teammates
 
 import httpx
 from dotenv import load_dotenv
@@ -1034,6 +1035,7 @@ class FrontappClient(AuthenticatedClient):
         self._messages: Messages | None = None
         self._tags: Tags | None = None
         self._inboxes: Inboxes | None = None
+        self._teammates: Teammates | None = None
 
         # Extract client-level parameters that shouldn't go to the transport
         # Event hooks for observability - start with our defaults
@@ -1185,6 +1187,20 @@ class FrontappClient(AuthenticatedClient):
         if self._inboxes is None:
             self._inboxes = Inboxes(self)
         return self._inboxes
+
+    @property
+    def teammates(self) -> "Teammates":
+        """Ergonomic operations over Frontapp's teammate roster.
+
+        Covers list / get / update + per-teammate inbox + assigned-
+        conversation lookups. Email and admin status are read-only at
+        this surface — managed via Front's admin UI.
+        """
+        from .helpers.teammates import Teammates
+
+        if self._teammates is None:
+            self._teammates = Teammates(self)
+        return self._teammates
 
     # Event hooks for observability
     async def _capture_pagination_metadata(self, response: httpx.Response) -> None:

--- a/frontapp_public_api_client/helpers/__init__.py
+++ b/frontapp_public_api_client/helpers/__init__.py
@@ -12,6 +12,7 @@ from frontapp_public_api_client.helpers.drafts import Drafts
 from frontapp_public_api_client.helpers.inboxes import Inboxes
 from frontapp_public_api_client.helpers.messages import Messages
 from frontapp_public_api_client.helpers.tags import Tags
+from frontapp_public_api_client.helpers.teammates import Teammates
 
 __all__ = [
     "Base",
@@ -21,4 +22,5 @@ __all__ = [
     "Inboxes",
     "Messages",
     "Tags",
+    "Teammates",
 ]

--- a/frontapp_public_api_client/helpers/teammates.py
+++ b/frontapp_public_api_client/helpers/teammates.py
@@ -1,0 +1,183 @@
+"""Teammates helper facade — ergonomic wrappers around generated teammate endpoints.
+
+Exposes ``client.teammates`` covering the workspace teammate roster:
+
+- ``list`` / ``get`` — read the workspace's teammates
+- ``update`` — change a teammate's name / username / availability
+- ``list_inboxes`` — inboxes a teammate has access to
+- ``list_assigned_conversations`` / ``iter_assigned_conversations`` —
+  conversations currently assigned to a teammate (paginated)
+
+Quirks worth knowing:
+
+- ``UpdateTeammate`` only accepts username / first_name / last_name /
+  is_available / custom_fields. Email and admin status are read-only at
+  this surface — managed via Front's admin UI.
+- ``list_teammates`` and ``list_teammate_inboxes`` take no pagination
+  params (Front returns the full set in one shot for both).
+- The ``TeammateResponse`` ``type_`` field deserializes to ``type`` in
+  the dict form; the ``Teammate`` Pydantic model uses ``type`` directly.
+"""
+
+from __future__ import annotations
+
+import builtins
+from collections.abc import AsyncIterator
+from typing import TYPE_CHECKING, Any
+
+from frontapp_public_api_client.helpers.base import Base
+
+if TYPE_CHECKING:
+    from frontapp_public_api_client.domain import Inbox, Teammate
+
+
+class Teammates(Base):
+    """Ergonomic operations over Frontapp's ``/teammates*`` surface."""
+
+    # -- reads --------------------------------------------------------------
+
+    async def list(self) -> builtins.list[Teammate]:
+        """List every teammate in the workspace.
+
+        No pagination params — Front returns the full set in one shot.
+        """
+        from frontapp_public_api_client.api.teammates import list_teammates
+        from frontapp_public_api_client.domain import Teammate
+        from frontapp_public_api_client.utils import unwrap
+
+        response = await list_teammates.asyncio_detailed(client=self._client)
+        parsed = unwrap(response)
+        results = getattr(parsed, "field_results", None) or []
+        return [Teammate.model_validate(t.to_dict()) for t in results]
+
+    async def get(self, teammate_id: str) -> Teammate:
+        """Fetch one teammate by id (e.g. ``"tea_abc"``)."""
+        from frontapp_public_api_client.api.teammates import get_teammate
+        from frontapp_public_api_client.domain import Teammate
+        from frontapp_public_api_client.models.teammate_response import TeammateResponse
+        from frontapp_public_api_client.utils import unwrap_as
+
+        response = await get_teammate.asyncio_detailed(
+            teammate_id=teammate_id, client=self._client
+        )
+        teammate = unwrap_as(response, TeammateResponse)
+        return Teammate.model_validate(teammate.to_dict())
+
+    async def list_inboxes(self, teammate_id: str) -> builtins.list[Inbox]:
+        """List inboxes this teammate has access to.
+
+        No pagination — Front returns the full set in one shot.
+        """
+        from frontapp_public_api_client.api.teammates import list_teammate_inboxes
+        from frontapp_public_api_client.domain import Inbox
+        from frontapp_public_api_client.utils import unwrap
+
+        response = await list_teammate_inboxes.asyncio_detailed(
+            teammate_id=teammate_id, client=self._client
+        )
+        parsed = unwrap(response)
+        results = getattr(parsed, "field_results", None) or []
+        return [Inbox.model_validate(i.to_dict()) for i in results]
+
+    async def list_assigned_conversations(
+        self,
+        teammate_id: str,
+        *,
+        q: str | None = None,
+        limit: int | None = None,
+        page_token: str | None = None,
+    ) -> builtins.list[Any]:
+        """List conversations currently assigned to this teammate.
+
+        Returns raw attrs ``ConversationResponse`` items.
+        """
+        from frontapp_public_api_client.api.teammates import (
+            list_assigned_conversations,
+        )
+        from frontapp_public_api_client.utils import unwrap
+
+        kwargs: dict[str, Any] = {"client": self._client, "teammate_id": teammate_id}
+        if q is not None:
+            kwargs["q"] = q
+        if limit is not None:
+            kwargs["limit"] = limit
+        if page_token is not None:
+            kwargs["page_token"] = page_token
+
+        response = await list_assigned_conversations.asyncio_detailed(**kwargs)
+        parsed = unwrap(response)
+        return list(getattr(parsed, "field_results", None) or [])
+
+    async def iter_assigned_conversations(
+        self,
+        teammate_id: str,
+        *,
+        q: str | None = None,
+        limit: int | None = None,
+        max_items: int | None = None,
+        max_pages: int | None = None,
+    ) -> AsyncIterator[Any]:
+        """Auto-paginated iterator over conversations assigned to this teammate.
+
+        Yields raw attrs ``ConversationResponse`` items.
+        """
+        from frontapp_public_api_client.api.teammates import (
+            list_assigned_conversations,
+        )
+
+        kwargs: dict[str, Any] = {"teammate_id": teammate_id}
+        if q is not None:
+            kwargs["q"] = q
+        if limit is not None:
+            kwargs["limit"] = limit
+
+        async for item in self._paginate(
+            list_assigned_conversations.asyncio_detailed,
+            max_items=max_items,
+            max_pages=max_pages,
+            **kwargs,
+        ):
+            yield item
+
+    # -- mutations ----------------------------------------------------------
+
+    async def update(
+        self,
+        teammate_id: str,
+        *,
+        username: str | None = None,
+        first_name: str | None = None,
+        last_name: str | None = None,
+        is_available: bool | None = None,
+        custom_fields: dict[str, Any] | None = None,
+    ) -> bool:
+        """Update mutable fields on a teammate.
+
+        Email and admin status are read-only at this API surface — those
+        live in Front's admin UI. Returns True on the documented 204 No
+        Content.
+        """
+        from frontapp_public_api_client.api.teammates import update_teammate
+        from frontapp_public_api_client.models.update_teammate import UpdateTeammate
+        from frontapp_public_api_client.utils import is_success
+
+        kwargs: dict[str, Any] = {}
+        if username is not None:
+            kwargs["username"] = username
+        if first_name is not None:
+            kwargs["first_name"] = first_name
+        if last_name is not None:
+            kwargs["last_name"] = last_name
+        if is_available is not None:
+            kwargs["is_available"] = is_available
+        if custom_fields is not None:
+            kwargs["custom_fields"] = custom_fields
+
+        body = UpdateTeammate(**kwargs)
+        response = await update_teammate.asyncio_detailed(
+            teammate_id=teammate_id, client=self._client, body=body
+        )
+        return is_success(response)
+
+
+__all__ = ["Teammates"]

--- a/tests/test_teammates.py
+++ b/tests/test_teammates.py
@@ -1,0 +1,258 @@
+"""Tests for the teammates vertical: Teammate domain model + Teammates helper."""
+
+from __future__ import annotations
+
+import json
+
+import pydantic
+import pytest
+
+from frontapp_public_api_client.domain import Inbox, Teammate
+
+# ---------------------------------------------------------------------------
+# Domain model: Teammate
+# ---------------------------------------------------------------------------
+
+
+class TestTeammateDomain:
+    def test_required_fields_minimum(self):
+        t = Teammate.model_validate(
+            {"id": "tea_abc", "email": "a@x.com", "username": "alice"}
+        )
+        assert t.id == "tea_abc"
+        assert t.email == "a@x.com"
+        assert t.username == "alice"
+        assert t.is_admin is False
+        assert t.is_available is True
+        assert t.is_blocked is False
+
+    def test_extra_fields_ignored(self):
+        t = Teammate.model_validate(
+            {
+                "id": "tea_abc",
+                "email": "a@x.com",
+                "username": "alice",
+                "_links": {"self": "https://x"},
+                "custom_fields": {"region": "us"},
+            }
+        )
+        assert t.id == "tea_abc"
+
+    def test_type_field_passes_through(self):
+        t = Teammate.model_validate(
+            {"id": "tea_a", "email": "a@x.com", "username": "a", "type": "user"}
+        )
+        assert t.type == "user"
+
+    def test_frozen(self):
+        t = Teammate.model_validate(
+            {"id": "tea_abc", "email": "a@x.com", "username": "alice"}
+        )
+        with pytest.raises(pydantic.ValidationError):
+            t.id = "tea_xyz"  # type: ignore[misc]
+
+    def test_missing_required_field_rejected(self):
+        with pytest.raises(pydantic.ValidationError):
+            Teammate.model_validate({"id": "tea_abc"})  # no email/username
+
+
+# ---------------------------------------------------------------------------
+# Helper: Teammates
+# ---------------------------------------------------------------------------
+
+
+def _teammate_payload(**overrides) -> dict:
+    """Minimal valid TeammateResponse-shaped dict (mirrors test_conversations.py)."""
+    base = {
+        "_links": {"self": "https://x", "related": {}},
+        "id": "tea_1",
+        "email": "a@example.com",
+        "username": "alice",
+        "first_name": "Alice",
+        "last_name": "Adams",
+        "is_admin": False,
+        "is_available": True,
+        "is_blocked": False,
+        "type": "user",
+        "custom_fields": {},
+    }
+    base.update(overrides)
+    return base
+
+
+class TestTeammatesHelper:
+    async def test_list_returns_domain_teammates(
+        self, attach_transport, make_mock_transport
+    ):
+        client = attach_transport(
+            make_mock_transport(
+                {
+                    "_results": [
+                        _teammate_payload(id="tea_1", username="alice"),
+                        _teammate_payload(id="tea_2", username="bob"),
+                    ],
+                    "_pagination": {},
+                    "_links": {},
+                }
+            )
+        )
+
+        teammates = await client.teammates.list()
+        assert len(teammates) == 2
+        assert all(isinstance(t, Teammate) for t in teammates)
+        assert [t.username for t in teammates] == ["alice", "bob"]
+
+    async def test_get_returns_full_teammate(
+        self, attach_transport, make_mock_transport
+    ):
+        client = attach_transport(
+            make_mock_transport(
+                _teammate_payload(
+                    id="tea_abc", username="charlie", is_admin=True, is_available=False
+                )
+            )
+        )
+
+        teammate = await client.teammates.get("tea_abc")
+        assert teammate.id == "tea_abc"
+        assert teammate.is_admin is True
+        assert teammate.is_available is False
+
+    async def test_list_inboxes_returns_domain_inboxes(
+        self, attach_transport, make_mock_transport
+    ):
+        client = attach_transport(
+            make_mock_transport(
+                {
+                    "_results": [
+                        {"id": "inb_1", "name": "Support"},
+                        {"id": "inb_2", "name": "Sales"},
+                    ],
+                    "_pagination": {},
+                    "_links": {},
+                }
+            )
+        )
+
+        inboxes = await client.teammates.list_inboxes("tea_abc")
+        assert len(inboxes) == 2
+        assert all(isinstance(i, Inbox) for i in inboxes)
+
+    async def test_list_assigned_conversations_passes_q_filter(
+        self, attach_transport, make_recording_transport
+    ):
+        transport, recorded = make_recording_transport(
+            {"_results": [], "_pagination": {}, "_links": {}}
+        )
+        client = attach_transport(transport)
+
+        await client.teammates.list_assigned_conversations(
+            "tea_abc", q="status:open", limit=25
+        )
+        assert "/teammates/tea_abc/conversations" in str(recorded[0].url)
+        assert recorded[0].url.params.get("q") == "status:open"
+        assert recorded[0].url.params.get("limit") == "25"
+
+    async def test_update_skips_unset_fields(
+        self, attach_transport, make_recording_transport
+    ):
+        transport, recorded = make_recording_transport(None, status=204)
+        client = attach_transport(transport)
+
+        success = await client.teammates.update("tea_abc", first_name="Alicia")
+        assert success is True
+        body = json.loads(recorded[0].content)
+        assert body == {"first_name": "Alicia"}
+        # Email and other read-only fields not in the body.
+        assert "email" not in body
+        assert "is_admin" not in body
+
+    async def test_update_with_is_available_flag(
+        self, attach_transport, make_recording_transport
+    ):
+        transport, recorded = make_recording_transport(None, status=204)
+        client = attach_transport(transport)
+
+        await client.teammates.update("tea_abc", is_available=False)
+        body = json.loads(recorded[0].content)
+        assert body == {"is_available": False}
+
+    async def test_update_returns_false_on_non_2xx(
+        self, attach_transport, make_mock_transport
+    ):
+        client = attach_transport(
+            make_mock_transport({"_error": {"message": "not found"}}, status=404)
+        )
+
+        # update_teammate uses is_success which returns False for non-2xx;
+        # the helper doesn't raise.
+        success = await client.teammates.update("tea_missing", first_name="x")
+        assert success is False
+
+    def test_teammates_property_lazy_caches(self, mock_api_credentials):
+        from frontapp_public_api_client import FrontappClient
+
+        client = FrontappClient(**mock_api_credentials)
+        first = client.teammates
+        second = client.teammates
+        assert first is second
+
+    # -- iter_assigned_conversations ----------------------------------------
+
+    async def test_iter_assigned_conversations_walks_pages(self, attach_transport):
+        import httpx
+
+        def _conv(id_: str) -> dict:
+            # Minimal shape the unwrap path needs — list_assigned_conversations
+            # returns ConversationResponse items, but we only ever read .id /
+            # url so we don't need full TeammateResponse on assignee.
+            return {
+                "_links": {"self": "https://x", "related": {}},
+                "id": id_,
+                "subject": id_,
+                "status": "assigned",
+                "ticket_ids": [],
+                "assignee": _teammate_payload(),
+                "recipient": {
+                    "_links": {"related": {}},
+                    "name": None,
+                    "handle": "c@x.com",
+                    "role": "to",
+                },
+                "tags": [],
+                "links": [],
+                "custom_fields": {},
+                "is_private": False,
+                "scheduled_reminders": [],
+                "metadata": {},
+            }
+
+        recorded: list[httpx.Request] = []
+        call = {"i": 0}
+        pages = [
+            {
+                "_results": [_conv("cnv_1")],
+                "_pagination": {
+                    "next": "https://api.frontapp.test/teammates/tea_a/conversations?page_token=P2"
+                },
+                "_links": {},
+            },
+            {
+                "_results": [_conv("cnv_2")],
+                "_pagination": {"next": None},
+                "_links": {},
+            },
+        ]
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            recorded.append(request)
+            idx = call["i"]
+            call["i"] += 1
+            return httpx.Response(200, json=pages[idx])
+
+        client = attach_transport(httpx.MockTransport(handler))
+
+        items = [c async for c in client.teammates.iter_assigned_conversations("tea_a")]
+        assert [c.id for c in items] == ["cnv_1", "cnv_2"]
+        assert "/teammates/tea_a/conversations" in str(recorded[0].url)
+        assert recorded[1].url.params.get("page_token") == "P2"


### PR DESCRIPTION
Final follow-up — completes the original list with the teammates vertical that closes the gap on the only major Front resource that had no helper or tools (only a \`frontapp://teammates\` reference resource shipped in PR #20).

## Helper (\`client.teammates\`)

- \`list()\` — every teammate in the workspace (no pagination)
- \`get(teammate_id)\` — full Teammate by id
- \`list_inboxes(teammate_id)\` — inboxes this teammate has access to
- \`list_assigned_conversations(teammate_id, q?, limit?, page_token?)\` — paginated, raw attrs items
- \`iter_assigned_conversations(teammate_id, ...)\` — auto-paginated variant via \`Base._paginate\`
- \`update(teammate_id, ...)\` — only the writable fields (username / first_name / last_name / is_available / custom_fields). Email and admin status are read-only via Front's API; manage those in Front's admin UI.

## Domain projection

\`domain/teammate.py\` adds a full \`Teammate\` Pydantic model. Distinct from the existing \`TeammateSummary\` in \`domain/conversation.py\`, which is the lighter conversation-nested projection used inside \`Conversation.assignee\`.

## MCP tools — 5 total

- **4 reads** (cached 30s): \`list_teammates\`, \`get_teammate\`, \`list_teammate_inboxes\`, \`list_assigned_conversations\`
- **1 mutation** (two-step confirm): \`update_teammate\` — preview surfaces the \`changes\` dict; \`no_changes_requested\` short-circuits empty updates

## Tests — 23 total

- **\`tests/test_teammates.py\`** (14): Teammate domain validation, helper methods including pagination cursor round-trip and is_success/non-2xx behavior, lazy-property cache.
- **\`frontapp_mcp_server/tests/test_teammates_tools.py\`** (9): all 4 read tools project correctly; update preview / no-changes / cancelled / declined / confirmed paths exhaustive.

## Test plan

- [x] \`uv run poe full-check\` exits 0
- [x] \`uv run poe test\`: 415 tests pass (392 from main + 23 new)
- [x] api-facts.yaml regenerated to reflect new helper + domain wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)