### PR TITLE
chore(client): normalize reply / add_comment return shape (#66)

### DIFF
--- a/frontapp_mcp_server/src/frontapp_mcp/tools/conversations.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/conversations.py
@@ -237,7 +237,7 @@ def register_tools(mcp: FastMCP) -> None:
         if result is not ConfirmationResult.CONFIRMED:
             return {"preview": preview, "confirmed": False, "result": result.value}
 
-        response = await services.client.conversations.add_comment(
+        comment = await services.client.conversations.add_comment(
             conversation_id, body=body, author_id=author_id
         )
-        return {"confirmed": True, "status_code": response.status_code}
+        return {"confirmed": True, "comment": comment}

--- a/frontapp_mcp_server/tests/test_conversations_tools.py
+++ b/frontapp_mcp_server/tests/test_conversations_tools.py
@@ -293,10 +293,9 @@ class TestAddConversationComment:
 
     async def test_confirmed_calls_helper(self, conversations_tools):
         context, lifespan = create_mock_context()
-        response = MagicMock()
-        response.status_code = 201
+        comment = {"id": "com_abc", "body": "VIP customer", "author_id": "tea_xyz"}
         lifespan.client = AsyncMock()
-        lifespan.client.conversations.add_comment = AsyncMock(return_value=response)
+        lifespan.client.conversations.add_comment = AsyncMock(return_value=comment)
 
         result = await conversations_tools["add_conversation_comment"](
             context,
@@ -309,4 +308,4 @@ class TestAddConversationComment:
         lifespan.client.conversations.add_comment.assert_awaited_once_with(
             "cnv_a", body="VIP customer", author_id="tea_xyz"
         )
-        assert result == {"confirmed": True, "status_code": 201}
+        assert result == {"confirmed": True, "comment": comment}

--- a/frontapp_public_api_client/helpers/conversations.py
+++ b/frontapp_public_api_client/helpers/conversations.py
@@ -275,16 +275,16 @@ class Conversations(Base):
         cc: builtins.list[str] | None = None,
         bcc: builtins.list[str] | None = None,
         attachments: builtins.list[FileSpec] | None = None,
-    ) -> Any:
+    ) -> dict[str, Any] | None:
         """Send an outbound reply on an existing conversation.
 
-        Uses the channel the conversation was opened on. Returns the raw
-        response (Front replies with 202 Accepted; the message is enqueued).
+        Uses the channel the conversation was opened on. Front returns
+        ``202 Accepted`` once the message is enqueued; the parsed body
+        is normalised to ``dict | None`` regardless of whether attachments
+        triggered the multipart path.
 
         Pass ``attachments=[FileSpec(...), ...]`` to attach files; the
-        request is then sent as ``multipart/form-data``. Returns the parsed
-        JSON dict (or ``None``) instead of the generated ``Response`` when
-        attachments are used.
+        request is then sent as ``multipart/form-data``.
         """
         from urllib.parse import quote as _quote
 
@@ -292,6 +292,7 @@ class Conversations(Base):
         from frontapp_public_api_client.models.outbound_reply_message import (
             OutboundReplyMessage,
         )
+        from frontapp_public_api_client.utils import unwrap
 
         if attachments:
             payload = {
@@ -328,9 +329,11 @@ class Conversations(Base):
             payload_kwargs["bcc"] = bcc
 
         message = OutboundReplyMessage(**payload_kwargs)
-        return await create_message_reply.asyncio_detailed(
+        response = await create_message_reply.asyncio_detailed(
             conversation_id=conversation_id, client=self._client, body=message
         )
+        parsed = unwrap(response)
+        return parsed.to_dict() if parsed is not None else None
 
     async def add_comment(
         self,
@@ -339,17 +342,21 @@ class Conversations(Base):
         body: str,
         author_id: str | None = None,
         attachments: builtins.list[FileSpec] | None = None,
-    ) -> Any:
+    ) -> dict[str, Any] | None:
         """Add an internal comment (visible to teammates only).
 
+        Front returns ``201 Created`` with the new comment as JSON; the
+        parsed body is normalised to ``dict | None`` regardless of whether
+        attachments triggered the multipart path.
+
         Pass ``attachments=[FileSpec(...), ...]`` to attach files; the
-        request is then sent as ``multipart/form-data`` and returns the
-        parsed JSON dict instead of the generated ``Response``.
+        request is then sent as ``multipart/form-data``.
         """
         from urllib.parse import quote as _quote
 
         from frontapp_public_api_client.api.comments import add_comment
         from frontapp_public_api_client.models.create_comment import CreateComment
+        from frontapp_public_api_client.utils import unwrap
 
         if attachments:
             payload = {
@@ -371,9 +378,11 @@ class Conversations(Base):
             payload_kwargs["author_id"] = author_id
 
         comment = CreateComment(**payload_kwargs)
-        return await add_comment.asyncio_detailed(
+        response = await add_comment.asyncio_detailed(
             conversation_id=conversation_id, client=self._client, body=comment
         )
+        parsed = unwrap(response)
+        return parsed.to_dict() if parsed is not None else None
 
     async def update(
         self,

--- a/tests/test_conversations.py
+++ b/tests/test_conversations.py
@@ -303,9 +303,12 @@ class TestMutations:
         transport, recorded = make_recording_transport({}, status=202)
         client = attach_transport(transport)
 
-        await client.conversations.reply(
+        result = await client.conversations.reply(
             "cnv_abc", body="Thanks for reaching out.", author_id="tea_xyz"
         )
+        # Helper unwraps the generated response into a dict (or None for
+        # empty 2xx) — same shape the multipart-attachments path returns.
+        assert result is None or isinstance(result, dict)
         assert recorded[0].method == "POST"
         body = json.loads(recorded[0].content)
         assert body["body"] == "Thanks for reaching out."
@@ -360,11 +363,67 @@ class TestMutations:
         transport, recorded = make_recording_transport(comment_payload(), status=201)
         client = attach_transport(transport)
 
-        await client.conversations.add_comment(
+        result = await client.conversations.add_comment(
             "cnv_abc", body="VIP customer", author_id="tea_xyz"
         )
+        # Helper unwraps the 201 response into a dict — same shape the
+        # multipart-attachments path returns.
+        assert isinstance(result, dict)
+        assert result["id"] == "com_1"
         body = json.loads(recorded[0].content)
         assert body == {"body": "VIP customer", "author_id": "tea_xyz"}
+
+    async def test_reply_returns_dict_or_none_in_both_paths(
+        self, attach_transport, make_recording_transport
+    ):
+        """Acceptance criterion: ``reply`` returns ``dict | None`` whether
+        or not attachments triggered the multipart bypass. PR #65 left the
+        no-attachment path returning the generated ``Response``; issue
+        #66 normalised it.
+        """
+        from frontapp_public_api_client.helpers.attachments import FileSpec
+
+        # Standard path: generated response → dict via to_dict().
+        transport, _ = make_recording_transport(
+            {"status": "accepted", "message_uid": "msg_1"}, status=202
+        )
+        client = attach_transport(transport)
+        no_attach = await client.conversations.reply("cnv_abc", body="Hi")
+        assert no_attach is None or isinstance(no_attach, dict)
+
+        # Multipart path: post_multipart returns dict|None directly.
+        transport2, _ = make_recording_transport({}, status=202)
+        client2 = attach_transport(transport2)
+        with_attach = await client2.conversations.reply(
+            "cnv_abc",
+            body="Hi",
+            attachments=[FileSpec(filename="x.txt", content=b"x")],
+        )
+        assert with_attach is None or isinstance(with_attach, dict)
+
+    async def test_add_comment_returns_dict_in_both_paths(
+        self, attach_transport, make_recording_transport
+    ):
+        """Acceptance criterion: ``add_comment`` returns ``dict`` whether
+        or not attachments triggered the multipart bypass.
+        """
+        from frontapp_public_api_client.helpers.attachments import FileSpec
+
+        transport, _ = make_recording_transport(comment_payload(), status=201)
+        client = attach_transport(transport)
+        no_attach = await client.conversations.add_comment("cnv_abc", body="Note")
+        assert isinstance(no_attach, dict)
+
+        transport2, _ = make_recording_transport(
+            {"id": "com_2", "body": "Note"}, status=201
+        )
+        client2 = attach_transport(transport2)
+        with_attach = await client2.conversations.add_comment(
+            "cnv_abc",
+            body="Note",
+            attachments=[FileSpec(filename="x.txt", content=b"x")],
+        )
+        assert isinstance(with_attach, dict)
 
     async def test_update_with_status_serializes_enum(
         self, attach_transport, make_recording_transport


### PR DESCRIPTION
## Summary

Normalizes `client.conversations.reply` and `client.conversations.add_comment` so both helpers return the same shape (`dict | None`) regardless of whether the `attachments=` kwarg routes the request through the multipart bypass.

PR #65 introduced the asymmetry — the multipart path returned `dict | None` from `post_multipart`, while the no-attachment path leaked the generated `Response[...]`. Copilot review and `/simplify` flagged it; we deferred the fix to issue #66 to keep #65's scope tight. This PR is that follow-up — design discussed in PR #65 review comments.

## Changes

- `helpers/conversations.py` — both `reply` and `add_comment` now `unwrap()` the generated response and call `.to_dict()` on the parsed body. Return type narrowed from `Any` to `dict[str, Any] | None`.
- `frontapp_mcp/tools/conversations.py` — `add_conversation_comment` consumed `.status_code`; switched to surface the parsed comment dict via `{"confirmed": True, "comment": comment}`.
- Tests updated; new parity test asserts both code paths return the same shape on each helper.

## Test plan

- [x] `uv run poe agent-check` — passes
- [x] `uv run poe test` — 484 passed
- [x] `uv run poe docs-build` — passes (strict)
- [x] `uv run poe check` — passes

Closes #66

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>