### PR TITLE
feat(client,mcp): attachment upload + download support (#12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ highest-value subset. Current status:
 | Tags          | ✅ `.tags`                   | list (+ company/team/teammate scopes) / get / list_children / list_tagged_conversations / add_tag_to_conversation / remove_tag_from_conversation / create / create_child / update / delete       |
 | Inboxes       | ✅ `.inboxes`                | list (+ team/teammate scopes) / get / list_conversations / list_channels / list_access / create (+ team) / grant_access / revoke_access                                                          |
 | Teammates     | ✅ `.teammates`              | list / get / list_inboxes / list_assigned_conversations / update                                                                                                                                 |
+| Attachments   | ✅ `.attachments`            | download_attachment + `attachment_paths` parameter on every draft / reply / comment tool                                                                                                         |
 | Analytics     | ⏳ planned                   | ⏳ planned (create→poll recipe)                                                                                                                                                                  |
 
 See the [issue tracker](https://github.com/dougborg/frontapp-openapi-client/issues) for

--- a/frontapp_mcp_server/src/frontapp_mcp/resources/help.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/resources/help.py
@@ -52,6 +52,30 @@ programmatic ``send_draft``.
 | `edit_draft` | `PATCH /drafts/{id}/` | Full-replacement edit of an existing draft (`body` + `channel_id` required). Two-step confirm. |
 | `delete_draft` | `DELETE /drafts/{id}` | Discard a draft. Two-step confirm. |
 
+### Attachments on drafts / replies / comments
+
+`create_draft_on_channel`, `create_draft_reply`, and `edit_draft` accept an
+optional `attachment_paths=[...]` parameter — a list of ABSOLUTE filesystem
+paths read at tool-invocation time. Each path is validated (must exist, be
+a regular file, ≤25 MB), MIME-type-inferred, and shipped to Front as
+`multipart/form-data`. The preview includes filename + size for human
+review. Note: `edit_draft` REPLACES the attachment list — any file not
+listed is dropped.
+
+`add_conversation_comment` (in the conversations vertical) takes the same
+`attachment_paths` parameter when you want to attach files to an internal
+note.
+
+## Attachments
+
+| Tool | Endpoint | Purpose |
+| ---- | -------- | ------- |
+| `download_attachment` | `GET /download/{attachment_link_id}` (and 4 sibling paths) | Fetch attachment bytes by URL (the value Front returns on `Attachment.url`) and write to a local filesystem path. Two-step confirm protects against unintended writes. The five `/download/...` paths are stripped from the spec because openapi-python-client can't model binary responses; this tool bypasses the generated client. |
+
+The download tool writes bytes to disk and returns metadata only — never
+the raw bytes themselves, which would explode token usage. Pass an
+absolute `save_path` whose parent already exists.
+
 ## Contacts
 
 A contact is a person identified by one or more handles (email/phone/etc.).

--- a/frontapp_mcp_server/src/frontapp_mcp/server.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/server.py
@@ -319,6 +319,27 @@ start to translate names/emails into `tea_*` ids.
   only — email and admin status are read-only via this API; manage
   those in Front's admin UI)
 
+## Attachments
+
+Front carries attachments as `multipart/form-data` on the create / edit
+endpoints (drafts, replies, comments) and exposes a binary `/download`
+endpoint for fetching them back out.
+
+**Uploading (on draft / reply / comment):**
+  Pass an `attachment_paths=[...]` list of ABSOLUTE filesystem paths to
+  `create_draft_reply` / `create_draft_on_channel` / `edit_draft`. Each
+  path is read at tool-invocation time, validated (must exist, be a
+  regular file, ≤25 MB), MIME-type-inferred, and shipped multipart. The
+  preview surfaces filename + size for human review before the upload
+  runs. Note: `edit_draft` REPLACES the attachment list — anything not
+  passed is dropped from the draft.
+
+**Downloading:**
+  download_attachment(attachment_url, save_path) — pulls bytes from
+  `Attachment.url` (the URL Front returns on every attachment record)
+  and writes them to a local file. Two-step confirm protects the local
+  filesystem; the response includes only metadata (path, size).
+
 ## Front Search Syntax (q parameter)
 
   status:open | status:archived | tag:urgent | assignee:me |

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/__init__.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/__init__.py
@@ -10,6 +10,7 @@ from fastmcp import FastMCP
 
 def register_all_tools(mcp: FastMCP) -> None:
     """Register every tool module with the FastMCP instance."""
+    from .attachments import register_tools as register_attachments_tools
     from .contacts import register_tools as register_contacts_tools
     from .conversations import register_tools as register_conversations_tools
     from .drafts import register_tools as register_drafts_tools
@@ -18,6 +19,7 @@ def register_all_tools(mcp: FastMCP) -> None:
     from .tags import register_tools as register_tags_tools
     from .teammates import register_tools as register_teammates_tools
 
+    register_attachments_tools(mcp)
     register_contacts_tools(mcp)
     register_conversations_tools(mcp)
     register_drafts_tools(mcp)

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/attachments.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/attachments.py
@@ -1,0 +1,129 @@
+"""MCP tools for Frontapp attachment download.
+
+Front's binary-download endpoints (``/download/{attachment_link_id}``,
+``/messages/{id}/download/...``, etc.) are stripped from the spec by
+``scripts/vendor_spec.py`` because openapi-python-client can't model them.
+The client-side ``client.attachments.download`` helper bypasses the
+generated API to fetch them; this module exposes that as an MCP tool.
+
+Returning raw binary blobs over MCP would balloon the agent's token budget
+(and most LLMs can't do useful work with random bytes anyway), so the tool
+writes the bytes to a filesystem path the user explicitly passes and
+returns metadata only. Two-step confirm protects against accidental writes
+into unintended paths.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from pathlib import Path
+from typing import Annotated, Any
+
+from fastmcp import Context, FastMCP
+from pydantic import Field
+
+from frontapp_mcp.services import get_services
+from frontapp_mcp.tools.schemas import ConfirmationResult, require_confirmation
+
+
+def register_tools(mcp: FastMCP) -> None:
+    """Register attachment-related tools with the FastMCP server."""
+
+    @mcp.tool(
+        name="download_attachment",
+        description=(
+            "Download a Front attachment by URL and write it to a local "
+            "file. The URL is the value Front returns on Attachment.url "
+            "(e.g. https://yourCompany.api.frontapp.com/download/fil_abc). "
+            "Two-step confirm: confirm=False returns a preview of where "
+            "the file will be written; confirm=True performs the download. "
+            "Returns the saved path and byte count."
+        ),
+    )
+    async def download_attachment(
+        context: Context,
+        attachment_url: Annotated[
+            str,
+            Field(
+                description=(
+                    "Full attachment download URL from Attachment.url, e.g. "
+                    "'https://yourCompany.api.frontapp.com/download/fil_abc'"
+                )
+            ),
+        ],
+        save_path: Annotated[
+            str,
+            Field(
+                description=(
+                    "Absolute filesystem path to write the bytes to. The "
+                    "parent directory must already exist; the file will be "
+                    "created or overwritten."
+                )
+            ),
+        ],
+        confirm: Annotated[
+            bool, Field(description="Must be true to perform the download")
+        ] = False,
+    ) -> dict[str, Any]:
+        path = Path(save_path)
+        if not path.is_absolute():
+            return {
+                "error": (
+                    f"save_path {save_path!r} must be absolute — pass a full "
+                    "filesystem path so the location is unambiguous."
+                ),
+                "confirmed": False,
+            }
+        if not path.parent.is_dir():
+            reason = (
+                "does not exist"
+                if not path.parent.exists()
+                else "is not a directory (it's a file)"
+            )
+            return {
+                "error": (
+                    f"Parent path {str(path.parent)!r} {reason}. "
+                    "Choose a save_path inside an existing directory."
+                ),
+                "confirmed": False,
+            }
+
+        preview = {
+            "action": "download_attachment",
+            "attachment_url": attachment_url,
+            "save_path": str(path),
+            "parent_exists": True,
+            "will_overwrite": path.exists(),
+        }
+        if not confirm:
+            return {"preview": preview, "confirmed": False}
+
+        message = f"Download attachment to {path}?" + (
+            " (will OVERWRITE existing file)" if path.exists() else ""
+        )
+        result = await require_confirmation(context, message)
+        if result is not ConfirmationResult.CONFIRMED:
+            return {"preview": preview, "confirmed": False, "result": result.value}
+
+        services = get_services(context)
+        # Stream to disk so we don't buffer large attachments in memory.
+        size_bytes = 0
+        try:
+            with path.open("wb") as fh:
+                async for chunk in services.client.attachments.stream(attachment_url):
+                    fh.write(chunk)
+                    size_bytes += len(chunk)
+        except Exception:
+            # Don't leave a partial file on the user's disk.
+            with contextlib.suppress(OSError):
+                path.unlink(missing_ok=True)
+            raise
+
+        return {
+            "confirmed": True,
+            "save_path": str(path),
+            "size_bytes": size_bytes,
+        }
+
+
+__all__ = ["register_tools"]

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/drafts.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/drafts.py
@@ -8,6 +8,13 @@ All four mutation tools (create-on-channel, create-reply, edit, delete) use
 the standard two-step confirm pattern: call with ``confirm=False`` for a
 preview, ``confirm=True`` to execute (which also elicits explicit user
 approval via ``ctx.elicit``).
+
+Attachments: every create/edit tool accepts an optional ``attachment_paths``
+parameter — a list of absolute filesystem paths. Each path is read at tool-
+invocation time, MIME-type-inferred, and shipped to Front as
+``multipart/form-data``. Paths must be absolute, exist, be regular files,
+and below Front's 25 MB per-attachment limit; the preview surfaces the
+filenames and sizes so the human can confirm before the upload runs.
 """
 
 from __future__ import annotations
@@ -20,6 +27,10 @@ from pydantic import Field
 from frontapp_mcp.projections import DraftSummary, to_draft_summary
 from frontapp_mcp.services import get_services
 from frontapp_mcp.tools.schemas import ConfirmationResult, require_confirmation
+from frontapp_public_api_client.helpers.attachments import (
+    preview_paths,
+    resolve_paths,
+)
 
 
 def _preview_body(body: str) -> str:
@@ -78,11 +89,21 @@ def register_tools(mcp: FastMCP) -> None:
             Literal["private", "shared"] | None,
             Field(description="'private' (author-only) or 'shared' (all teammates)"),
         ] = None,
+        attachment_paths: Annotated[
+            list[str] | None,
+            Field(
+                description=(
+                    "Absolute filesystem paths to files to attach. Each must "
+                    "exist, be a regular file, and be ≤25 MB."
+                )
+            ),
+        ] = None,
         confirm: Annotated[
             bool, Field(description="Must be true to create the draft")
         ] = False,
     ) -> dict[str, Any]:
         services = get_services(context)
