### PR TITLE
docs(adr): add ADR-0007 (Domain Helper Classes) and ADR-0010 (MCP Server Architecture)

### DIFF
--- a/frontapp_mcp_server/docs/adr/0010-mcp-server-architecture.md
+++ b/frontapp_mcp_server/docs/adr/0010-mcp-server-architecture.md
@@ -1,0 +1,315 @@
+# ADR-0010: Frontapp MCP Server Architecture
+
+## Status
+
+Accepted
+
+Date: 2026-04-26
+
+## Context
+
+The `frontapp-mcp-server` package exposes Front's Core API as Model Context Protocol
+tools so an AI assistant can list conversations, draft replies, manage tags, look up
+contacts, and so on. Several questions had to be settled up front:
+
+1. **Server framework** — implement MCP from scratch or adopt a library?
+2. **Tool organization** — one giant `tools.py` or per-resource modules?
+3. **Client lifecycle** — how does each tool get a `FrontappClient` without re-
+   authenticating per call?
+4. **Mutation safety** — how do we keep an autonomous agent from sending an email or
+   deleting a contact without explicit human consent?
+5. **Read caching** — Front's rate limit is shared across the whole workspace; how do we
+   keep "list tags" / "list inboxes" from burning every tool call?
+6. **Outbound replies** — should the server expose a "send reply now" tool, or force
+   human review?
+
+These decisions interact: the answers shape every new tool module added per vertical.
+
+## Decision
+
+The Frontapp MCP server is built on **FastMCP** with a per-resource tool layout, a
+lifespan-managed `FrontappClient`, and a two-step confirm pattern on every mutation.
+Outbound replies always go through the drafts surface — there is no programmatic send.
+
+### 1. FastMCP + lifespan-managed `FrontappClient`
+
+The server is a single `FastMCP("frontapp", lifespan=lifespan)` instance. The lifespan
+context manager loads `FRONTAPP_API_KEY`, opens a `FrontappClient`, and exposes it via a
+`Services` dependency-injection object that tools resolve through
+`get_services(context)`:
+
+```python
+@asynccontextmanager
+async def lifespan(server: FastMCP) -> AsyncIterator[Services]:
+    async with FrontappClient(api_key=..., max_retries=5, max_pages=100) as client:
+        yield Services(client=client)
+```
+
+```python
+@mcp.tool(name="get_conversation", description="...")
+async def get_conversation(context: Context, conversation_id: str) -> ConversationSummary:
+    services = get_services(context)
+    conv = await services.client.conversations.get(conversation_id)
+    return to_summary(conv)
+```
+
+Auth lives in the FastMCP layer (bearer token via `MCP_AUTH_TOKEN` or GitHub OAuth via
+`MCP_GITHUB_*`); see `_build_auth()` in `server.py`.
+
+### 2. One tool module per resource (`tools/<resource>.py`)
+
+Each vertical exports a `register_tools(mcp)` function that registers every tool for
+that resource. `tools/__init__.py` exposes a single `register_all_tools(mcp)` entry
+point that the server calls at startup:
+
+```
+tools/
+├── __init__.py        # register_all_tools fan-out
+├── schemas.py         # ConfirmationResult, require_confirmation
+├── conversations.py   # 7 tools (5 read, 2 mutate)
+├── contacts.py        # 12 tools
+├── drafts.py          # 5 tools (drafts-first outbound — see ADR-0016)
+├── inboxes.py         # ...
+├── messages.py        # ...
+├── tags.py            # ...
+└── teammates.py       # ...
+```
+
+The mirror to `helpers/<resource>.py` (ADR-0007) is intentional: each tool module
+delegates to the corresponding client helper. Tool code is thin glue — argument shaping,
+projection to summary types, and the confirm gate.
+
+### 3. Two-step confirm on every mutation
+
+Every mutating tool takes a `confirm: bool = False` parameter. The pattern:
+
+```python
+async def update_conversation(
+    context: Context,
+    conversation_id: str,
+    status: str | None = None,
+    confirm: Annotated[bool, Field(description="Must be true to apply")] = False,
+) -> dict[str, Any]:
+    if not confirm:
+        # Preview: return what would change without executing
+        return {"action": "update_conversation", "preview": ..., "confirm_required": True}
+
+    # Confirm via FastMCP elicitation — the client surfaces a yes/no prompt to the user
+    result = await require_confirmation(
+        context, f"Update conversation {conversation_id}?"
+    )
+    if result is not ConfirmationResult.CONFIRMED:
+        return {"status": "cancelled", ...}
+
+    # Execute
+    services = get_services(context)
+    await services.client.conversations.update(conversation_id, status=status)
+    return {"status": "updated", ...}
+```
+
+`require_confirmation` (in `tools/schemas.py`) wraps
+`ctx.elicit(message, ConfirmationSchema)` and returns one of `CONFIRMED` / `CANCELLED` /
+`DECLINED`. The `confirm=False` preview path is the agent's contract: it sees what would
+happen, can narrate it to the user, then re-invokes with `confirm=True` to actually
+apply. The elicitation step is a second backstop — if the user is sitting at the client,
+they explicitly approve before the call lands on Front.
+
+The confirm gate is **per-tool**, not transport-level. Every mutating tool wires it in
+the same shape; the helpers (ADR-0007) themselves don't gate.
+
+### 4. Read tools are cached via `ResponseCachingMiddleware`
+
+Read-only tools (every name in the `_READ_ONLY_TOOLS` set in `server.py`) go through
+FastMCP's `ResponseCachingMiddleware` with a single shared TTL —
+`CallToolSettings(ttl=30, included_tools=_READ_ONLY_TOOLS)` — plus
+`ReadResourceSettings(ttl=60)` for reference resources (`frontapp://tags`,
+`frontapp://inboxes`, `frontapp://teammates`). The cache lives in an in-memory
+`MemoryStore`; it does not persist across restarts.
+
+Caching is applied via the `_READ_ONLY_TOOLS` set so a new vertical only needs to extend
+that set when adding read tools — no per-tool middleware wiring. If a future tool needs
+a different TTL than 30s, a per-tool override can be added; today every cached tool
+shares the 30s value.
+
+### 5. Drafts-first outbound (no programmatic send)
+
+There is **no `send_message` or `reply_to_conversation` tool** that bypasses human
+review. Outbound replies are exclusively created as drafts via the `drafts` vertical
+(`create_draft_reply`, `create_draft_on_channel`, `edit_draft`, `delete_draft`). The
+draft lands in Front's UI; a human reviews and clicks send.
+
+Draft mutations still use the §3 two-step confirm pattern (`confirm=False` returns a
+preview; `confirm=True` plus `require_confirmation` executes), so the agent sees a
+preview before the draft is even created. The drafts-first guarantee is at a higher
+level: even after the draft lands, sending requires a human in Front's UI — there is no
+programmatic send. See ADR-0016 → "Drafts-first outbound" for the full reasoning.
+
+The `instructions=` block on the `FastMCP(...)` call documents this contract for the
+agent at session start, including the rule "There is no programmatic 'send a reply now'
+tool. By design — agents draft; humans send."
+
+### 6. Domain-summary projections for tool responses
+
+Tool responses use the `ConversationSummary` / `ContactSummary` / etc. projections from
+`frontapp_mcp/projections.py`, not the full Pydantic domain models. Summaries strip the
+fields LLMs don't need (`_links`, `metadata`, `custom_fields`, `ticket_ids`) to keep
+tool-response token counts low. Full detail is one method call away if the agent needs
+it.
+
+## Consequences
+
+### Positive
+
+1. **Stereotyped vertical layout** — adding a new vertical is a copy-modify exercise.
+   The mirror between `helpers/<resource>.py` (ADR-0007) and `tools/<resource>.py` keeps
+   the surface predictable.
+2. **Mutations are safe by default** — every destructive call surfaces a preview and a
+   confirmation prompt before it lands. An agent that hasn't internalized "confirm:
+   true" can't accidentally delete a contact.
+3. **No surprise sends** — drafts-first outbound means the only way to reach a customer
+   is through Front's UI, with a human in the loop. The MCP server cannot be tricked
+   into dispatching a real reply.
+4. **Read calls are cheap** — reference data (tags, inboxes, teammates) caches across
+   tool invocations within a session. A long-running agent doesn't burn rate limit
+   re-listing the workspace catalog every turn.
+5. **One auth boundary** — `lifespan` initializes the client once. Tools never see the
+   API key directly; they get a configured client through `Services`.
+6. **Token economy** — summary projections keep tool responses small. The agent gets
+   what it needs; the verbose API shape stays one layer down.
+
+### Negative
+
+1. **Tool-author discipline** — every new mutating tool has to wire the confirm gate by
+   hand. Easy to forget. Mitigated by the canonical template (`tools/conversations.py`),
+   the `vertical-planner` agent, and CI tests
+   (`test_<resource>_tools_two_step_confirm`).
+2. **No batch mutations** — each mutation requires its own confirm. An agent that wants
+   to retag 50 conversations does 50 confirms. Acceptable: this is the safety floor.
+3. **Cache invalidation is loose** — read caching is TTL-based with no per-mutation
+   invalidation. After `update_tag(name=...)`, a `list_tags` call may briefly serve the
+   stale name until the TTL expires. Acceptable for reference data; tools that need
+   fresh state can call `get_*` directly.
+4. **Two ways to read** — `client.conversations.get(...)` from Python code vs
+   `get_conversation` from MCP. Both exist by design (the helper is the Pythonic entry
+   point; the MCP tool is the agent-facing entry point) but the maintenance weight is
+   real.
+
+### Neutral
+
+1. **`help.py` resource is hand-maintained** — the
+   [Help resource drift](../../../CLAUDE.md#known-pitfalls) pitfall is that
+   `resources/help.py` contains tool-doc Markdown that has to stay in sync with each
+   tool module. ADR-0017 (Automated Tool Documentation) tracks moving this to generated
+   content.
+2. **`instructions=` is the runtime cheat-sheet** — the FastMCP `instructions` block in
+   `server.py` is loaded into every agent session and is the canonical place to document
+   tool-selection rules and safety patterns. New verticals add a section.
+3. **Auth is optional** — bearer token / GitHub OAuth are env-configured and the server
+   runs unauthenticated by default. Suitable for local dev; production deployments must
+   set `MCP_AUTH_TOKEN` or `MCP_GITHUB_*`.
+
+## Alternatives considered
+
+### One giant `tools.py`
+
+All tools registered in a single module.
+
+**Rejected**: with ~50 tools across 7 verticals, the file would be unreadable. Per-
+resource modules co-locate related tools and make it obvious where to add a new one.
+
+### Confirm at the helper layer instead of per-tool
+
+Move the two-step confirm into `client.conversations.update(..., confirm=True)`.
+
+**Rejected**: the confirm gate is an MCP-runtime safety feature; the Python helper
+shouldn't gate. Library callers (scripts, tests, application code) need to be able to
+call mutations directly without a confirm dance — they're not in the agent threat model.
+
+### Single `confirm=True` flag set at session start
+
+Have the user enable an "agent autonomy" mode once, and skip per-call confirms
+afterward.
+
+**Rejected**: defeats the point. The two-step confirm exists to make every individual
+mutation visible, not to gate the agent's general access. Per-call confirm is the safety
+floor.
+
+### Direct `send_reply` tool with a confirm gate
+
+Provide `reply_to_conversation` with the standard two-step confirm.
+
+**Rejected**: drafts-first is a stronger guarantee. Even with a confirm prompt, an agent
+can hold context that misleads the user (wrong tone, wrong recipient, leaked secret) and
+the user might confirm without catching it. Forcing the draft to land in Front's UI puts
+the message in front of a human in its final form, in their actual inbox UI, before it
+ships.
+
+### Re-authenticate per tool call
+
+Open a `FrontappClient` inside each tool function.
+
+**Rejected**: kills connection reuse, multiplies env-var loads, and obscures the client
+config. Lifespan management is the FastMCP-idiomatic pattern.
+
+### Generate tool modules from helpers automatically
+
+Auto-derive tool definitions from helper signatures.
+
+**Rejected — for now**: the per-tool description, parameter docstrings, summary
+projection shape, and confirm-gate logic involve enough judgment that codegen would be
+more brittle than copy-modify. Revisit if the tool count grows past ~100 and the
+hand-maintenance cost dominates.
+
+## Implementation notes
+
+### Adding a vertical's MCP tools
+
+Encoded in the `/new-vertical` skill. Mirror the canonical template
+(`tools/conversations.py`):
+
+1. Create `tools/<resource>.py` with a `register_tools(mcp)` function.
+2. For each helper method, write a `@mcp.tool(name=..., description=...)` async function
+   that calls the helper through `get_services(context)`.
+3. Mutations get `confirm: bool = False` + a preview branch + `require_confirmation`.
+4. Wire `register_<resource>_tools(mcp)` into `tools/__init__.py:register_all_tools`.
+5. Add read-only tool names to `_READ_ONLY_TOOLS` in `server.py` for caching.
+6. Extend the `instructions=` block in `server.py` with a section on the new vertical
+   (domain model, tool-selection guide, safety pattern).
+7. Update `resources/help.py` Markdown — the help drift pitfall.
+8. Tests: `test_<resource>_tools.py` covers reads and the two-step confirm flow for
+   every mutating tool — confirm/elicitation cases live alongside the happy-path tests
+   in the same module (e.g. `test_conversations_tools.py`).
+
+### Why FastMCP
+
+The MCP protocol has multiple Python implementations; FastMCP was chosen because:
+
+- Built-in lifespan management via `@asynccontextmanager`
+- First-class `ctx.elicit()` for the two-step confirm pattern
+- Pydantic-native parameter annotations (ADR-0016 → "Tool Interface Pattern")
+- Response caching middleware ships with the framework
+- Maintained, with an active community and faster cadence on protocol updates than
+  hand-rolling
+
+### `_fastmcp_patches.py`
+
+A small monkey-patch keeps FastMCP working with Pydantic 2.12+. Applied once at import
+time before any tool is registered. See module docstring for details. Will be removed
+when FastMCP upstream merges the equivalent fix.
+
+## References
+
+- [`server.py`](https://github.com/dougborg/frontapp-openapi-client/blob/main/frontapp_mcp_server/src/frontapp_mcp/server.py)
+  — server entry point with lifespan + auth + caching
+- [`tools/conversations.py`](https://github.com/dougborg/frontapp-openapi-client/blob/main/frontapp_mcp_server/src/frontapp_mcp/tools/conversations.py)
+  — canonical tool-module template
+- [`tools/schemas.py`](https://github.com/dougborg/frontapp-openapi-client/blob/main/frontapp_mcp_server/src/frontapp_mcp/tools/schemas.py)
+  — `require_confirmation` and `ConfirmationResult`
+- [`projections.py`](https://github.com/dougborg/frontapp-openapi-client/blob/main/frontapp_mcp_server/src/frontapp_mcp/projections.py)
+  — summary projections for tool responses
+- [ADR-0007: Domain Helper Classes](../../../frontapp_public_api_client/docs/adr/0007-domain-helper-classes.md)
+  — the helper layer that every tool module delegates to
+- [ADR-0016: Tool Interface Pattern](0016-tool-interface-pattern.md) — per-parameter
+  Pydantic annotations and drafts-first outbound
+- [ADR-0017: Automated Tool Documentation](0017-automated-tool-documentation.md) — the
+  follow-up to remove `resources/help.py` drift

--- a/frontapp_mcp_server/docs/adr/0010-mcp-server-architecture.md
+++ b/frontapp_mcp_server/docs/adr/0010-mcp-server-architecture.md
@@ -197,10 +197,10 @@ it.
 ### Neutral
 
 1. **`help.py` resource is hand-maintained** — the
-   [Help resource drift](../../../CLAUDE.md#known-pitfalls) pitfall is that
-   `resources/help.py` contains tool-doc Markdown that has to stay in sync with each
-   tool module. ADR-0017 (Automated Tool Documentation) tracks moving this to generated
-   content.
+   [Help resource drift](https://github.com/dougborg/frontapp-openapi-client/blob/main/CLAUDE.md#known-pitfalls)
+   pitfall is that `resources/help.py` contains tool-doc Markdown that has to stay in
+   sync with each tool module. ADR-0017 (Automated Tool Documentation) tracks moving
+   this to generated content.
 2. **`instructions=` is the runtime cheat-sheet** — the FastMCP `instructions` block in
    `server.py` is loaded into every agent session and is the canonical place to document
    tool-selection rules and safety patterns. New verticals add a section.
@@ -307,7 +307,7 @@ when FastMCP upstream merges the equivalent fix.
   — `require_confirmation` and `ConfirmationResult`
 - [`projections.py`](https://github.com/dougborg/frontapp-openapi-client/blob/main/frontapp_mcp_server/src/frontapp_mcp/projections.py)
   — summary projections for tool responses
-- [ADR-0007: Domain Helper Classes](../../../frontapp_public_api_client/docs/adr/0007-domain-helper-classes.md)
+- [ADR-0007: Domain Helper Classes](https://github.com/dougborg/frontapp-openapi-client/blob/main/frontapp_public_api_client/docs/adr/0007-domain-helper-classes.md)
   — the helper layer that every tool module delegates to
 - [ADR-0016: Tool Interface Pattern](0016-tool-interface-pattern.md) — per-parameter
   Pydantic annotations and drafts-first outbound

--- a/frontapp_mcp_server/docs/adr/README.md
+++ b/frontapp_mcp_server/docs/adr/README.md
@@ -19,6 +19,7 @@ We use the format proposed by Michael Nygard in
 
 ### Accepted
 
+- [ADR-0010: Frontapp MCP Server Architecture](0010-mcp-server-architecture.md)
 - [ADR-0016: Tool Interface Pattern](0016-tool-interface-pattern.md)
 - [ADR-0017: Automated Tool Documentation](0017-automated-tool-documentation.md)
 

--- a/frontapp_public_api_client/docs/adr/0007-domain-helper-classes.md
+++ b/frontapp_public_api_client/docs/adr/0007-domain-helper-classes.md
@@ -1,0 +1,267 @@
+# ADR-0007: Domain Helper Classes
+
+## Status
+
+Accepted
+
+Date: 2026-04-26
+
+## Context
+
+The generated API surface — `from frontapp_public_api_client.api.<tag> import <op>` —
+exposes every endpoint Front's spec defines. It is direct, type-safe, and complete, but
+the per-call boilerplate adds up:
+
+```python
+from frontapp_public_api_client.api.conversations import list_conversations
+from frontapp_public_api_client.models.list_conversations_sort_order import (
+    ListConversationsSortOrder,
+)
+from frontapp_public_api_client.utils import unwrap
+
+response = await list_conversations.asyncio_detailed(
+    client=client,
+    q="status:open tag:urgent",
+    limit=50,
+    sort_order=ListConversationsSortOrder("desc"),
+)
+parsed = unwrap(response)
+results = getattr(parsed, "field_results", None) or []
+convs = [Conversation.model_validate(c.to_dict()) for c in results]
+```
+
+Every caller repeats five steps:
+
+1. Import the generated endpoint module
+2. Import any enum models for typed parameters
+3. Call `asyncio_detailed`
+4. Unwrap the response and dig out `field_results` (the `_results` → `field_results`
+   rename is a documented Known Pitfall)
+5. Project attrs models into Pydantic domain models (ADR-0011) for business code
+
+The same five steps repeat across MCP tools, scripts, application code. Multiplying that
+over ~30 resources and several methods per resource produces a lot of duplicated wiring.
+
+The auto-pagination cursor walk is even more boilerplate: each iterator implementation
+needs to extract the next-page token from `_pagination.next`, feed it back into the next
+call, terminate on empty pages, and respect `max_pages` / `max_items` caps.
+
+## Decision
+
+Provide **hand-written ergonomic facades** in `frontapp_public_api_client.helpers.*`,
+exposed as lazy properties on `FrontappClient`:
+
+```python
+async with FrontappClient() as client:
+    convs = await client.conversations.list(q="status:open tag:urgent", limit=50)
+    async for conv in client.conversations.iter_all(q="status:open"):
+        ...
+```
+
+The shape:
+
+- **One module per resource** — `helpers/conversations.py`, `helpers/contacts.py`,
+  `helpers/drafts.py`, `helpers/messages.py`, `helpers/tags.py`, `helpers/inboxes.py`,
+  `helpers/teammates.py`. New verticals add a sibling module.
+- **Class inherits from `Base`** — defined in `helpers/base.py`. `Base.__init__` stores
+  the `FrontappClient`; `Base._paginate` walks Front's cursor pagination so each
+  helper's `iter_*` methods are a thin wrapper.
+- **Lazy property on `FrontappClient`** — `client.conversations` instantiates
+  `Conversations(self)` on first access and caches it. New verticals add a property next
+  to the existing ones.
+- **Method-level imports** — generated endpoint modules and enum models are imported
+  inside each method, not at module top-level. Keeps
+  `from frontapp_public_api_client import FrontappClient` fast and avoids dragging the
+  entire `api/` tree into every caller's import graph.
+- **Returns Pydantic domain models** — list/get methods project attrs through
+  `Conversation.model_validate(item.to_dict())` (see ADR-0011). Mutations return the
+  fresh domain model after the call.
+- **Naming mirrors Front, not the spec quirks** — `client.contacts.update(...)` even
+  though the generated module is `update_a_contact` (the `_a_` infix is openapi-python-
+  client's handling of "Update a contact" summaries). Helper names hide the quirk.
+
+### The canonical template
+
+`helpers/conversations.py` is the canonical template — when scaffolding a new vertical,
+mirror its structure:
+
+```python
+class Conversations(Base):
+    """Ergonomic operations over Frontapp's ``/conversations*`` endpoints."""
+
+    async def list(self, *, q=None, limit=None, page_token=None, ...) -> list[Conversation]:
+        from frontapp_public_api_client.api.conversations import list_conversations
+        from frontapp_public_api_client.domain import Conversation
+        from frontapp_public_api_client.utils import unwrap
+
+        response = await list_conversations.asyncio_detailed(
+            client=self._client, q=q, limit=limit, page_token=page_token, ...
+        )
+        parsed = unwrap(response)
+        results = getattr(parsed, "field_results", None) or []
+        return [Conversation.model_validate(c.to_dict()) for c in results]
+
+    async def iter_all(self, *, q=None, limit=None, ...) -> AsyncIterator[Conversation]:
+        from frontapp_public_api_client.api.conversations import list_conversations
+        from frontapp_public_api_client.domain import Conversation
+
+        async for conv in self._paginate(
+            list_conversations.asyncio_detailed,
+            projector=lambda item: Conversation.model_validate(item.to_dict()),
+            q=q, limit=limit,
+        ):
+            yield conv
+```
+
+### Why classes, not modules of free functions
+
+Three reasons the helpers are classes (with `Base.__init__` storing the client) rather
+than free functions taking a `FrontappClient` argument:
+
+1. **Bound client** — `client.conversations.list(...)` reads cleaner than
+   `conversations.list(client, ...)`, and the bound shape mirrors how the underlying
+   resource is structured ("operations on conversations" → a Conversations object).
+2. **Shared pagination machinery** — `Base._paginate` is genuinely shared state-aware
+   logic (max_pages defaults from the client, debug logging via `self._client.logger`).
+   Inheriting it is cheaper than passing it around.
+3. **Lazy property registration** — the `FrontappClient.<resource>` property pattern
+   needs an instance to attach to. A class is the natural target.
+
+## Consequences
+
+### Positive
+
+1. **Boilerplate elimination** — five steps collapse to one method call.
+2. **Discoverability** — IDE autocomplete on `client.` reveals every vertical at once.
+3. **Single canonical pattern** — the `Base` + lazy-property + `Helpers(Base)` shape is
+   stereotyped enough that a new vertical is a search-and-replace exercise. The
+   `/new-vertical` skill (`.claude/skills/new-vertical/`) and `vertical-planner` agent
+   (`.claude/agents/vertical-planner.md`) encode this.
+4. **Domain-model projection happens at the boundary** — every helper returns Pydantic
+   domain models, never raw attrs. Callers don't need `unwrap_unset` or `to_dict()`.
+5. **Method-level imports keep the package light** — `import FrontappClient` does not
+   transitively import every generated endpoint module.
+6. **`field_results` gotcha is hidden** — every helper's list method does the
+   `getattr(parsed, "field_results", None) or []` dance once; callers never see it.
+7. **Cursor pagination is one line** — `iter_all` is a thin wrapper around
+   `Base._paginate`; the next-token extraction and termination logic is shared.
+
+### Negative
+
+1. **Two API layers to know about** — generated `api/<tag>` access is still available
+   for endpoints we haven't wrapped, so the client has both a direct-access surface and
+   a helper surface. Document which one to reach for in `guide.md` (helpers first;
+   direct access for unwrapped endpoints).
+2. **Duplication risk** — every helper repeats the same import-and-unwrap shape. If we
+   ever change the unwrap convention (e.g. moving from `unwrap` to a different helper),
+   every method needs an edit. Mitigated by the `vertical-planner` plan-before-code
+   workflow and the canonical-template reference.
+3. **Hand-written, so it lags spec changes** — when Front adds a new endpoint, the
+   helper layer doesn't pick it up automatically; someone has to file a vertical issue
+   and ship it. Acceptable: the helper layer is selectively curated, not exhaustive.
+
+### Neutral
+
+1. **Hand-written code is in the typecheck task scope** — `helpers/` is included in
+   `uv run poe typecheck`'s path list, unlike the generated `api/` and `models/` trees
+   which are excluded (issue #8). Helper changes get the full type-check rigor.
+2. **Mutations need a return-value decision per resource** — most return the fresh
+   domain model after the call; some (delete, archive) return `None`. No global rule —
+   the canonical template shows the common cases.
+3. **Two-step confirm lives in the MCP layer, not here** — the helper layer is the
+   ergonomic Python surface; the MCP layer adds confirm-before-execute for agent safety
+   (see ADR-0010). Helpers themselves don't gate.
+
+## Alternatives considered
+
+### Free functions taking a client argument
+
+```python
+from frontapp_public_api_client.helpers.conversations import list_conversations
+
+convs = await list_conversations(client, q="status:open")
+```
+
+**Rejected**: loses bound-client ergonomics and IDE autocomplete-on-`client.`
+discoverability. Forces callers to import every helper module separately.
+
+### Mixin into `FrontappClient`
+
+```python
+client = FrontappClient()
+await client.list_conversations(q="status:open")
+```
+
+**Rejected**: explodes the client's namespace (~50 methods across ~30 verticals). Loses
+the resource grouping that `client.conversations.list()` makes obvious. Makes the client
+class hard to read.
+
+### Module-level helpers without classes (free functions in `helpers/conversations.py`)
+
+A class-free version of the helper modules: `helpers/conversations.py` exports
+`async def list(client, ...)`, etc.
+
+**Rejected**: doesn't compose cleanly with the lazy-property pattern (no instance for
+the property to return), can't share `_paginate` without passing the client into every
+call, and reads worse at the call site.
+
+### Code-generate helpers from the spec
+
+Auto-generate the helper layer from `docs/frontapp-openapi.yaml` with a separate codegen
+pass.
+
+**Rejected — for now**: the helper layer is intentionally selective (it doesn't wrap
+every endpoint, only the high-traffic ones), and the projection-to-domain-model step is
+a judgment call that doesn't generate cleanly. Revisit if the matrix of wrapped
+endpoints grows large enough that hand-writing becomes the bottleneck.
+
+## Implementation notes
+
+### Adding a new helper vertical
+
+The full sequence is encoded in the `/new-vertical` skill. Briefly:
+
+1. Run the `vertical-planner` agent to produce a plan that confirms generated module
+   names and list-response shapes (the `field_results` vs raw-array question is
+   pre-computed in `docs/api-facts.yaml`).
+2. Create `frontapp_public_api_client/domain/<resource>.py` (Pydantic projections,
+   ADR-0011).
+3. Create `frontapp_public_api_client/helpers/<resource>.py` (`class Resource(Base)`).
+4. Add a lazy property to `FrontappClient` and a `TYPE_CHECKING` import.
+5. Add the helper class to `helpers/__init__.py` `__all__`.
+6. Wire the MCP tool module (ADR-0010) and update `resources/help.py`.
+7. Tests + README coverage table.
+
+### Cross-vertical sub-resources
+
+Some helpers span multiple generated tags. `client.contacts` covers the `contacts/`,
+`contact_handles/`, and `contact_notes/` tags as one logical resource — sub-resource
+methods (`add_handle`, `delete_handle`, `add_note`, `list_notes`) live on the same
+`Contacts` class. Mirror this when a new vertical's endpoints are split across spec
+tags.
+
+### `iter_*` variants
+
+Every list method has a sibling `iter_*` that walks pages automatically via
+`Base._paginate`. The `iter_*` form is the auto-pagination async iterator from ADR-003 —
+preferred when iterating every match in a query, since the cursor plumbing and
+termination logic stay hidden.
+
+## References
+
+- [`helpers/base.py`](https://github.com/dougborg/frontapp-openapi-client/blob/main/frontapp_public_api_client/helpers/base.py)
+  — `Base` class with `_paginate`
+- [`helpers/conversations.py`](https://github.com/dougborg/frontapp-openapi-client/blob/main/frontapp_public_api_client/helpers/conversations.py)
+  — canonical template
+- [ADR-002: Generate Client from OpenAPI Specification](0002-openapi-code-generation.md)
+  — the layer this sits on top of
+- [ADR-003: Transparent Automatic Pagination](0003-transparent-pagination.md) — the
+  pagination model that `Base._paginate` implements
+- [ADR-006: Utility Functions for Response Unwrapping](0006-response-unwrapping-utilities.md)
+  — the `unwrap` / `unwrap_as` helpers used internally
+- [ADR-008: Avoid Traditional Builder Pattern](0008-avoid-builder-pattern.md) — why
+  helpers are direct method calls, not fluent chains
+- [ADR-0011: Pydantic Domain Models for Business Entities](0011-pydantic-domain-models.md)
+  — what helpers return
+- [`docs/api-facts.yaml`](https://github.com/dougborg/frontapp-openapi-client/blob/main/docs/api-facts.yaml)
+  — facts file the `vertical-planner` agent and humans consult before writing a helper

--- a/frontapp_public_api_client/docs/adr/README.md
+++ b/frontapp_public_api_client/docs/adr/README.md
@@ -25,12 +25,10 @@ We use the format proposed by Michael Nygard in
 - [ADR-004: Defer Observability to httpx](0004-defer-observability-to-httpx.md)
 - [ADR-005: Provide Both Sync and Async APIs](0005-sync-async-apis.md)
 - [ADR-006: Utility Functions for Response Unwrapping](0006-response-unwrapping-utilities.md)
+- [ADR-0007: Domain Helper Classes](0007-domain-helper-classes.md)
+- [ADR-008: Avoid Traditional Builder Pattern](0008-avoid-builder-pattern.md)
 - [ADR-011: Pydantic Domain Models for Business Entities](0011-pydantic-domain-models.md)
 - [ADR-012: Validation Tiers for Agent Workflows](0012-validation-tiers-for-agent-workflows.md)
-
-### Proposed
-
-- [ADR-008: Avoid Traditional Builder Pattern](0008-avoid-builder-pattern.md)
 
 ## Related
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -149,7 +149,8 @@ nav:
           - ADR-004 Defer Observability to httpx: client/adr/0004-defer-observability-to-httpx.md
           - ADR-005 Sync and Async APIs: client/adr/0005-sync-async-apis.md
           - ADR-006 Response Unwrapping Utilities: client/adr/0006-response-unwrapping-utilities.md
-          - ADR-008 Avoid Builder Pattern (Proposed): client/adr/0008-avoid-builder-pattern.md
+          - ADR-0007 Domain Helper Classes: client/adr/0007-domain-helper-classes.md
+          - ADR-008 Avoid Builder Pattern: client/adr/0008-avoid-builder-pattern.md
           - ADR-011 Pydantic Domain Models: client/adr/0011-pydantic-domain-models.md
           - ADR-012 Validation Tiers: client/adr/0012-validation-tiers-for-agent-workflows.md
   - MCP Server:
@@ -161,6 +162,7 @@ nav:
       - Logging: mcp-server/LOGGING.md
       - ADRs:
           - Overview: mcp-server/adr/README.md
+          - ADR-0010 MCP Server Architecture: mcp-server/adr/0010-mcp-server-architecture.md
           - ADR-0016 Tool Interface Pattern: mcp-server/adr/0016-tool-interface-pattern.md
           - ADR-0017 Automated Tool Documentation: mcp-server/adr/0017-automated-tool-documentation.md
   - API Reference: reference/


### PR DESCRIPTION
## Summary

Closes #31. Both ADRs were referenced from agent prompts and `ARCHITECTURE_QUICK_REF.md` but did not exist. Numbering had skipped 0007 / 0010 deliberately, but the cited ADRs were never written.

- **ADR-0007: Domain Helper Classes** — codifies the `helpers/<resource>.py` + `Base` + lazy-property pattern (canonical: `helpers/conversations.py`). Documents why classes (vs free functions or mixins), how method-level imports keep the package light, and the relationship to ADR-0011 (Pydantic domain projection at the helper boundary).
- **ADR-0010: Frontapp MCP Server Architecture** — codifies FastMCP + lifespan-managed `FrontappClient` + `tools/<resource>.py` per-resource layout + two-step confirm + drafts-first outbound. Documents read-tool caching via `ResponseCachingMiddleware` and the tool→helper delegation that mirrors ADR-0007.

Both files are pure docs; no code changes.

## Test plan

- [x] `uv run poe quick-check` passes
- [x] Cross-references resolve (`ADR-0007`, `ADR-0010`, paths from `frontapp_mcp_server/docs/adr/0010-...` → `../../../frontapp_public_api_client/docs/adr/0007-...`)
- [x] Both ADR README index files updated to list the new entries
- [x] Stale references to old paths under `.github/agents/guides/shared/ARCHITECTURE_QUICK_REF.md` will be addressed when that tree is removed in the harness-cleanup PR (#39, #17)

🤖 Generated with [Claude Code](https://claude.com/claude-code)