### PR TITLE
fix(client): close wrapped transport on ErrorLoggingTransport.aclose() (#77)

### DIFF
--- a/frontapp_public_api_client/frontapp_client.py
+++ b/frontapp_public_api_client/frontapp_client.py
@@ -213,6 +213,17 @@ class ErrorLoggingTransport(AsyncHTTPTransport):
 
         return response
 
+    async def aclose(self) -> None:
+        """Close the wrapped transport's connection pool, then our own.
+
+        ``super().__init__()`` allocated an unused ``AsyncHTTPTransport`` pool
+        (this class delegates every request to ``_wrapped_transport``); without
+        this override only the unused pool would close on shutdown and the
+        wrapped transport's pool would leak.
+        """
+        await self._wrapped_transport.aclose()
+        await super().aclose()
+
     async def _log_client_error(
         self, response: httpx.Response, request: httpx.Request
     ) -> None:

--- a/tests/test_transport_integration.py
+++ b/tests/test_transport_integration.py
@@ -20,7 +20,7 @@ import logging
 import os
 import stat
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
@@ -242,6 +242,23 @@ class TestErrorLoggingTransport:
         msg = logger.error.call_args[0][0]
         assert "secret" not in msg
         assert "***" in msg
+
+    async def test_aclose_delegates_to_wrapped_transport(self):
+        """Closing the wrapper must close the wrapped transport's pool too.
+
+        ErrorLoggingTransport extends AsyncHTTPTransport, so super().__init__()
+        allocates an unused parent pool. Without the aclose override, only
+        the unused pool would close on shutdown — the wrapped transport's
+        pool would leak. Regression test for issue #77.
+        """
+        wrapped_aclose = AsyncMock()
+        wrapped = MagicMock(spec=httpx.AsyncBaseTransport)
+        wrapped.aclose = wrapped_aclose
+        transport = ErrorLoggingTransport(
+            wrapped_transport=wrapped, logger=MagicMock(spec=logging.Logger)
+        )
+        await transport.aclose()
+        wrapped_aclose.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #77.

## Summary

`ErrorLoggingTransport` extends `AsyncHTTPTransport`, so `super().__init__()` allocates an unused connection pool. Every request is delegated to `_wrapped_transport`, but without an `aclose` override, the parent's `aclose()` only closes the **unused** pool; the wrapped transport's pool leaks.

This pattern was carried over from a sibling project and was masked by the (now-deleted) `PaginationTransport` having the same shape. After PR #75 deleted that layer, the leak is the same but the shape is more visible — Copilot caught it during the #75 review.

## Fix

```python
async def aclose(self) -> None:
    await self._wrapped_transport.aclose()
    await super().aclose()
```

Plus a regression test in `TestErrorLoggingTransport.test_aclose_delegates_to_wrapped_transport` that asserts the wrapped transport's `aclose` is awaited when the wrapper closes.

## Why not switch to `AsyncBaseTransport` instead

The alternative — re-rooting `ErrorLoggingTransport` on `httpx.AsyncBaseTransport` instead of `AsyncHTTPTransport` so we don't allocate the unused parent pool at all — is a bigger refactor with the same observable outcome. Override is one line; staying close to the existing shape avoids touching the `**kwargs` path that's still used when `wrapped_transport=None`.

## Test plan

- [ ] CI green
- [ ] `uv run poe agent-check` passes locally ✅
- [ ] New `test_aclose_delegates_to_wrapped_transport` passes ✅
- [ ] Existing 44 tests in `test_transport_integration.py` still pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)