+        attachment_preview = preview_paths(attachment_paths)
         preview = {
             "action": "create_draft_on_channel",
             "channel_id": channel_id,
@@ -92,6 +113,7 @@ def register_tools(mcp: FastMCP) -> None:
             "cc": cc,
             "bcc": bcc,
             "mode": mode,
+            "attachments": attachment_preview,
         }
         if not confirm:
             return {"preview": preview, "confirmed": False}
@@ -111,6 +133,7 @@ def register_tools(mcp: FastMCP) -> None:
             cc=cc,
             bcc=bcc,
             mode=mode,
+            attachments=resolve_paths(attachment_paths)[0] or None,
         )
         return {"confirmed": True, "draft": to_draft_summary(draft).model_dump()}
 
@@ -149,11 +172,21 @@ def register_tools(mcp: FastMCP) -> None:
             Literal["private", "shared"] | None,
             Field(description="'private' or 'shared'"),
         ] = None,
+        attachment_paths: Annotated[
+            list[str] | None,
+            Field(
+                description=(
+                    "Absolute filesystem paths to files to attach. Each must "
+                    "exist, be a regular file, and be ≤25 MB."
+                )
+            ),
+        ] = None,
         confirm: Annotated[
             bool, Field(description="Must be true to create the draft")
         ] = False,
     ) -> dict[str, Any]:
         services = get_services(context)
+        attachment_preview = preview_paths(attachment_paths)
         preview = {
             "action": "create_draft_reply",
             "conversation_id": conversation_id,
@@ -163,6 +196,7 @@ def register_tools(mcp: FastMCP) -> None:
             "cc": cc,
             "bcc": bcc,
             "mode": mode,
+            "attachments": attachment_preview,
         }
         if not confirm:
             return {"preview": preview, "confirmed": False}
@@ -173,7 +207,7 @@ def register_tools(mcp: FastMCP) -> None:
         if result is not ConfirmationResult.CONFIRMED:
             return {"preview": preview, "confirmed": False, "result": result.value}
 
-        response = await services.client.drafts.create_reply(
+        draft = await services.client.drafts.create_reply(
             conversation_id,
             body=body,
             channel_id=channel_id,
@@ -183,10 +217,11 @@ def register_tools(mcp: FastMCP) -> None:
             cc=cc,
             bcc=bcc,
             mode=mode,
+            attachments=resolve_paths(attachment_paths)[0] or None,
         )
         return {
             "confirmed": True,
-            "status_code": response.status_code,
+            "draft": to_draft_summary(draft).model_dump(),
             "note": (
                 "Draft created. The human reviews in Front and clicks send; "
                 "there is no programmatic send_draft."
@@ -226,11 +261,22 @@ def register_tools(mcp: FastMCP) -> None:
             str | None,
             Field(description="Version token from a prior draft to avoid clobbers"),
         ] = None,
+        attachment_paths: Annotated[
+            list[str] | None,
+            Field(
+                description=(
+                    "Absolute filesystem paths for the new attachment set. "
+                    "Front's edit semantics replace the attachment list, so "
+                    "anything not listed here is dropped from the draft."
+                )
+            ),
+        ] = None,
         confirm: Annotated[
             bool, Field(description="Must be true to apply the edit")
         ] = False,
     ) -> dict[str, Any]:
         services = get_services(context)
+        attachment_preview = preview_paths(attachment_paths)
         preview = {
             "action": "edit_draft",
             "draft_id": draft_id,
@@ -242,6 +288,7 @@ def register_tools(mcp: FastMCP) -> None:
             "bcc": bcc,
             "mode": mode,
             "version": version,
+            "attachments": attachment_preview,
         }
         if not confirm:
             return {"preview": preview, "confirmed": False}
@@ -263,6 +310,7 @@ def register_tools(mcp: FastMCP) -> None:
             bcc=bcc,
             mode=mode,
             version=version,
+            attachments=resolve_paths(attachment_paths)[0] or None,
         )
         return {"confirmed": True, "draft": to_draft_summary(draft).model_dump()}
 

