### PR TITLE
chore: fix all LSP-surfaced type errors across hand-written code

### DIFF
--- a/frontapp_mcp_server/src/frontapp_mcp/resources/reference.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/resources/reference.py
@@ -67,11 +67,13 @@ async def _list_field_results(
     """Boilerplate for `field_results`-shaped list endpoints.
 
     Three of the four reference resources (`tags`, `inboxes`, `teammates`)
-    follow the identical shape: call list_*.asyncio_detailed, unwrap field_results,
-    project each item through a Pydantic ref model, JSON-dump.
+    follow the identical shape: call ``list_*.asyncio_detailed``, unwrap
+    ``field_results``, project each item through a Pydantic ref model,
+    JSON-dump. Pass the ``asyncio_detailed`` function directly, e.g.
+    ``_list_field_results(context, list_tags.asyncio_detailed, TagRef)``.
     """
     services = get_services(context)
-    response = await list_fn.asyncio_detailed(client=services.client)
+    response = await list_fn(client=services.client)
     parsed = unwrap(response)
     results = getattr(parsed, "field_results", None) or []
     return _dump([_project(model, item) for item in results])
@@ -92,7 +94,7 @@ def register_resources(mcp: FastMCP) -> None:
     async def tags_resource(context: Context) -> str:
         from frontapp_public_api_client.api.tags import list_tags
 
-        return await _list_field_results(context, list_tags, TagRef)
+        return await _list_field_results(context, list_tags.asyncio_detailed, TagRef)
 
     @mcp.resource(
         uri="frontapp://inboxes",
@@ -106,7 +108,9 @@ def register_resources(mcp: FastMCP) -> None:
     async def inboxes_resource(context: Context) -> str:
         from frontapp_public_api_client.api.inboxes import list_inboxes
 
-        return await _list_field_results(context, list_inboxes, InboxRef)
+        return await _list_field_results(
+            context, list_inboxes.asyncio_detailed, InboxRef
+        )
 
     @mcp.resource(
         uri="frontapp://teammates",
@@ -120,7 +124,9 @@ def register_resources(mcp: FastMCP) -> None:
     async def teammates_resource(context: Context) -> str:
         from frontapp_public_api_client.api.teammates import list_teammates
 
-        return await _list_field_results(context, list_teammates, TeammateRef)
+        return await _list_field_results(
+            context, list_teammates.asyncio_detailed, TeammateRef
+        )
 
     @mcp.resource(
         uri="frontapp://conversations/recent",

--- a/frontapp_mcp_server/tests/conftest.py
+++ b/frontapp_mcp_server/tests/conftest.py
@@ -111,6 +111,9 @@ def mcp_tool_capture():
         class FakeMCP:
             def tool(self, **kwargs: object):
                 name = kwargs["name"]
+                assert isinstance(name, str), (
+                    f"tool name must be a str, got {type(name).__name__}"
+                )
 
                 def decorator(fn):
                     captured[name] = fn

--- a/frontapp_mcp_server/tests/test_attachments_tools.py
+++ b/frontapp_mcp_server/tests/test_attachments_tools.py
@@ -207,6 +207,7 @@ class TestDraftAttachmentPaths:
         assert result["confirmed"] is True
         # Helper called with FileSpec list
         call = lifespan.client.drafts.create_on_channel.await_args
+        assert call is not None
         attachments = call.kwargs["attachments"]
         assert len(attachments) == 2
         assert all(isinstance(a, FileSpec) for a in attachments)

--- a/frontapp_mcp_server/tests/test_drafts_tools.py
+++ b/frontapp_mcp_server/tests/test_drafts_tools.py
@@ -214,7 +214,7 @@ class TestDraftSummary:
             }
         )
         # Re-construct with author and recipients for projection.
-        author = TeammateSummary(first_name="Ada", last_name="Lovelace")
+        author = TeammateSummary(id="tea_1", first_name="Ada", last_name="Lovelace")
         recipient = RecipientSummary(handle="customer@example.com", role="to")
         draft = draft.model_copy(update={"author": author, "recipients": [recipient]})
 
@@ -230,7 +230,9 @@ class TestDraftSummary:
         from frontapp_public_api_client.domain import TeammateSummary
 
         draft = Draft.model_validate({"id": "msg_abc"})
-        author = TeammateSummary(username="ada", first_name=None, last_name=None)
+        author = TeammateSummary(
+            id="tea_1", username="ada", first_name=None, last_name=None
+        )
         draft = draft.model_copy(update={"author": author})
 
         summary = to_draft_summary(draft)

--- a/frontapp_public_api_client/frontapp_client.py
+++ b/frontapp_public_api_client/frontapp_client.py
@@ -16,7 +16,7 @@ from collections.abc import Awaitable, Callable
 from http import HTTPStatus
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
-from urllib.parse import parse_qs, quote, urlencode, urlparse, urlunparse
+from urllib.parse import parse_qs, quote, urlparse, urlunparse
 
 if TYPE_CHECKING:
     from .helpers.attachments import Attachments
@@ -78,13 +78,13 @@ def _sanitize_url(url: str) -> str:
                 sanitized[k] = [_REDACTED]
             else:
                 sanitized[k] = values
-        # Use urlencode with custom quote function that preserves * characters
-        clean_query = urlencode(
-            sanitized,
-            doseq=True,
-            quote_via=lambda s, safe="", encoding=None, errors=None: quote(
-                s, safe=safe + "*", encoding=encoding, errors=errors
-            ),
+
+        # Build the query string manually so we can preserve `*` (Front uses
+        # `*` in some search-DSL values; the default urlencode percent-encodes it).
+        clean_query = "&".join(
+            f"{quote(k, safe='*')}={quote(v, safe='*')}"
+            for k, vs in sanitized.items()
+            for v in vs
         )
         return urlunparse(parsed._replace(query=clean_query))
     except Exception:
@@ -183,7 +183,7 @@ class ErrorLoggingTransport(AsyncHTTPTransport):
 
     def __init__(
         self,
-        wrapped_transport: AsyncHTTPTransport | None = None,
+        wrapped_transport: httpx.AsyncBaseTransport | None = None,
         logger: Logger | None = None,
         **kwargs: Any,
     ):
@@ -191,14 +191,16 @@ class ErrorLoggingTransport(AsyncHTTPTransport):
         Initialize the error logging transport.
 
         Args:
-            wrapped_transport: The transport to wrap. If None, creates a new AsyncHTTPTransport.
+            wrapped_transport: The transport to wrap. Any ``httpx.AsyncBaseTransport``
+                works (including ``MockTransport`` for tests). If None, creates a
+                new AsyncHTTPTransport.
             logger: Logger instance for capturing error details. If None, creates a default logger.
             **kwargs: Additional arguments passed to AsyncHTTPTransport if wrapped_transport is None.
         """
         super().__init__()
         if wrapped_transport is None:
             wrapped_transport = AsyncHTTPTransport(**kwargs)
-        self._wrapped_transport = wrapped_transport
+        self._wrapped_transport: httpx.AsyncBaseTransport = wrapped_transport
         self.logger: Logger = logger or logging.getLogger(__name__)
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
@@ -616,6 +618,14 @@ class FrontappClient(AuthenticatedClient):
 
     # Remove the client property since we inherit from AuthenticatedClient
     # Users can now pass the FrontappClient instance directly to API methods
+
+    async def __aenter__(self) -> "FrontappClient":
+        # Override AuthenticatedClient.__aenter__ to return Self instead of
+        # the parent type, so `async with FrontappClient() as c` narrows c
+        # to FrontappClient and the .conversations / .drafts / etc. helpers
+        # are visible to type checkers.
+        await super().__aenter__()
+        return self
 
     # Domain properties for ergonomic access
     @property

--- a/frontapp_public_api_client/helpers/attachments.py
+++ b/frontapp_public_api_client/helpers/attachments.py
@@ -37,7 +37,7 @@ Public surface:
 from __future__ import annotations
 
 import mimetypes
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
@@ -134,7 +134,7 @@ def _validate_path(raw: str | Path) -> Path:
 
 
 def preview_paths(
-    paths: list[str | Path] | None,
+    paths: Sequence[str | Path] | None,
 ) -> list[dict[str, Any]]:
     """Stat-only preview of attachment paths — no file bytes are read.
 
@@ -169,7 +169,7 @@ def preview_paths(
 
 
 def resolve_paths(
-    paths: list[str | Path] | None,
+    paths: Sequence[str | Path] | None,
 ) -> tuple[list[FileSpec], list[dict[str, Any]]]:
     """Resolve filesystem paths to FileSpec instances + a preview list.
 

--- a/frontapp_public_api_client/helpers/base.py
+++ b/frontapp_public_api_client/helpers/base.py
@@ -13,7 +13,7 @@ response and feeding the extracted ``page_token`` back to the next call.
 from __future__ import annotations
 
 from collections.abc import AsyncIterator, Awaitable, Callable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import parse_qs, urlparse
 
 if TYPE_CHECKING:
@@ -74,8 +74,9 @@ class Base:
             max_items: Stop after yielding this many items (yields a
                 partial final page rather than fetching more). ``None``
                 means no per-iterator limit.
-            max_pages: Stop after this many page fetches. Defaults to the
-                ``FrontappClient(max_pages=...)`` config (100).
+            max_pages: Stop after this many page fetches. Falls back to
+                the legacy ``FrontappClient(max_pages=...)`` setting when
+                present, otherwise defaults to 100.
             **request_kwargs: Forwarded to every ``endpoint_call`` invocation
                 (q, limit, path-id args, etc.). ``client=`` and
                 ``page_token=`` are managed internally — don't pass them.
@@ -87,7 +88,10 @@ class Base:
         from frontapp_public_api_client.utils import unwrap
 
         if max_pages is None:
-            max_pages = getattr(self._client, "max_pages", 100)
+            # Fallback to the client-level cap if it has one (legacy behavior),
+            # otherwise default to 100. The cast keeps pyright narrow since
+            # getattr returns Any.
+            max_pages = cast(int, getattr(self._client, "max_pages", 100))
         logger = getattr(self._client, "logger", None)
 
         request_kwargs.pop("client", None)

--- a/frontapp_public_api_client/utils.py
+++ b/frontapp_public_api_client/utils.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from http import HTTPStatus
-from typing import Any, overload
+from typing import Any, Literal, overload
 
 from .client_types import Response, Unset
 from .domain.converters import unwrap_unset
@@ -75,11 +75,11 @@ class ServerError(APIError):
 
 
 @overload
-def unwrap[T](response: Response[T], *, raise_on_error: bool = True) -> T: ...
+def unwrap[T](response: Response[T], *, raise_on_error: Literal[True] = True) -> T: ...
 
 
 @overload
-def unwrap[T](response: Response[T], *, raise_on_error: bool = False) -> T | None: ...
+def unwrap[T](response: Response[T], *, raise_on_error: Literal[False]) -> T | None: ...
 
 
 def unwrap[T](response: Response[T], *, raise_on_error: bool = True) -> T | None:
@@ -136,13 +136,13 @@ def unwrap[T](response: Response[T], *, raise_on_error: bool = True) -> T | None
 
 @overload
 def unwrap_data[T](
-    response: Response[T], *, raise_on_error: bool = True, default: None = None
+    response: Response[T], *, raise_on_error: Literal[True] = True, default: None = None
 ) -> Any: ...
 
 
 @overload
 def unwrap_data[T](
-    response: Response[T], *, raise_on_error: bool = False, default: None = None
+    response: Response[T], *, raise_on_error: Literal[False], default: None = None
 ) -> Any | None: ...
 
 
@@ -150,7 +150,7 @@ def unwrap_data[T](
 def unwrap_data[T, DataT](
     response: Response[T],
     *,
-    raise_on_error: bool = False,
+    raise_on_error: bool = ...,
     default: list[DataT],
 ) -> Any: ...
 
@@ -208,7 +208,7 @@ def unwrap_as[T, ExpectedT](
     response: Response[T],
     expected_type: type[ExpectedT],
     *,
-    raise_on_error: bool = True,
+    raise_on_error: Literal[True] = True,
 ) -> ExpectedT: ...
 
 
@@ -217,7 +217,7 @@ def unwrap_as[T, ExpectedT](
     response: Response[T],
     expected_type: type[ExpectedT],
     *,
-    raise_on_error: bool = False,
+    raise_on_error: Literal[False],
 ) -> ExpectedT | None: ...
 
 

--- a/packages/frontapp-client/src/index.ts
+++ b/packages/frontapp-client/src/index.ts
@@ -33,11 +33,11 @@ export { FrontappClient, type FrontappClientOptions } from './client.js';
 // Re-export error types and utilities
 export {
   AuthenticationError,
+  FrontappError,
   NetworkError,
   parseError,
   RateLimitError,
   ServerError,
-  FrontappError,
   ValidationError,
   type ValidationErrorDetail,
 } from './errors.js';

--- a/packages/frontapp-client/tests/errors.test.ts
+++ b/packages/frontapp-client/tests/errors.test.ts
@@ -5,11 +5,11 @@
 import { describe, expect, it } from 'vitest';
 import {
   AuthenticationError,
+  FrontappError,
   NetworkError,
   parseError,
   RateLimitError,
   ServerError,
-  FrontappError,
   ValidationError,
 } from '../src/errors.js';
 

--- a/scripts/regenerate_client.py
+++ b/scripts/regenerate_client.py
@@ -78,6 +78,7 @@ def run_command_streaming(
     if timeout:
         print(f"   ⏱️  Timeout: {timeout}s")
 
+    process: subprocess.Popen[str] | None = None
     try:
         process = subprocess.Popen(
             cmd,
@@ -99,7 +100,7 @@ def run_command_streaming(
 
     except subprocess.TimeoutExpired:
         print(f"\n   ⏰ Command timed out after {timeout}s")
-        if process:
+        if process is not None:
             process.kill()
         return 124
     except Exception as e:

--- a/scripts/vendor_spec.py
+++ b/scripts/vendor_spec.py
@@ -138,7 +138,8 @@ def main() -> int:
             stripped_defaults += 1
     print(f"🧹 Stripped {stripped_defaults} inherited-default values")
 
-    spec = _replace_confusables(spec)
+    # _replace_confusables mutates dicts in place; the top-level node is always a dict.
+    _replace_confusables(spec)
     print("🧹 Replaced Unicode confusables")
 
     OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,13 +111,12 @@ def frontapp_client_with_mock_transport(mock_api_credentials, mock_transport):
     # Create a FrontappClient
     client = FrontappClient(**mock_api_credentials)
 
-    # Create a new httpx client with the mock transport and base_url
-    mock_httpx_client = httpx.AsyncClient(
-        transport=mock_transport, base_url=mock_api_credentials["base_url"]
+    # Replace the underlying httpx client with one that uses the mock transport.
+    client.set_async_httpx_client(
+        httpx.AsyncClient(
+            transport=mock_transport, base_url=mock_api_credentials["base_url"]
+        )
     )
-
-    # Replace the authenticated client's async client
-    client._client._async_client = mock_httpx_client
 
     return client
 

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -271,9 +271,9 @@ class TestPostMultipart:
                     name = piece[len("name=") :].strip('"')
                 elif piece.startswith("filename="):
                     filenames.append(piece[len("filename=") :].strip('"'))
-            parts_by_name.setdefault(name, []).append(
-                part.get_payload(decode=True) or b""
-            )
+            payload = part.get_payload(decode=True) or b""
+            assert isinstance(payload, bytes)
+            parts_by_name.setdefault(name, []).append(payload)
 
         assert parts_by_name.get("body") == [b"Hello"]
         assert parts_by_name.get("to") == [b"a@example.com", b"b@example.com"]


### PR DESCRIPTION
## Summary

After the LSP plugins were enabled in PR #74, pyright and biome surfaced a backlog of type errors across editable Python and TypeScript code that weren't being caught (the previous typechecker, `ty`, doesn't run in IDE mode and `ruff` doesn't typecheck). This PR sweeps them.

**Before**: 26 pyright errors + 2 biome errors across 14 files.
**After**: pyright ✅ • biome ✅ • tsc ✅ • `uv run poe full-check` ✅ • 536 tests pass.

## Behavior changes (narrow, type-safety-only)

- **`ErrorLoggingTransport.wrapped_transport`** now accepts any `httpx.AsyncBaseTransport` (including `MockTransport`) instead of just `AsyncHTTPTransport`. The test in `tests/test_transport_integration.py` was constructing it with a `MockTransport` so the parameter type was actually wrong — runtime worked because both classes share the same `handle_async_request` shape.
- **`FrontappClient.__aenter__`** now returns `FrontappClient` (Self-narrowed) instead of inheriting the parent's `AuthenticatedClient` return type. So `async with FrontappClient() as c` finally narrows `c` to the subclass and the `.conversations` / `.drafts` / etc. helpers are visible to type checkers.

## Type-only fixes (no runtime semantics change)

| File | Change |
| --- | --- |
| `utils.py` | `unwrap` / `unwrap_data` / `unwrap_as` overloads now discriminate on `raise_on_error` via `Literal[True]` / `Literal[False]` so the second overload isn't unreachable |
| `helpers/attachments.py` | `preview_paths` / `resolve_paths` accept `Sequence[str \| Path]` (covariant) instead of `list[str \| Path]` (invariant), so MCP tools passing `list[str]` type-check |
| `helpers/base.py` | `cast(int, getattr(self._client, "max_pages", 100))` for the legacy-client lookup so the `>=` comparison is well-typed |
| `frontapp_client.py` | Replace `urlencode(quote_via=lambda)` with manual query-string build (lambda couldn't satisfy `_QuoteVia`'s overloaded protocol) |
| `scripts/regenerate_client.py` | Restructure try/except so `process` is always bound on the timeout path |
| `scripts/vendor_spec.py` | Drop redundant `spec = _replace_confusables(spec)` rebinding (the function mutates dicts in place); fixes a false "indexing object" error |
| `resources/reference.py` | `_list_field_results` takes a `Callable` directly; call sites pass `list_*.asyncio_detailed` explicitly |
| `frontapp_mcp_server/tests/conftest.py` | Assert the captured tool name is a `str` |
| `frontapp_mcp_server/tests/test_attachments_tools.py` | Assert `await_args is not None` before reading `.kwargs` |
| `frontapp_mcp_server/tests/test_drafts_tools.py` | Pass `id="tea_1"` explicitly to `TeammateSummary` (pyright doesn't see Pydantic's `Field(None, ...)` default) |
| `tests/conftest.py` | Switch `frontapp_client_with_mock_transport` to public `set_async_httpx_client(...)` instead of poking `client._client._async_client` |
| `tests/test_attachments.py` | `assert isinstance(payload, bytes)` so the multipart-decode result narrows |
| `packages/frontapp-client/{src/index.ts,tests/errors.test.ts}` | Biome auto-fix import ordering |

## Test plan

- [ ] CI green
- [ ] `uv run poe full-check` passes
- [ ] `pyright` (no flags) reports 0 errors
- [ ] `pnpm --filter frontapp-client run lint` and `... run typecheck` both pass

## Stack

- Builds on **#74** (LSP plugin enablement) and is **independent of #62** — both can land in any order. After all three land, the rebase is trivial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)