### PR TITLE
chore(harness): enable pyright + typescript LSP plugins

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,9 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "enabledPlugins": {
+    "pyright-lsp@claude-plugins-official": true,
+    "typescript-lsp@claude-plugins-official": true
+  },
   "hooks": {
     "PreToolUse": [
       {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,10 +144,25 @@ Common mistakes to avoid:
 
 ## Using the LSP tool
 
-Both Python (pyright) and TypeScript (typescript-language-server) LSPs are configured
-and active. **Prefer LSP operations over `Read` + `Grep` for type and call-graph
-questions** — they are faster, more accurate, and cross-reference the real type system
-(including third-party libraries in `.venv`).
+Both Python (pyright) and TypeScript (typescript-language-server) LSPs are wired through
+Claude Code plugins (`pyright-lsp@claude-plugins-official` and
+`typescript-lsp@claude-plugins-official`, enabled in `.claude/settings.json` →
+`enabledPlugins`). The plugins only register the language servers — the binaries
+themselves must be installed and on PATH:
+
+```bash
+uv tool install pyright                              # pyright + pyright-langserver → ~/.local/bin
+npm install --prefix ~/.local typescript-language-server typescript
+# then symlink both binaries into a directory already on PATH (e.g. ~/bin/)
+```
+
+If `LSP <op>` returns `No LSP server available for file type: .py` (or `.ts`), the
+plugin isn't enabled or the binary isn't reachable — verify `which pyright-langserver` /
+`which typescript-language-server` and restart Claude Code after enabling the plugin.
+
+**Prefer LSP operations over `Read` + `Grep` for type and call-graph questions** — they
+are faster, more accurate, and cross-reference the real type system (including
+third-party libraries in `.venv`).
 
 | When you need to…                                             | Use                  |
 | ------------------------------------------------------------- | -------------------- |


### PR DESCRIPTION
## Summary

- Add `pyright-lsp@claude-plugins-official` and `typescript-lsp@claude-plugins-official` to `.claude/settings.json` → `enabledPlugins`, so the LSP tool resolves `.py` and `.ts` files in this repo.
- Replace the misleading "configured and active" line in `CLAUDE.md` with the actual install steps (`uv tool install pyright`, `npm install --prefix ~/.local typescript-language-server typescript`, symlink into a PATH dir) plus a troubleshooting hint for `No LSP server available`.

## Why project-level instead of user-level

`enabledPlugins` is conventionally a user-scope key, but `~/.claude/settings.json` on contributor machines may be managed externally (e.g. Nix Home Manager makes it a read-only symlink). Putting it in the committed project file means every contributor gets the LSPs without having to touch their personal config — and the README of CLAUDE.md is now in sync with reality.

## Verified

- `LSP documentSymbol` against `frontapp_public_api_client/utils.py` returns the full symbol tree (classes, methods, variables) after restart.
- `LSP documentSymbol` against `packages/frontapp-client/src/client.ts` returns the full TS symbol tree.
- Pyright also pushed real diagnostics into the editor (3 `reportOverlappingOverload` warnings on `utils.py` overloads — pre-existing, not addressed in this PR; will be cleaned up in a follow-up sweep).
- `uv run poe agent-check` ✅

## Test plan

- [ ] Pull, restart Claude Code, run `LSP hover` on any symbol — should return type info, not "No LSP server available"
- [ ] CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)