--- a/frontapp_mcp_server/tests/test_attachments_tools.py
+++ b/frontapp_mcp_server/tests/test_attachments_tools.py
@@ -1,0 +1,268 @@
+"""Tests for MCP attachment tools — download path-safety and confirm flow,
+plus attachment-path plumbing through draft tools.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from frontapp_mcp.tools.attachments import register_tools as register_attachments
+from frontapp_mcp.tools.drafts import register_tools as register_drafts
+
+from frontapp_public_api_client import FileSpec
+from frontapp_public_api_client.domain import Draft
+
+from .conftest import create_mock_context
+
+
+@pytest.fixture
+def attachments_tools(mcp_tool_capture) -> dict[str, object]:
+    return mcp_tool_capture(register_attachments)
+
+
+@pytest.fixture
+def drafts_tools(mcp_tool_capture) -> dict[str, object]:
+    return mcp_tool_capture(register_drafts)
+
+
+# ---------------------------------------------------------------------------
+# download_attachment
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadAttachment:
+    async def test_relative_save_path_rejected(self, attachments_tools):
+        context, _ = create_mock_context()
+
+        result = await attachments_tools["download_attachment"](
+            context,
+            attachment_url="https://api.frontapp.test/download/fil_x",
+            save_path="relative.bin",
+        )
+        assert result["confirmed"] is False
+        assert "must be absolute" in result["error"]
+
+    async def test_missing_parent_directory_rejected(
+        self, attachments_tools, tmp_path: Path
+    ):
+        context, _ = create_mock_context()
+        bogus = tmp_path / "does" / "not" / "exist" / "f.bin"
+
+        result = await attachments_tools["download_attachment"](
+            context,
+            attachment_url="https://api.frontapp.test/download/fil_x",
+            save_path=str(bogus),
+        )
+        assert result["confirmed"] is False
+        assert "Parent path" in result["error"]
+        assert "does not exist" in result["error"]
+
+    async def test_preview_path(self, attachments_tools, tmp_path: Path):
+        context, lifespan = create_mock_context()
+        # Crash if any client method is called during preview.
+        lifespan.client = AsyncMock(
+            side_effect=AssertionError("client invoked on preview path")
+        )
+
+        target = tmp_path / "out.bin"
+        result = await attachments_tools["download_attachment"](
+            context,
+            attachment_url="https://api.frontapp.test/download/fil_x",
+            save_path=str(target),
+            confirm=False,
+        )
+        assert result == {
+            "preview": {
+                "action": "download_attachment",
+                "attachment_url": "https://api.frontapp.test/download/fil_x",
+                "save_path": str(target),
+                "parent_exists": True,
+                "will_overwrite": False,
+            },
+            "confirmed": False,
+        }
+        context.elicit.assert_not_called()
+
+    async def test_will_overwrite_flag_when_target_exists(
+        self, attachments_tools, tmp_path: Path
+    ):
+        context, _ = create_mock_context()
+        target = tmp_path / "exists.bin"
+        target.write_bytes(b"old")
+
+        result = await attachments_tools["download_attachment"](
+            context,
+            attachment_url="https://api.frontapp.test/download/fil_x",
+            save_path=str(target),
+            confirm=False,
+        )
+        assert result["preview"]["will_overwrite"] is True
+
+    async def test_writes_bytes_when_confirmed(self, attachments_tools, tmp_path: Path):
+        context, lifespan = create_mock_context(elicit_confirm=True)
+
+        async def fake_stream(_url, *, chunk_size=65536):
+            yield b"chunk-1-"
+            yield b"chunk-2"
+
+        lifespan.client = AsyncMock()
+        lifespan.client.attachments.stream = fake_stream
+
+        target = tmp_path / "saved.bin"
+        result = await attachments_tools["download_attachment"](
+            context,
+            attachment_url="https://api.frontapp.test/download/fil_x",
+            save_path=str(target),
+            confirm=True,
+        )
+        assert result == {
+            "confirmed": True,
+            "save_path": str(target),
+            "size_bytes": len(b"chunk-1-chunk-2"),
+        }
+        assert target.read_bytes() == b"chunk-1-chunk-2"
+        context.elicit.assert_called_once()
+
+    async def test_declined_elicitation_does_not_write(
+        self, attachments_tools, tmp_path: Path
+    ):
+        context, lifespan = create_mock_context(
+            elicit_confirm=False, elicit_action="accept"
+        )
+        # If stream is invoked, the test should fail.
+        lifespan.client = AsyncMock()
+        lifespan.client.attachments.stream = AsyncMock(
+            side_effect=AssertionError("stream invoked on declined elicitation")
+        )
+
+        target = tmp_path / "saved.bin"
+        result = await attachments_tools["download_attachment"](
+            context,
+            attachment_url="https://api.frontapp.test/download/fil_x",
+            save_path=str(target),
+            confirm=True,
+        )
+        assert result["confirmed"] is False
+        assert result["result"] == "declined"
+        assert not target.exists()
+
+    async def test_partial_write_cleaned_up_on_error(
+        self, attachments_tools, tmp_path: Path
+    ):
+        context, lifespan = create_mock_context(elicit_confirm=True)
+
+        async def fake_stream(_url, *, chunk_size=65536):
+            yield b"first chunk"
+            raise RuntimeError("network blew up")
+
+        lifespan.client = AsyncMock()
+        lifespan.client.attachments.stream = fake_stream
+
+        target = tmp_path / "saved.bin"
+        with pytest.raises(RuntimeError, match="network blew up"):
+            await attachments_tools["download_attachment"](
+                context,
+                attachment_url="https://api.frontapp.test/download/fil_x",
+                save_path=str(target),
+                confirm=True,
+            )
+        # Partial file should have been cleaned up.
+        assert not target.exists()
+
+
+# ---------------------------------------------------------------------------
+# attachment_paths plumbing through draft tools
+# ---------------------------------------------------------------------------
+
+
+class TestDraftAttachmentPaths:
+    async def test_create_draft_on_channel_resolves_paths(
+        self, drafts_tools, tmp_path: Path
+    ):
+        context, lifespan = create_mock_context(elicit_confirm=True)
+        f1 = tmp_path / "doc.pdf"
+        f1.write_bytes(b"%PDF-fake")
+        f2 = tmp_path / "image.png"
+        f2.write_bytes(b"\x89PNG fake")
+
+        returned_draft = Draft.model_validate(
+            {"id": "msg_new", "subject": "Hi", "draft_mode": "shared"}
+        )
+        lifespan.client = AsyncMock()
+        lifespan.client.drafts.create_on_channel = AsyncMock(
+            return_value=returned_draft
+        )
+
+        result = await drafts_tools["create_draft_on_channel"](
+            context,
+            channel_id="cha_abc",
+            body="hi",
+            subject="Hi",
+            attachment_paths=[str(f1), str(f2)],
+            confirm=True,
+        )
+
+        assert result["confirmed"] is True
+        # Helper called with FileSpec list
+        call = lifespan.client.drafts.create_on_channel.await_args
+        attachments = call.kwargs["attachments"]
+        assert len(attachments) == 2
+        assert all(isinstance(a, FileSpec) for a in attachments)
+        assert attachments[0].filename == "doc.pdf"
+        assert attachments[1].filename == "image.png"
+
+    async def test_preview_includes_attachment_metadata(
+        self, drafts_tools, tmp_path: Path
+    ):
+        context, lifespan = create_mock_context()
+        # Crash if helper called on preview
+        lifespan.client = AsyncMock(
+            side_effect=AssertionError("client invoked on preview path")
+        )
+        f = tmp_path / "report.txt"
+        f.write_bytes(b"abc")
+
+        result = await drafts_tools["create_draft_on_channel"](
+            context,
+            channel_id="cha_abc",
+            body="hi",
+            attachment_paths=[str(f)],
+            confirm=False,
+        )
+        assert result["confirmed"] is False
+        assert result["preview"]["attachments"] == [
+            {
+                "path": str(f),
+                "filename": "report.txt",
+                "mime_type": "text/plain",
+                "size_bytes": 3,
+            }
+        ]
+
+    async def test_relative_attachment_path_rejected(self, drafts_tools):
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock()
+
+        with pytest.raises(ValueError, match="must be absolute"):
+            await drafts_tools["create_draft_on_channel"](
+                context,
+                channel_id="cha_abc",
+                body="hi",
+                attachment_paths=["relative.txt"],
+                confirm=False,
+            )
+
+    async def test_missing_attachment_path_rejected(self, drafts_tools, tmp_path: Path):
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock()
+
+        with pytest.raises(FileNotFoundError):
+            await drafts_tools["create_draft_on_channel"](
+                context,
+                channel_id="cha_abc",
+                body="hi",
+                attachment_paths=[str(tmp_path / "missing.txt")],
+                confirm=False,
+            )

--- a/frontapp_mcp_server/tests/test_drafts_tools.py
+++ b/frontapp_mcp_server/tests/test_drafts_tools.py
@@ -54,6 +54,7 @@ class TestPreviewPath:
                 "cc": None,
                 "bcc": None,
                 "mode": None,
+                "attachments": [],
             },
             "confirmed": False,
         }
@@ -173,6 +174,7 @@ class TestConfirmedExecution:
             cc=None,
             bcc=None,
             mode="shared",
+            attachments=None,
         )
         assert result["confirmed"] is True
         assert result["draft"]["id"] == "msg_new"

--- a/frontapp_public_api_client/__init__.py
+++ b/frontapp_public_api_client/__init__.py
@@ -2,6 +2,7 @@
 
 from .client import AuthenticatedClient, Client
 from .frontapp_client import FrontappClient
+from .helpers.attachments import MAX_ATTACHMENT_BYTES, FileSpec
 from .utils import (
     APIError,
     AuthenticationError,
@@ -18,10 +19,12 @@ from .utils import (
 )
 
 __all__ = [
+    "MAX_ATTACHMENT_BYTES",
     "APIError",
     "AuthenticatedClient",
     "AuthenticationError",
     "Client",
+    "FileSpec",
     "FrontappClient",
     "RateLimitError",
     "ServerError",

--- a/frontapp_public_api_client/frontapp_client.py
+++ b/frontapp_public_api_client/frontapp_client.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import parse_qs, quote, urlencode, urlparse, urlunparse
 
 if TYPE_CHECKING:
+    from .helpers.attachments import Attachments
     from .helpers.contacts import Contacts
     from .helpers.conversations import Conversations
     from .helpers.drafts import Drafts
@@ -1029,6 +1030,7 @@ class FrontappClient(AuthenticatedClient):
             )
 
         # Domain helper instances (lazy-loaded via properties)
+        self._attachments: Attachments | None = None
         self._conversations: Conversations | None = None
         self._contacts: Contacts | None = None
         self._drafts: Drafts | None = None
@@ -1105,6 +1107,23 @@ class FrontappClient(AuthenticatedClient):
     # Users can now pass the FrontappClient instance directly to API methods
 
     # Domain properties for ergonomic access
+    @property
+    def attachments(self) -> "Attachments":
+        """Ergonomic operations over Frontapp attachments — upload + download.
+
+        Front's draft / message / comment endpoints accept binary attachments
+        as ``multipart/form-data`` (the generated client misencodes this as
+        JSON; see ``helpers.attachments`` for the multipart bypass). This
+        helper also exposes ``download(url)`` and ``stream(url)`` for the
+        five binary-download paths that ``scripts/vendor_spec.py`` strips
+        from the spec.
+        """
+        from .helpers.attachments import Attachments
+
+        if self._attachments is None:
+            self._attachments = Attachments(self)
+        return self._attachments
+
     @property
     def conversations(self) -> "Conversations":
         """Ergonomic operations over ``/conversations*`` endpoints."""

--- a/frontapp_public_api_client/helpers/__init__.py
+++ b/frontapp_public_api_client/helpers/__init__.py
@@ -5,6 +5,11 @@ boilerplate for common workflows. Each helper is accessed as an attribute on
 ``FrontappClient`` (e.g. ``client.conversations.list(...)``).
 """
 
+from frontapp_public_api_client.helpers.attachments import (
+    MAX_ATTACHMENT_BYTES,
+    Attachments,
+    FileSpec,
+)
 from frontapp_public_api_client.helpers.base import Base
 from frontapp_public_api_client.helpers.contacts import Contacts
 from frontapp_public_api_client.helpers.conversations import Conversations
@@ -15,10 +20,13 @@ from frontapp_public_api_client.helpers.tags import Tags
 from frontapp_public_api_client.helpers.teammates import Teammates
 
 __all__ = [
+    "MAX_ATTACHMENT_BYTES",
+    "Attachments",
     "Base",
     "Contacts",
     "Conversations",
     "Drafts",
+    "FileSpec",
     "Inboxes",
     "Messages",
     "Tags",

--- a/frontapp_public_api_client/helpers/attachments.py
+++ b/frontapp_public_api_client/helpers/attachments.py
@@ -1,0 +1,440 @@
+"""Attachments helper — upload (via multipart bypass) and download.
+
+Front's OpenAPI spec models ``attachments: array<binary>`` on draft / message
+/ comment / template request bodies, but the generated openapi-python-client
+serializes those endpoints as ``Content-Type: application/json``. That is
+incorrect for any request that actually carries binary data — Front expects
+``Content-Type: multipart/form-data`` with the file content as form parts.
+
+This module bypasses the generated path for the multipart case and exposes
+download support for the five binary-response paths that
+``scripts/vendor_spec.py`` strips from the spec (``/download/...``,
+``/messages/{id}/download/...``, etc.).
+
+Public surface:
+
+- ``FileSpec`` — a small dataclass describing one upload (filename, bytes,
+  mime type). Construct directly or via ``FileSpec.from_path(path)``.
+- ``client.attachments.download(url)`` — fetch attachment bytes by the URL
+  Front returns on ``Attachment.url``. Uses the same ``FrontappClient``'s
+  authenticated httpx session, so transport-layer retries / rate-limit
+  awareness still apply. The URL host is validated against the client's
+  configured ``base_url`` so the API token is never sent to a third-party
+  domain.
+- ``client.attachments.stream(url)`` — same as ``download`` but yields
+  chunks for large files.
+- ``client.attachments.post_multipart(...)`` — low-level multipart sender
+  used internally by ``drafts`` and ``conversations`` helpers when the
+  caller passes ``attachments=[FileSpec(...)]``. Library callers can use
+  it directly to attach files to any Front endpoint that accepts binary
+  attachments (10 today: 3 drafts, 1 reply, 2 messages, 2 comments,
+  2 message-templates).
+- ``preview_paths(paths)`` / ``resolve_paths(paths)`` — module-level helpers
+  used by MCP tools to validate filesystem paths before / during upload.
+  ``preview_paths`` only stats the file; ``resolve_paths`` reads it.
+"""
+
+from __future__ import annotations
+
+import mimetypes
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+from frontapp_public_api_client.helpers.base import Base
+
+# Front's per-attachment size limit (25 MB) — enforced server-side; we surface
+# it here so callers can fail fast instead of round-tripping a guaranteed 413.
+MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024
+
+# Multipart form-field name Front expects for the array of binary attachments.
+# Confirmed against Front's published example
+# (https://gist.github.com/hdornier/e04d04921032e98271f46ff8a539a4cb): the
+# field name is plain ``attachments`` — httpx repeats it once per file, which
+# Front parses as an array.
+_MULTIPART_FIELD = "attachments"
+
+
+@dataclass(frozen=True)
+class FileSpec:
+    """One attachment to upload.
+
+    Attributes:
+        filename: Display filename Front will record on the attachment.
+        content: File contents as bytes. ``BinaryIO`` is not supported here —
+            read the file fully before constructing the FileSpec so the size
+            can be validated up-front.
+        mime_type: MIME type (e.g. ``"application/pdf"``). Defaults to
+            ``"application/octet-stream"`` when omitted.
+    """
+
+    filename: str
+    content: bytes
+    mime_type: str = "application/octet-stream"
+
+    def __post_init__(self) -> None:
+        if not self.filename:
+            raise ValueError("FileSpec.filename must be non-empty")
+        if not isinstance(self.content, bytes | bytearray):
+            raise TypeError(
+                "FileSpec.content must be bytes (got "
+                f"{type(self.content).__name__}); read the file before constructing"
+            )
+        if len(self.content) > MAX_ATTACHMENT_BYTES:
+            raise ValueError(
+                f"FileSpec '{self.filename}' is {len(self.content):,} bytes, "
+                f"exceeding Front's 25 MB attachment limit"
+            )
+
+    @classmethod
+    def from_path(cls, path: str | Path, *, mime_type: str | None = None) -> FileSpec:
+        """Construct a FileSpec by reading a file from disk.
+
+        Args:
+            path: Filesystem path to the file. Must exist and be a regular file.
+            mime_type: Override the auto-detected MIME type. When omitted,
+                ``mimetypes.guess_type`` infers from the filename extension;
+                falls back to ``application/octet-stream`` if no match.
+        """
+        p = Path(path)
+        if not p.exists():
+            raise FileNotFoundError(f"Attachment path does not exist: {p}")
+        if not p.is_file():
+            raise ValueError(f"Attachment path is not a regular file: {p}")
+        resolved_mime = (
+            mime_type or mimetypes.guess_type(p.name)[0] or ("application/octet-stream")
+        )
+        return cls(filename=p.name, content=p.read_bytes(), mime_type=resolved_mime)
+
+    def to_httpx_tuple(self) -> tuple[str, bytes, str]:
+        """Render as the (filename, content, mime_type) tuple httpx expects."""
+        return (self.filename, bytes(self.content), self.mime_type)
+
+
+def _validate_path(raw: str | Path) -> Path:
+    """Validate a single attachment path: absolute, exists, regular file.
+
+    Raises ValueError (non-absolute), FileNotFoundError (missing), or
+    ValueError (not a regular file). Caller decides whether to also enforce
+    the size limit (handled separately by ``FileSpec.__post_init__``).
+    """
+    p = Path(raw)
+    if not p.is_absolute():
+        raise ValueError(
+            f"Attachment path {str(raw)!r} must be absolute (avoid relative "
+            "paths to keep tool behavior deterministic across working "
+            "directories)"
+        )
+    if not p.exists():
+        raise FileNotFoundError(f"Attachment path does not exist: {p}")
+    if not p.is_file():
+        raise ValueError(f"Attachment path is not a regular file: {p}")
+    return p
+
+
+def preview_paths(
+    paths: list[str | Path] | None,
+) -> list[dict[str, Any]]:
+    """Stat-only preview of attachment paths — no file bytes are read.
+
+    Returns one preview row per path with ``{path, filename, mime_type,
+    size_bytes}``. Validates the path is absolute / exists / is a regular
+    file, and that the size is within Front's 25 MB limit. Use this on the
+    preview path of an MCP tool (``confirm=False``) so the LLM can show
+    the human what would be uploaded without burning the read until
+    they actually confirm.
+    """
+    if not paths:
+        return []
+    rows: list[dict[str, Any]] = []
+    for raw in paths:
+        p = _validate_path(raw)
+        size = p.stat().st_size
+        if size > MAX_ATTACHMENT_BYTES:
+            raise ValueError(
+                f"Attachment {p.name!r} is {size:,} bytes, exceeding Front's "
+                "25 MB limit"
+            )
+        mime = mimetypes.guess_type(p.name)[0] or "application/octet-stream"
+        rows.append(
+            {
+                "path": str(p),
+                "filename": p.name,
+                "mime_type": mime,
+                "size_bytes": size,
+            }
+        )
+    return rows
+
+
+def resolve_paths(
+    paths: list[str | Path] | None,
+) -> tuple[list[FileSpec], list[dict[str, Any]]]:
+    """Resolve filesystem paths to FileSpec instances + a preview list.
+
+    Reads each file's bytes (the multipart upload needs them) and produces
+    the same preview rows ``preview_paths`` returns. Validates absolute /
+    exists / regular file / ≤25 MB.
+
+    Use this on the execute path (``confirm=True``) of an MCP tool, after
+    ``preview_paths`` has already been called for the preview. Library
+    callers (e.g. Python scripts) can call directly.
+
+    Raises ``ValueError`` (relative path or oversize), ``FileNotFoundError``
+    (missing). MCP tools let these bubble so the LLM gets a clear "this
+    path won't work" message instead of a multipart request that 4xx's at
+    Front.
+    """
+    if not paths:
+        return [], []
+    specs: list[FileSpec] = []
+    preview: list[dict[str, Any]] = []
+    for raw in paths:
+        p = _validate_path(raw)
+        spec = FileSpec.from_path(p)
+        specs.append(spec)
+        preview.append(
+            {
+                "path": str(p),
+                "filename": spec.filename,
+                "mime_type": spec.mime_type,
+                "size_bytes": len(spec.content),
+            }
+        )
+    return specs, preview
+
+
+def _raise_for_status(
+    status: int,
+    body: bytes,
+    *,
+    operation: str,
+) -> None:
+    """Raise the correct typed exception for a non-2xx httpx response.
+
+    Mirrors ``utils.unwrap``'s status-based dispatch but operates on raw
+    httpx responses (not the generated ``Response[T]`` wrapper), so we can
+    use it from the multipart-bypass and download paths that don't go
+    through the generated API.
+    """
+    from frontapp_public_api_client.utils import (
+        APIError,
+        AuthenticationError,
+        RateLimitError,
+        ServerError,
+        ValidationError,
+    )
+
+    if 200 <= status < 300:
+        return
+    if status == 401:
+        raise AuthenticationError(f"Authentication failed: {operation}", status, body)
+    if status == 422:
+        raise ValidationError(f"Validation failed: {operation}", status, body)
+    if status == 429:
+        raise RateLimitError(f"Rate limit exceeded: {operation}", status, body)
+    if 500 <= status < 600:
+        raise ServerError(f"Server error ({status}): {operation}", status, body)
+    raise APIError(f"Request failed ({status}): {operation}", status, body)
+
+
+class Attachments(Base):
+    """Ergonomic operations for Frontapp attachments — upload and download."""
+
+    def _check_url_host(self, url: str) -> None:
+        """Reject download URLs whose host doesn't match the client's base_url.
+
+        Front populates ``Attachment.url`` with a fully-qualified URL on the
+        workspace's own subdomain (``https://<workspace>.api.frontapp.com/
+        download/...``) — but the client carries an authenticated bearer
+        token in headers, so following an attacker-controlled URL would
+        leak the token to a third party. Verify the host before issuing the
+        request.
+
+        The match is hostname-only against ``base_url`` (port and scheme
+        intentionally not compared — Front uses https on the standard port).
+        """
+        from urllib.parse import urlparse
+
+        parsed = urlparse(url)
+        if parsed.scheme not in ("http", "https"):
+            raise ValueError(
+                f"Attachment URL must be http or https, got {parsed.scheme!r}"
+            )
+        target_host = (parsed.hostname or "").lower()
+        base = urlparse(str(self._client._base_url))
+        base_host = (base.hostname or "").lower()
+        if not target_host:
+            raise ValueError(f"Attachment URL has no host: {url!r}")
+        # Allow the configured base host directly OR any subdomain of
+        # frontapp.com (Front workspace subdomains end with this suffix).
+        if target_host != base_host and not target_host.endswith(".frontapp.com"):
+            raise ValueError(
+                f"Attachment URL host {target_host!r} does not match the "
+                f"client's base host ({base_host!r}) or *.frontapp.com — "
+                "refusing to send the API token to a foreign domain"
+            )
+
+    # -- download ----------------------------------------------------------
+
+    async def download(self, url: str) -> bytes:
+        """Download an attachment by URL and return its bytes.
+
+        Use the URL value from ``AttachmentSummary.url`` (Front populates this
+        on every attachment that lives inside a message, comment, or draft).
+        The request goes through the same authenticated httpx session as
+        every other client call, so retries and rate-limit handling apply.
+
+        The URL host is validated against the client's base URL (or the
+        ``*.frontapp.com`` subdomain space) so the API token is never sent
+        to a third-party domain.
+
+        Args:
+            url: Full attachment download URL — typically of the form
+                ``https://yourCompany.api.frontapp.com/download/fil_xxx``.
+
+        Returns:
+            Raw bytes of the attachment.
+
+        Raises:
+            ValueError: If the URL host doesn't match the client's base URL
+                or the ``*.frontapp.com`` allowlist.
+            APIError: and its subclasses on non-2xx responses; see
+                ``utils.unwrap``'s exception hierarchy.
+        """
+        self._check_url_host(url)
+        httpx_client = self._client.get_async_httpx_client()
+        response = await httpx_client.get(url)
+        _raise_for_status(
+            response.status_code, response.content, operation="downloading attachment"
+        )
+        return response.content
+
+    async def stream(
+        self, url: str, *, chunk_size: int = 65536
+    ) -> AsyncIterator[bytes]:
+        """Stream attachment bytes for large files.
+
+        Yields chunks of ``chunk_size`` bytes (default 64 KiB). Use this in
+        place of ``download`` when the attachment is too large to comfortably
+        buffer in memory. URL host is validated like ``download``.
+
+        Args:
+            url: Same URL as ``download``.
+            chunk_size: Bytes per chunk. Default 64 KiB.
+
+        Yields:
+            Successive ``bytes`` chunks of the attachment body.
+
+        Raises:
+            ValueError: If the URL host doesn't match the client's base URL.
+            APIError: and its subclasses on non-2xx responses.
+        """
+        self._check_url_host(url)
+        httpx_client = self._client.get_async_httpx_client()
+        async with httpx_client.stream("GET", url) as response:
+            _raise_for_status(
+                response.status_code, b"", operation="streaming attachment"
+            )
+            async for chunk in response.aiter_bytes(chunk_size=chunk_size):
+                yield chunk
+
+    # -- upload (low-level multipart) -------------------------------------
+
+    async def post_multipart(
+        self,
+        *,
+        method: Literal["POST", "PATCH"],
+        path: str,
+        fields: dict[str, Any],
+        files: list[FileSpec],
+    ) -> dict[str, Any] | None:
+        """Send a multipart/form-data request to a Front endpoint.
+
+        Bypasses the generated client to send the request body as
+        ``multipart/form-data`` rather than the broken ``application/json``
+        path the generated code uses for binary-bearing endpoints. The
+        authenticated httpx session is shared with the generated API, so all
+        transport-layer behaviors (retries, rate-limit awareness, error
+        logging) still apply.
+
+        Args:
+            method: HTTP method — ``"POST"`` (every create endpoint) or
+                ``"PATCH"`` (the edit-draft and edit-template endpoints).
+                Anything else means the call is wrong; the type narrows
+                to those two.
+            path: Path relative to the client's ``base_url``, e.g.
+                ``"/conversations/cnv_abc/drafts"``. The base URL is joined
+                automatically.
+            fields: Non-file form fields. List values become repeated
+                form parts (``to[]`` / ``cc[]`` semantics); other values
+                are stringified.
+            files: List of ``FileSpec`` instances. Each becomes one
+                ``attachments`` part in the multipart envelope.
+
+        Returns:
+            The parsed JSON response body, or ``None`` for empty/non-JSON
+            success responses (204, etc.).
+
+        Raises:
+            APIError: and its subclasses (AuthenticationError, ValidationError,
+                RateLimitError, ServerError) on non-2xx responses; see
+                ``utils.unwrap``'s exception hierarchy.
+        """
+        data = _flatten_form_fields(fields)
+        httpx_files = [
+            (_MULTIPART_FIELD, file_spec.to_httpx_tuple()) for file_spec in files
+        ]
+
+        httpx_client = self._client.get_async_httpx_client()
+        response = await httpx_client.request(
+            method=method,
+            url=path,
+            data=data,
+            files=httpx_files,
+        )
+        _raise_for_status(
+            response.status_code, response.content, operation="multipart upload"
+        )
+        if not response.content:
+            return None
+        try:
+            return response.json()
+        except ValueError:
+            return None
+
+
+def _flatten_form_fields(fields: dict[str, Any]) -> dict[str, Any]:
+    """Render form-field values into shapes httpx can encode.
+
+    httpx's ``data=`` mapping encodes list values as repeated form parts
+    (e.g. ``to=a@x&to=b@x``), which is exactly what Front's API expects for
+    array-valued form fields. So we keep list values as lists, drop
+    ``None`` values, stringify booleans, and pass everything else through
+    after a ``str()`` for safety.
+    """
+    out: dict[str, Any] = {}
+    for key, value in fields.items():
+        if value is None:
+            continue
+        if isinstance(value, list | tuple):
+            cleaned = [str(item) for item in value if item is not None]
+            if cleaned:
+                out[key] = cleaned
+        elif isinstance(value, bool):
+            out[key] = "true" if value else "false"
+        elif isinstance(value, int | float):
+            out[key] = str(value)
+        else:
+            out[key] = str(value)
+    return out
+
+
+__all__ = [
+    "MAX_ATTACHMENT_BYTES",
+    "Attachments",
+    "FileSpec",
+    "preview_paths",
+    "resolve_paths",
+]

--- a/frontapp_public_api_client/helpers/conversations.py
+++ b/frontapp_public_api_client/helpers/conversations.py
@@ -10,6 +10,7 @@ import builtins
 from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Any
 
+from frontapp_public_api_client.helpers.attachments import FileSpec
 from frontapp_public_api_client.helpers.base import Base, extract_page_token
 
 if TYPE_CHECKING:
@@ -273,16 +274,46 @@ class Conversations(Base):
         to: builtins.list[str] | None = None,
         cc: builtins.list[str] | None = None,
         bcc: builtins.list[str] | None = None,
+        attachments: builtins.list[FileSpec] | None = None,
     ) -> Any:
         """Send an outbound reply on an existing conversation.
 
         Uses the channel the conversation was opened on. Returns the raw
         response (Front replies with 202 Accepted; the message is enqueued).
+
+        Pass ``attachments=[FileSpec(...), ...]`` to attach files; the
+        request is then sent as ``multipart/form-data``. Returns the parsed
+        JSON dict (or ``None``) instead of the generated ``Response`` when
+        attachments are used.
         """
+        from urllib.parse import quote as _quote
+
         from frontapp_public_api_client.api.messages import create_message_reply
         from frontapp_public_api_client.models.outbound_reply_message import (
             OutboundReplyMessage,
         )
+
+        if attachments:
+            payload = {
+                k: v
+                for k, v in {
+                    "body": body,
+                    "author_id": author_id,
+                    "subject": subject,
+                    "to": to,
+                    "cc": cc,
+                    "bcc": bcc,
+                }.items()
+                if v is not None
+            }
+            return await self._client.attachments.post_multipart(
+                method="POST",
+                path=(
+                    f"/conversations/{_quote(str(conversation_id), safe='')}/messages"
+                ),
+                fields=payload,
+                files=attachments,
+            )
 
         payload_kwargs: dict[str, Any] = {"body": body}
         if author_id is not None:
@@ -307,10 +338,33 @@ class Conversations(Base):
         *,
         body: str,
         author_id: str | None = None,
+        attachments: builtins.list[FileSpec] | None = None,
     ) -> Any:
-        """Add an internal comment (visible to teammates only)."""
+        """Add an internal comment (visible to teammates only).
+
+        Pass ``attachments=[FileSpec(...), ...]`` to attach files; the
+        request is then sent as ``multipart/form-data`` and returns the
+        parsed JSON dict instead of the generated ``Response``.
+        """
+        from urllib.parse import quote as _quote
+
         from frontapp_public_api_client.api.comments import add_comment
         from frontapp_public_api_client.models.create_comment import CreateComment
+
+        if attachments:
+            payload = {
+                k: v
+                for k, v in {"body": body, "author_id": author_id}.items()
+                if v is not None
+            }
+            return await self._client.attachments.post_multipart(
+                method="POST",
+                path=(
+                    f"/conversations/{_quote(str(conversation_id), safe='')}/comments"
+                ),
+                fields=payload,
+                files=attachments,
+            )
 
         payload_kwargs: dict[str, Any] = {"body": body}
         if author_id is not None:

--- a/frontapp_public_api_client/helpers/drafts.py
+++ b/frontapp_public_api_client/helpers/drafts.py
@@ -16,23 +16,53 @@ Notes:
   out of the standard ``field_results`` wrapper of
   ``ListConversationDraftsResponse200`` — same shape as every other Front
   list endpoint.
-- ``attachments`` is accepted as a typed pass-through (``list[File] | None``)
-  on all three mutation helpers; the actual upload mechanism is unresolved
-  upstream and tracked in #12. Callers who already have ``File`` objects (e.g.
-  from ``models.attachment``) can pass them through; the MCP tool surface
-  doesn't expose attachments yet because the upload flow needs to land first.
+- ``attachments`` accepts ``list[FileSpec]`` on every mutation helper. When
+  provided, the helper bypasses the generated client and sends the request
+  as ``multipart/form-data`` (the generated client serializes these endpoints
+  as ``application/json``, which Front rejects for binary content). When
+  ``attachments`` is ``None`` or empty, the standard generated path is used.
 """
 
 from __future__ import annotations
 
 import builtins
 from typing import TYPE_CHECKING, Any, Literal
+from urllib.parse import quote
 
+from frontapp_public_api_client.helpers.attachments import FileSpec
 from frontapp_public_api_client.helpers.base import Base
 
 if TYPE_CHECKING:
     from frontapp_public_api_client.domain import Draft
     from frontapp_public_api_client.models.message_response import MessageResponse
+
+
+async def _send_draft_multipart(
+    drafts: Drafts,
+    *,
+    method: Literal["POST", "PATCH"],
+    path: str,
+    files: builtins.list[FileSpec],
+    **fields: Any,
+) -> Draft:
+    """Shared multipart-bypass + Draft validation for the three draft mutations.
+
+    Folds the four lines that were copy-pasted across create_on_channel /
+    create_reply / edit (build payload → call attachments.post_multipart →
+    validate Draft) into one place. ``fields`` accepts the same kwargs the
+    callers expose; ``None`` values are dropped before encoding so missing
+    optional fields don't show up as empty multipart parts.
+    """
+    from frontapp_public_api_client.domain import Draft
+
+    payload = {k: v for k, v in fields.items() if v is not None}
+    data = await drafts._client.attachments.post_multipart(
+        method=method,
+        path=path,
+        fields=payload,
+        files=files,
+    )
+    return Draft.model_validate(data or {})
 
 
 class Drafts(Base):
@@ -70,7 +100,7 @@ class Drafts(Base):
         cc: builtins.list[str] | None = None,
         bcc: builtins.list[str] | None = None,
         quote_body: str | None = None,
-        attachments: builtins.list[Any] | None = None,
+        attachments: builtins.list[FileSpec] | None = None,
         mode: Literal["private", "shared"] | None = None,
         signature_id: str | None = None,
         should_add_default_signature: bool | None = None,
@@ -78,9 +108,28 @@ class Drafts(Base):
         """Create a new draft on a channel (no existing conversation).
 
         Returns the created ``Draft``. The human reviews it in Front and sends.
-        ``attachments`` accepts ``list[File]`` from ``models.attachment``;
-        upload mechanism is tracked in #12.
+        Pass ``attachments=[FileSpec(...), ...]`` to attach files; the request
+        is then sent as ``multipart/form-data`` (the generated client's
+        JSON-only path doesn't support binary).
         """
+        if attachments:
+            return await _send_draft_multipart(
+                self,
+                method="POST",
+                path=f"/channels/{quote(str(channel_id), safe='')}/drafts",
+                files=attachments,
+                body=body,
+                author_id=author_id,
+                subject=subject,
+                to=to,
+                cc=cc,
+                bcc=bcc,
+                quote_body=quote_body,
+                mode=mode,
+                signature_id=signature_id,
+                should_add_default_signature=should_add_default_signature,
+            )
+
         from frontapp_public_api_client.api.drafts import create_draft
         from frontapp_public_api_client.domain import Draft
         from frontapp_public_api_client.models.create_draft import CreateDraft
@@ -103,8 +152,6 @@ class Drafts(Base):
             payload_kwargs["bcc"] = bcc
         if quote_body is not None:
             payload_kwargs["quote_body"] = quote_body
-        if attachments is not None:
-            payload_kwargs["attachments"] = attachments
         if mode is not None:
             payload_kwargs["mode"] = CreateDraftMode(mode)
         if signature_id is not None:
@@ -133,7 +180,7 @@ class Drafts(Base):
         cc: builtins.list[str] | None = None,
         bcc: builtins.list[str] | None = None,
         quote_body: str | None = None,
-        attachments: builtins.list[Any] | None = None,
+        attachments: builtins.list[FileSpec] | None = None,
         mode: Literal["private", "shared"] | None = None,
         signature_id: str | None = None,
         should_add_default_signature: bool | None = None,
@@ -144,7 +191,29 @@ class Drafts(Base):
         outbound reply will eventually send through. Returns the created
         ``Draft`` (Front's ``_parse_response`` parses ``MessageResponse`` on
         200 — the spec's ``Any`` arm covers redirects only).
+
+        Pass ``attachments=[FileSpec(...), ...]`` to attach files; the request
+        is then sent as ``multipart/form-data``.
         """
+        if attachments:
+            return await _send_draft_multipart(
+                self,
+                method="POST",
+                path=(f"/conversations/{quote(str(conversation_id), safe='')}/drafts"),
+                files=attachments,
+                body=body,
+                channel_id=channel_id,
+                author_id=author_id,
+                subject=subject,
+                to=to,
+                cc=cc,
+                bcc=bcc,
+                quote_body=quote_body,
+                mode=mode,
+                signature_id=signature_id,
+                should_add_default_signature=should_add_default_signature,
+            )
+
         from frontapp_public_api_client.api.drafts import create_draft_reply
         from frontapp_public_api_client.domain import Draft
         from frontapp_public_api_client.models.create_draft_mode import (
@@ -167,8 +236,6 @@ class Drafts(Base):
             payload_kwargs["bcc"] = bcc
         if quote_body is not None:
             payload_kwargs["quote_body"] = quote_body
-        if attachments is not None:
-            payload_kwargs["attachments"] = attachments
         if mode is not None:
             payload_kwargs["mode"] = CreateDraftMode(mode)
         if signature_id is not None:
@@ -197,7 +264,7 @@ class Drafts(Base):
         cc: builtins.list[str] | None = None,
         bcc: builtins.list[str] | None = None,
         quote_body: str | None = None,
-        attachments: builtins.list[Any] | None = None,
+        attachments: builtins.list[FileSpec] | None = None,
         mode: Literal["shared"] | None = None,
         signature_id: str | None = None,
         should_add_default_signature: bool | None = None,
@@ -216,7 +283,30 @@ class Drafts(Base):
         The endpoint path is ``/drafts/{message_id}/`` — note the trailing
         slash and the parameter rename. The helper accepts ``draft_id`` and
         passes it through as ``message_id`` to the generated module.
+
+        Pass ``attachments=[FileSpec(...), ...]`` to replace the draft's
+        attachment set; the request is then sent as ``multipart/form-data``.
         """
+        if attachments:
+            return await _send_draft_multipart(
+                self,
+                method="PATCH",
+                path=f"/drafts/{quote(str(draft_id), safe='')}/",
+                files=attachments,
+                body=body,
+                channel_id=channel_id,
+                author_id=author_id,
+                subject=subject,
+                to=to,
+                cc=cc,
+                bcc=bcc,
+                quote_body=quote_body,
+                mode=mode,
+                signature_id=signature_id,
+                should_add_default_signature=should_add_default_signature,
+                version=version,
+            )
+
         from frontapp_public_api_client.api.drafts import edit_draft
         from frontapp_public_api_client.domain import Draft
         from frontapp_public_api_client.models.edit_draft import EditDraft
@@ -237,8 +327,6 @@ class Drafts(Base):
             payload_kwargs["bcc"] = bcc
         if quote_body is not None:
             payload_kwargs["quote_body"] = quote_body
-        if attachments is not None:
-            payload_kwargs["attachments"] = attachments
         if mode is not None:
             payload_kwargs["mode"] = EditDraftMode(mode)
         if signature_id is not None:

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -1,0 +1,553 @@
+"""Tests for the attachments vertical: FileSpec + Attachments helper.
+
+Covers:
+- FileSpec validation and from_path construction
+- client.attachments.download single-shot
+- client.attachments.stream chunked
+- client.attachments.post_multipart wire shape
+- drafts/conversations multipart upload integration
+- Error mapping for 401/422/429/5xx on both download and upload paths
+"""
+
+from __future__ import annotations
+
+import email.policy
+import mimetypes
+from email.parser import BytesParser
+from pathlib import Path
+
+import httpx
+import pytest
+
+from frontapp_public_api_client import FileSpec, FrontappClient
+from frontapp_public_api_client.helpers.attachments import (
+    MAX_ATTACHMENT_BYTES,
+    _flatten_form_fields,
+    preview_paths,
+    resolve_paths,
+)
+from frontapp_public_api_client.utils import (
+    APIError,
+    AuthenticationError,
+    RateLimitError,
+    ServerError,
+    ValidationError,
+)
+
+# ---------------------------------------------------------------------------
+# FileSpec
+# ---------------------------------------------------------------------------
+
+
+class TestFileSpec:
+    def test_construct_from_bytes(self):
+        spec = FileSpec(
+            filename="doc.pdf", content=b"%PDF-1.4 hello", mime_type="application/pdf"
+        )
+        assert spec.filename == "doc.pdf"
+        assert spec.mime_type == "application/pdf"
+        assert spec.content == b"%PDF-1.4 hello"
+
+    def test_default_mime_type(self):
+        spec = FileSpec(filename="x.bin", content=b"\x00\x01")
+        assert spec.mime_type == "application/octet-stream"
+
+    def test_empty_filename_rejected(self):
+        with pytest.raises(ValueError, match="filename must be non-empty"):
+            FileSpec(filename="", content=b"x")
+
+    def test_non_bytes_content_rejected(self):
+        with pytest.raises(TypeError, match="must be bytes"):
+            FileSpec(filename="x", content="not bytes")  # type: ignore[arg-type]
+
+    def test_oversize_content_rejected(self):
+        too_big = b"x" * (MAX_ATTACHMENT_BYTES + 1)
+        with pytest.raises(ValueError, match="exceeding Front's 25 MB"):
+            FileSpec(filename="big.bin", content=too_big)
+
+    def test_to_httpx_tuple(self):
+        spec = FileSpec(filename="a.txt", content=b"hello", mime_type="text/plain")
+        assert spec.to_httpx_tuple() == ("a.txt", b"hello", "text/plain")
+
+    def test_from_path_reads_file_and_infers_mime(self, tmp_path: Path):
+        f = tmp_path / "report.pdf"
+        f.write_bytes(b"%PDF-1.4 fake-pdf-bytes")
+        spec = FileSpec.from_path(f)
+        assert spec.filename == "report.pdf"
+        # mimetypes registers application/pdf for .pdf cross-platform
+        assert spec.mime_type == (
+            mimetypes.guess_type("report.pdf")[0] or "application/octet-stream"
+        )
+        assert spec.content == b"%PDF-1.4 fake-pdf-bytes"
+
+    def test_from_path_mime_override(self, tmp_path: Path):
+        f = tmp_path / "x.bin"
+        f.write_bytes(b"x")
+        spec = FileSpec.from_path(f, mime_type="application/x-custom")
+        assert spec.mime_type == "application/x-custom"
+
+    def test_from_path_missing_file(self, tmp_path: Path):
+        with pytest.raises(FileNotFoundError):
+            FileSpec.from_path(tmp_path / "nope.txt")
+
+    def test_from_path_directory_rejected(self, tmp_path: Path):
+        with pytest.raises(ValueError, match="not a regular file"):
+            FileSpec.from_path(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# _flatten_form_fields
+# ---------------------------------------------------------------------------
+
+
+class TestFlattenFormFields:
+    def test_drops_none_values(self):
+        out = _flatten_form_fields({"a": "x", "b": None, "c": 0})
+        assert out == {"a": "x", "c": "0"}
+
+    def test_lists_passed_through_for_repeated_form_fields(self):
+        out = _flatten_form_fields({"to": ["a@x", "b@x"]})
+        assert out == {"to": ["a@x", "b@x"]}
+
+    def test_drops_empty_lists(self):
+        out = _flatten_form_fields({"to": [], "body": "hi"})
+        assert out == {"body": "hi"}
+
+    def test_booleans_lowercased(self):
+        out = _flatten_form_fields({"flag": True, "off": False})
+        assert out == {"flag": "true", "off": "false"}
+
+
+# ---------------------------------------------------------------------------
+# Attachments.download (single-shot)
+# ---------------------------------------------------------------------------
+
+
+class TestDownload:
+    async def test_returns_response_bytes(self, attach_transport):
+        recorded: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            recorded.append(request)
+            return httpx.Response(200, content=b"\x89PNG\r\n\x1a\n binary-blob")
+
+        client = attach_transport(httpx.MockTransport(handler))
+        url = "https://api.frontapp.test/download/fil_abc"
+        body = await client.attachments.download(url)
+        assert body == b"\x89PNG\r\n\x1a\n binary-blob"
+        # Authentication header should have been added by AuthenticatedClient.
+        assert len(recorded) == 1
+        assert recorded[0].url.path == "/download/fil_abc"
+
+    async def test_raises_auth_error_on_401(self, attach_transport):
+        def handler(_request):
+            return httpx.Response(401, content=b'{"message": "no"}')
+
+        client = attach_transport(httpx.MockTransport(handler))
+        with pytest.raises(AuthenticationError):
+            await client.attachments.download(
+                "https://api.frontapp.test/download/fil_x"
+            )
+
+    async def test_raises_validation_on_422(self, attach_transport):
+        def handler(_request):
+            return httpx.Response(422, content=b"")
+
+        client = attach_transport(httpx.MockTransport(handler))
+        with pytest.raises(ValidationError):
+            await client.attachments.download(
+                "https://api.frontapp.test/download/fil_x"
+            )
+
+    async def test_raises_rate_limit_on_429(self, attach_transport):
+        def handler(_request):
+            return httpx.Response(429, content=b"")
+
+        client = attach_transport(httpx.MockTransport(handler))
+        with pytest.raises(RateLimitError):
+            await client.attachments.download(
+                "https://api.frontapp.test/download/fil_x"
+            )
+
+    async def test_raises_server_error_on_500(self, attach_transport):
+        def handler(_request):
+            return httpx.Response(503, content=b"")
+
+        client = attach_transport(httpx.MockTransport(handler))
+        with pytest.raises(ServerError):
+            await client.attachments.download(
+                "https://api.frontapp.test/download/fil_x"
+            )
+
+    async def test_raises_api_error_on_unexpected(self, attach_transport):
+        def handler(_request):
+            return httpx.Response(404, content=b"")
+
+        client = attach_transport(httpx.MockTransport(handler))
+        with pytest.raises(APIError):
+            await client.attachments.download(
+                "https://api.frontapp.test/download/fil_x"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Attachments.stream
+# ---------------------------------------------------------------------------
+
+
+class TestStream:
+    async def test_yields_chunks(self, attach_transport):
+        body = b"x" * 200_000  # 200 KB
+
+        def handler(_request):
+            return httpx.Response(200, content=body)
+
+        client = attach_transport(httpx.MockTransport(handler))
+        chunks = []
+        async for chunk in client.attachments.stream(
+            "https://api.frontapp.test/download/fil_big", chunk_size=4096
+        ):
+            chunks.append(chunk)
+        assert b"".join(chunks) == body
+
+    async def test_stream_raises_auth_error(self, attach_transport):
+        def handler(_request):
+            return httpx.Response(401)
+
+        client = attach_transport(httpx.MockTransport(handler))
+        with pytest.raises(AuthenticationError):
+            async for _ in client.attachments.stream(
+                "https://api.frontapp.test/download/fil_x"
+            ):
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Attachments.post_multipart
+# ---------------------------------------------------------------------------
+
+
+class TestPostMultipart:
+    async def test_sends_multipart_with_file_and_fields(self, attach_transport):
+        recorded: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            recorded.append(request)
+            return httpx.Response(200, json={"id": "msg_xyz"})
+
+        client = attach_transport(httpx.MockTransport(handler))
+        result = await client.attachments.post_multipart(
+            method="POST",
+            path="/conversations/cnv_abc/drafts",
+            fields={"body": "Hello", "to": ["a@example.com", "b@example.com"]},
+            files=[
+                FileSpec(
+                    filename="r.pdf", content=b"%PDF-1.4 x", mime_type="application/pdf"
+                )
+            ],
+        )
+        assert result == {"id": "msg_xyz"}
+
+        req = recorded[0]
+        assert req.method == "POST"
+        assert req.url.path == "/conversations/cnv_abc/drafts"
+        # Content-Type should be multipart with a boundary
+        ct = req.headers.get("content-type", "")
+        assert ct.startswith("multipart/form-data; boundary=")
+
+        # Parse the multipart envelope; verify body/to/attachments parts present.
+        parsed = BytesParser(policy=email.policy.default).parsebytes(
+            b"Content-Type: " + ct.encode() + b"\r\n\r\n" + req.content
+        )
+        assert parsed.is_multipart()
+        parts_by_name: dict[str, list[bytes]] = {}
+        filenames: list[str] = []
+        for part in parsed.iter_parts():
+            disp = str(part.get("Content-Disposition", ""))
+            name = ""
+            for raw_piece in disp.split(";"):
+                piece = raw_piece.strip()
+                if piece.startswith("name="):
+                    name = piece[len("name=") :].strip('"')
+                elif piece.startswith("filename="):
+                    filenames.append(piece[len("filename=") :].strip('"'))
+            parts_by_name.setdefault(name, []).append(
+                part.get_payload(decode=True) or b""
+            )
+
+        assert parts_by_name.get("body") == [b"Hello"]
+        assert parts_by_name.get("to") == [b"a@example.com", b"b@example.com"]
+        assert parts_by_name.get("attachments") == [b"%PDF-1.4 x"]
+        assert "r.pdf" in filenames
+
+    async def test_returns_none_for_204(self, attach_transport):
+        def handler(_request):
+            return httpx.Response(204, content=b"")
+
+        client = attach_transport(httpx.MockTransport(handler))
+        result = await client.attachments.post_multipart(
+            method="POST",
+            path="/x",
+            fields={"body": "hi"},
+            files=[FileSpec(filename="a.txt", content=b"x")],
+        )
+        assert result is None
+
+    async def test_raises_validation_error_on_422(self, attach_transport):
+        def handler(_request):
+            return httpx.Response(422, content=b'{"message": "bad"}')
+
+        client = attach_transport(httpx.MockTransport(handler))
+        with pytest.raises(ValidationError):
+            await client.attachments.post_multipart(
+                method="POST",
+                path="/x",
+                fields={},
+                files=[FileSpec(filename="a", content=b"x")],
+            )
+
+
+# ---------------------------------------------------------------------------
+# Helper integration: drafts + conversations
+# ---------------------------------------------------------------------------
+
+
+class TestDraftsWithAttachments:
+    async def test_create_on_channel_uses_multipart_when_attachments(
+        self, attach_transport
+    ):
+        recorded: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            recorded.append(request)
+            return httpx.Response(
+                200,
+                json={
+                    "id": "msg_new",
+                    "type": "email",
+                    "is_inbound": False,
+                    "subject": "Hi",
+                },
+            )
+
+        client = attach_transport(httpx.MockTransport(handler))
+        draft = await client.drafts.create_on_channel(
+            "cha_abc",
+            body="<p>hi</p>",
+            subject="Hi",
+            attachments=[FileSpec(filename="a.txt", content=b"x")],
+        )
+        assert draft.id == "msg_new"
+        assert recorded[0].method == "POST"
+        assert recorded[0].url.path == "/channels/cha_abc/drafts"
+        assert recorded[0].headers["content-type"].startswith("multipart/form-data")
+
+    async def test_create_on_channel_uses_json_when_no_attachments(
+        self, attach_transport
+    ):
+        """Confirms the no-attachment path still uses the generated JSON code."""
+        recorded: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            recorded.append(request)
+            return httpx.Response(
+                200,
+                json={"id": "msg_json", "type": "email", "is_inbound": False},
+            )
+
+        client = attach_transport(httpx.MockTransport(handler))
+        draft = await client.drafts.create_on_channel("cha_abc", body="<p>hi</p>")
+        assert draft.id == "msg_json"
+        assert recorded[0].headers["content-type"] == "application/json"
+
+    async def test_create_reply_with_attachments(self, attach_transport):
+        recorded: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            recorded.append(request)
+            return httpx.Response(200, json={"id": "msg_r", "type": "email"})
+
+        client = attach_transport(httpx.MockTransport(handler))
+        draft = await client.drafts.create_reply(
+            "cnv_abc",
+            body="re: hello",
+            channel_id="cha_xyz",
+            attachments=[FileSpec(filename="r.pdf", content=b"%PDF")],
+        )
+        assert draft.id == "msg_r"
+        assert recorded[0].url.path == "/conversations/cnv_abc/drafts"
+        assert recorded[0].headers["content-type"].startswith("multipart/form-data")
+
+    async def test_edit_with_attachments_uses_patch(self, attach_transport):
+        recorded: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            recorded.append(request)
+            return httpx.Response(200, json={"id": "msg_e", "type": "email"})
+
+        client = attach_transport(httpx.MockTransport(handler))
+        draft = await client.drafts.edit(
+            "msg_e",
+            body="updated",
+            channel_id="cha_xyz",
+            attachments=[FileSpec(filename="r.pdf", content=b"%PDF")],
+        )
+        assert draft.id == "msg_e"
+        assert recorded[0].method == "PATCH"
+        assert recorded[0].url.path == "/drafts/msg_e/"
+
+
+class TestConversationsWithAttachments:
+    async def test_reply_with_attachments(self, attach_transport):
+        recorded: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            recorded.append(request)
+            # 202 Accepted is what Front returns on reply
+            return httpx.Response(202, content=b"")
+
+        client = attach_transport(httpx.MockTransport(handler))
+        result = await client.conversations.reply(
+            "cnv_abc",
+            body="thanks",
+            attachments=[FileSpec(filename="x.txt", content=b"x")],
+        )
+        # post_multipart returns None for empty 2xx bodies
+        assert result is None
+        assert recorded[0].method == "POST"
+        assert recorded[0].url.path == "/conversations/cnv_abc/messages"
+        assert recorded[0].headers["content-type"].startswith("multipart/form-data")
+
+    async def test_add_comment_with_attachments(self, attach_transport):
+        recorded: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            recorded.append(request)
+            return httpx.Response(201, json={"id": "com_abc", "body": "internal"})
+
+        client = attach_transport(httpx.MockTransport(handler))
+        result = await client.conversations.add_comment(
+            "cnv_abc",
+            body="internal",
+            author_id="tea_1",
+            attachments=[FileSpec(filename="x.txt", content=b"x")],
+        )
+        assert isinstance(result, dict)
+        assert result["id"] == "com_abc"
+        assert recorded[0].url.path == "/conversations/cnv_abc/comments"
+
+
+# ---------------------------------------------------------------------------
+# Lazy property
+# ---------------------------------------------------------------------------
+
+
+def test_attachments_property_lazy_caches(mock_api_credentials):
+    client = FrontappClient(**mock_api_credentials)
+    first = client.attachments
+    second = client.attachments
+    assert first is second
+
+
+# ---------------------------------------------------------------------------
+# preview_paths vs resolve_paths
+# ---------------------------------------------------------------------------
+
+
+class TestPreviewPaths:
+    def test_returns_metadata_without_reading_bytes(self, tmp_path: Path):
+        f = tmp_path / "doc.txt"
+        f.write_bytes(b"hello world" * 100)
+        rows = preview_paths([str(f)])
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["filename"] == "doc.txt"
+        assert row["size_bytes"] == len(b"hello world" * 100)
+        assert "text" in row["mime_type"]
+
+    def test_relative_path_rejected(self):
+        with pytest.raises(ValueError, match="must be absolute"):
+            preview_paths(["doc.txt"])
+
+    def test_oversize_rejected_via_stat(self, tmp_path: Path, monkeypatch):
+        # Don't actually allocate 25 MB+ on disk just to exercise the gate —
+        # patch the size cap down to a small value and write a small file
+        # that exceeds it. Tests the same code path (Path.stat().st_size
+        # vs MAX_ATTACHMENT_BYTES check inside preview_paths).
+        from frontapp_public_api_client.helpers import attachments as attachments_mod
+
+        monkeypatch.setattr(attachments_mod, "MAX_ATTACHMENT_BYTES", 100)
+        f = tmp_path / "tiny-but-over.bin"
+        f.write_bytes(b"x" * 200)  # 200 bytes > new 100-byte cap
+
+        with pytest.raises(ValueError, match="exceeding Front's 25 MB"):
+            preview_paths([str(f)])
+
+    def test_empty_input_returns_empty(self):
+        assert preview_paths(None) == []
+        assert preview_paths([]) == []
+
+
+class TestResolvePaths:
+    def test_returns_specs_and_preview(self, tmp_path: Path):
+        f = tmp_path / "x.bin"
+        f.write_bytes(b"abc")
+        specs, preview = resolve_paths([str(f)])
+        assert len(specs) == 1
+        assert specs[0].content == b"abc"
+        assert preview[0]["size_bytes"] == 3
+
+    def test_empty_input_returns_empty(self):
+        specs, preview = resolve_paths(None)
+        assert specs == [] and preview == []
+
+
+# ---------------------------------------------------------------------------
+# URL host validation on download / stream
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadHostValidation:
+    async def test_foreign_host_rejected(self, attach_transport):
+        client = attach_transport(httpx.MockTransport(lambda _: httpx.Response(200)))
+        with pytest.raises(ValueError, match="does not match"):
+            await client.attachments.download("https://evil.example.com/download/x")
+
+    async def test_frontapp_subdomain_allowed(self, attach_transport):
+        # *.frontapp.com is allowlisted even when base_url is api.frontapp.test
+        captured = []
+
+        def handler(request):
+            captured.append(request)
+            return httpx.Response(200, content=b"ok")
+
+        client = attach_transport(httpx.MockTransport(handler))
+        body = await client.attachments.download(
+            "https://acme.api.frontapp.com/download/fil_x"
+        )
+        assert body == b"ok"
+
+    async def test_base_host_allowed(self, attach_transport):
+        # The mock_api_credentials base_url is api.frontapp.test
+        client = attach_transport(
+            httpx.MockTransport(lambda _: httpx.Response(200, content=b"ok"))
+        )
+        body = await client.attachments.download(
+            "https://api.frontapp.test/download/fil_x"
+        )
+        assert body == b"ok"
+
+    async def test_non_http_scheme_rejected(self, attach_transport):
+        client = attach_transport(
+            httpx.MockTransport(lambda _: httpx.Response(200, content=b"ok"))
+        )
+        with pytest.raises(ValueError, match="must be http or https"):
+            await client.attachments.download("file:///etc/passwd")
+
+    async def test_stream_also_validates(self, attach_transport):
+        client = attach_transport(httpx.MockTransport(lambda _: httpx.Response(200)))
+        with pytest.raises(ValueError, match="does not match"):
+            async for _ in client.attachments.stream(
+                "https://evil.example.com/download/x"
+            ):
+                pass


### PR DESCRIPTION
## Summary

Closes #12. Adds a complete attachments vertical: multipart-form-data upload bypass for the generated client (which mis-encodes binary-bearing endpoints as `application/json`) and raw-httpx download for the five binary paths that `scripts/vendor_spec.py` strips from the spec.

## Background

Front's spec models `attachments: array<binary>` on draft / message / comment / template request bodies and explicitly says "Must use `Content-Type: multipart/form-data` if specified" — but openapi-python-client serializes those endpoints as JSON. The generated `attachments: list[File]` field gets `to_dict()`'d into the JSON body, which Front rejects for binary content. This PR bypasses the generated path when attachments are present and keeps the JSON path intact when they're not.

The five binary-download paths (`/download/{id}`, `/messages/{id}/download/{id}`, etc.) are stripped from the spec because openapi-python-client can't model binary responses; this PR fetches them via raw httpx through the same authenticated session, so transport-layer retries / rate-limit handling still apply.

## Client surface

- **`FileSpec`** dataclass — filename + bytes + MIME with size validation (Front's 25 MB cap), plus `FileSpec.from_path(path)` constructor that reads + infers MIME.
- **`client.attachments.download(url)`** → `bytes` — single-shot fetch.
- **`client.attachments.stream(url)`** → `AsyncIterator[bytes]` — chunked, for large files.
- **`client.attachments.post_multipart(method, path, fields, files)`** — low-level multipart sender (used internally by drafts/conversations helpers; available for direct use against any of the 10 attachment-bearing endpoints).
- **`resolve_paths(paths)`** — module-level helper that converts a list of filesystem paths to `FileSpec`s with validation + preview rows. Used by MCP tools.

Existing helpers gain an `attachments=[FileSpec(...), ...]` kwarg that triggers the multipart bypass when present:

| Helper | Endpoint |
| --- | --- |
| `client.drafts.create_on_channel` | `POST /channels/{cha}/drafts` |
| `client.drafts.create_reply` | `POST /conversations/{cnv}/drafts` |
| `client.drafts.edit` | `PATCH /drafts/{id}/` |
| `client.conversations.reply` | `POST /conversations/{cnv}/messages` |
| `client.conversations.add_comment` | `POST /conversations/{cnv}/comments` |

When `attachments` is `None` or empty, the existing JSON path is used unchanged — no regression for non-attachment callers.

## MCP surface

- **`download_attachment(attachment_url, save_path, confirm)`** — streams to disk; two-step confirm protects the local filesystem; cleans up partial files on stream errors.
- **`attachment_paths=[...]`** parameter on `create_draft_on_channel`, `create_draft_reply`, `edit_draft`. Each path is validated as absolute, existing, ≤25 MB; preview surfaces filename + size + MIME for human review before the upload runs.

The `instructions=` block on the FastMCP server, the `frontapp://help` resource, and the README API-coverage table are all updated.

## Tests

- 32 client tests (`tests/test_attachments.py`) — FileSpec validation, download / stream / post_multipart wire shape (multipart envelope is parsed and asserted), error mapping for 401/422/429/5xx, drafts + conversations multipart integration.
- 11 MCP tool tests (`frontapp_mcp_server/tests/test_attachments_tools.py`) — download path safety, two-step confirm, partial-write cleanup on stream error, `attachment_paths` plumbing through draft tools.

## Manual integration test plan

#12's acceptance criteria require real-credential E2E. The implementation can't be verified without it; happy to support this run:

1. `client.drafts.create_reply(conv_id, body=..., channel_id=..., attachments=[FileSpec.from_path("/path/to/test.pdf")])`
2. Verify draft appears in Front's UI with PDF attached
3. Human clicks send; verify recipient receives email with PDF
4. From the resulting message in Front, copy `Attachment.url`
5. `client.attachments.download(url)` — verify bytes match the PDF
6. Same with `stream()` for a 10+MB file (asserts the chunked path doesn't buffer)

The wire format (multipart with field name `attachments` + repeated parts per file) follows Front's published example. If real-workspace testing reveals a different wire shape, the bypass is centralized in `helpers/attachments.py:post_multipart` for single-file fixes.

## Test plan

- [x] `uv run poe check` passes (471 tests + 1 skipped doc-build test)
- [x] `uv run poe agent-check` passes (typecheck + facts-check)
- [x] `uv run poe docs-build` clean
- [x] `/simplify` round: extracted shared helpers (`_raise_for_status`, `_send_draft_multipart`, `resolve_paths`); added `Literal["POST", "PATCH"]` typing
- [ ] **User**: real-credential integration test per the plan above

🤖 Generated with [Claude Code](https://claude.com/claude-code)