### PR TITLE
feat(client,mcp): analytics polling vertical (#6)

### DIFF
--- a/docs/api-facts.yaml
+++ b/docs/api-facts.yaml
@@ -17,8 +17,8 @@
 #      domain wiring status, full path/method/response info).
 #
 schema_version: 1
-generated_at: '2026-04-27T05:04:16+00:00'
-generated_from_commit: e7cedf939409d95a10c1ed173704838b8ad179f1
+generated_at: '2026-04-27T15:54:45+00:00'
+generated_from_commit: 48172d1a7373084ab7c2ddb083548c57c8940826
 summary:
   list_endpoints_with_field_results:
     - accounts.list_account_contacts
@@ -241,6 +241,7 @@ summary:
     - tags.update_a_tag
     - teammate_groups.update_a_company_teammate_group
   tags_with_helper:
+    - analytics
     - contact_groups
     - contact_lists
     - contacts
@@ -323,9 +324,9 @@ tags:
     spec_tag: Analytics
     api_dir: frontapp_public_api_client/api/analytics
     helper:
-      built: false
-      path: null
-      class: null
+      built: true
+      path: frontapp_public_api_client/helpers/analytics.py
+      class: Analytics
     domain:
       built: false
       path: null

--- a/frontapp_mcp_server/src/frontapp_mcp/resources/help.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/resources/help.py
@@ -225,6 +225,30 @@ preferred name-to-id lookup at session start.
 | `list_assigned_conversations` | `GET /teammates/{id}/conversations` | Conversations currently assigned to this teammate. Returns `ConversationSummary`s. |
 | `update_teammate` | `PATCH /teammates/{id}` | Update username / first_name / last_name / is_available. Email and admin status are NOT changeable here. Two-step confirm. |
 
+## Analytics
+
+Front's analytics endpoints are server-side asynchronous: the POST returns
+immediately with a job id; a follow-up GET polls until `status == "done"`.
+The MCP tools wrap that loop into a single call. No two-step confirm —
+these are read/query operations; the server-side job is just how Front
+computes the result.
+
+| Tool | Endpoint | Purpose |
+| ---- | -------- | ------- |
+| `run_analytics_report` | `POST /analytics/reports` + `GET /analytics/reports/{uid}` | Compute scalar metrics over a time window. Pass exactly one filter category (`inbox_ids` OR `tag_ids` OR `teammate_ids` OR `team_ids` OR `channel_ids` OR `account_ids`) — Front rejects combined categories. Returns final dict with `metrics`. |
+| `run_analytics_export` | `POST /analytics/exports` + `GET /analytics/exports/{id}` | Bulk-export teammate-activity rows (`export_type="activities"`) or message-level rows (`export_type="messages"`) to CSV. Returns a download URL. If Front responds `too_big`, narrow the date range or column set and retry. |
+
+Both tools poll until `done`, fail (`failed` or `too_big`), or
+`timeout_seconds` elapses (returns `{"status": "timeout"}`). The
+server-side job keeps running on Front after a tool timeout — library
+callers can resume via `client.analytics.get_report(uid)` /
+`get_export(id)`.
+
+Defaults: `run_analytics_report` polls once a second for 30s;
+`run_analytics_export` polls every 2 seconds for 120s. Both honor a
+`Retry-After` response header if
+Front sends one.
+
 ### Workflow recipe — "what else do we have on this customer?"
 
 ```

--- a/frontapp_mcp_server/src/frontapp_mcp/server.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/server.py
@@ -375,6 +375,28 @@ endpoint for fetching them back out.
   and writes them to a local file. Two-step confirm protects the local
   filesystem; the response includes only metadata (path, size).
 
+## Analytics
+
+Front's analytics endpoints are server-side asynchronous: a POST creates
+a compute job and returns immediately; the result lands seconds later.
+The MCP tools wrap the create-then-poll loop into a single call.
+
+  run_analytics_report(start, end, metrics, [filters], timeout_seconds=30)
+    Compute scalar metrics over a time window. Pass exactly one filter
+    category (inbox_ids OR tag_ids OR teammate_ids OR team_ids OR
+    channel_ids OR account_ids) — Front rejects combined categories.
+    Returns the final report dict with `metrics` populated.
+
+  run_analytics_export(export_type, columns, timeout_seconds=120)
+    Bulk-export teammate-activity rows or message-level rows to a CSV.
+    Returns a download URL when ready. If Front responds `too_big`,
+    narrow the date range or column set and retry.
+
+Both tools poll until done, fail (status `failed` / `too_big`), or the
+`timeout_seconds` budget elapses (`status: "timeout"` in the result).
+The server-side job continues running on Front; library callers can
+resume via `client.analytics.get_report(uid)` / `get_export(id)`.
+
 ## Front Search Syntax (q parameter)
 
   status:open | status:archived | tag:urgent | assignee:me |

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/__init__.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/__init__.py
@@ -10,6 +10,7 @@ from fastmcp import FastMCP
 
 def register_all_tools(mcp: FastMCP) -> None:
     """Register every tool module with the FastMCP instance."""
+    from .analytics import register_tools as register_analytics_tools
     from .attachments import register_tools as register_attachments_tools
     from .contact_groups import register_tools as register_contact_groups_tools
     from .contact_lists import register_tools as register_contact_lists_tools
@@ -21,6 +22,7 @@ def register_all_tools(mcp: FastMCP) -> None:
     from .tags import register_tools as register_tags_tools
     from .teammates import register_tools as register_teammates_tools
 
+    register_analytics_tools(mcp)
     register_attachments_tools(mcp)
     register_contacts_tools(mcp)
     register_contact_lists_tools(mcp)

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/analytics.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/analytics.py
@@ -1,0 +1,278 @@
+"""MCP tools for Frontapp analytics — async create→poll wrapped as one call.
+
+Front's analytics endpoints are server-side asynchronous: POST creates a
+job and returns an id; GET polls until ``status == "done"``. The helper
+(``client.analytics.run_report`` / ``run_export``) does the polling
+loop. These MCP tools are the same surface, exposing only the parameters
+an LLM caller needs.
+
+No two-step confirm — these are read/query operations (the server-side
+job is just how Front computes a report or export, not a write to
+workspace state).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Annotated, Any, Literal
+
+from fastmcp import Context, FastMCP
+from pydantic import Field
+
+from frontapp_mcp.services import get_services
+from frontapp_public_api_client.helpers.analytics import attempts_for
+from frontapp_public_api_client.utils import APIError
+
+# Default polling cadence — fixed (matches the legacy TS prototype). The
+# tool exposes ``timeout_seconds``; we derive ``max_attempts`` from it.
+_REPORT_INTERVAL = 1.0
+_EXPORT_INTERVAL = 2.0
+
+
+def register_tools(mcp: FastMCP) -> None:
+    """Register analytics tools with the FastMCP server."""
+
+    @mcp.tool(
+        name="run_analytics_report",
+        description=(
+            "Create an analytics report for a metric set over a time range, "
+            "then poll Front until the report is ready (server-side async; "
+            "typically a few seconds). Returns the final report dict with "
+            "`uid`, `status`, `progress`, and `metrics`. "
+            "Filters are AND-combined across categories (e.g. `inbox_ids` "
+            "AND `tag_ids`); IDs within one category are OR-combined. Pass "
+            "exactly one filter category — the spec doesn't allow combining "
+            "filter types in a single report. If the timeout elapses, the "
+            "tool raises a TimeoutError; the report continues running on "
+            "Front and can be retrieved later via the underlying client."
+        ),
+    )
+    async def run_analytics_report(
+        context: Context,
+        start: Annotated[
+            str, Field(description="ISO 8601 datetime, e.g. '2026-04-01T00:00:00Z'")
+        ],
+        end: Annotated[
+            str, Field(description="ISO 8601 datetime, e.g. '2026-04-30T23:59:59Z'")
+        ],
+        metrics: Annotated[
+            list[str],
+            Field(
+                description=(
+                    "Metric ids — see Front's analytics docs for the full "
+                    "list (e.g. 'avg_handle_time', 'sla_breach_count')."
+                )
+            ),
+        ],
+        timezone: Annotated[
+            str | None,
+            Field(
+                description=(
+                    "IANA timezone name (e.g. 'America/Los_Angeles'). "
+                    "Defaults to UTC if omitted."
+                )
+            ),
+        ] = None,
+        inbox_ids: Annotated[
+            list[str] | None,
+            Field(description="Filter to these inboxes (e.g. 'inb_abc')."),
+        ] = None,
+        tag_ids: Annotated[
+            list[str] | None,
+            Field(description="Filter to these tags (e.g. 'tag_abc')."),
+        ] = None,
+        teammate_ids: Annotated[
+            list[str] | None,
+            Field(description="Filter to these teammates (e.g. 'tea_abc')."),
+        ] = None,
+        team_ids: Annotated[
+            list[str] | None,
+            Field(description="Filter to these teams (e.g. 'tim_abc')."),
+        ] = None,
+        channel_ids: Annotated[
+            list[str] | None,
+            Field(description="Filter to these channels (e.g. 'cha_abc')."),
+        ] = None,
+        account_ids: Annotated[
+            list[str] | None,
+            Field(description="Filter to these accounts (e.g. 'acc_abc')."),
+        ] = None,
+        timeout_seconds: Annotated[
+            int,
+            Field(
+                description=(
+                    "How long to poll before giving up. Defaults to 30s; "
+                    "raise to 60-90s for large date ranges."
+                )
+            ),
+        ] = 30,
+    ) -> dict[str, Any]:
+        from frontapp_public_api_client.models.analytics_metric_id import (
+            AnalyticsMetricId,
+        )
+
+        services = get_services(context)
+
+        try:
+            metric_ids = [AnalyticsMetricId(m) for m in metrics]
+        except ValueError as e:
+            return {
+                "error": f"Invalid metric id: {e}",
+                "valid_metrics": [m.value for m in AnalyticsMetricId],
+            }
+
+        filter_args = {
+            "inbox_ids": inbox_ids,
+            "tag_ids": tag_ids,
+            "teammate_ids": teammate_ids,
+            "team_ids": team_ids,
+            "channel_ids": channel_ids,
+            "account_ids": account_ids,
+        }
+        populated = [name for name, ids in filter_args.items() if ids]
+        if len(populated) > 1:
+            return {
+                "error": (
+                    "Pass exactly one filter category — Front's report spec "
+                    "doesn't allow combining filter types. Got: "
+                    f"{', '.join(populated)}"
+                )
+            }
+        filters = _build_report_filters(filter_args)
+
+        try:
+            report = await services.client.analytics.run_report(
+                start=datetime.fromisoformat(start.replace("Z", "+00:00")),
+                end=datetime.fromisoformat(end.replace("Z", "+00:00")),
+                metrics=metric_ids,
+                timezone=timezone,
+                filters=filters,
+                max_attempts=attempts_for(timeout_seconds, _REPORT_INTERVAL),
+                interval=_REPORT_INTERVAL,
+            )
+        except TimeoutError as e:
+            return {"error": str(e), "status": "timeout"}
+        except APIError as e:
+            return {"error": str(e), "status": "failed"}
+
+        return report.to_dict()
+
+    @mcp.tool(
+        name="run_analytics_export",
+        description=(
+            "Create an analytics export of teammate-activity or message-level "
+            "rows, then poll Front until ready (server-side async; can take "
+            "1-2 minutes for large date ranges). Returns the final export "
+            "dict with `id`, `status`, `url` (download link), `filename`, "
+            "and `size`. If Front responds `too_big`, narrow the date range "
+            "or column set and retry."
+        ),
+    )
+    async def run_analytics_export(
+        context: Context,
+        export_type: Annotated[
+            Literal["activities", "messages"],
+            Field(
+                description=(
+                    "Which export shape to produce. 'activities' = teammate "
+                    "activity rows; 'messages' = message-level rows."
+                )
+            ),
+        ],
+        columns: Annotated[
+            list[str],
+            Field(
+                description=(
+                    "Columns to include. The valid set depends on "
+                    "`export_type` — see Front's analytics docs."
+                )
+            ),
+        ],
+        timeout_seconds: Annotated[
+            int,
+            Field(
+                description=(
+                    "How long to poll before giving up. Defaults to 120s; "
+                    "exports of large date ranges may need more."
+                )
+            ),
+        ] = 120,
+    ) -> dict[str, Any]:
+        from frontapp_public_api_client.models.analytics_activities_columns import (
+            AnalyticsActivitiesColumns,
+        )
+        from frontapp_public_api_client.models.analytics_activities_exports_columns import (
+            AnalyticsActivitiesExportsColumns,
+        )
+        from frontapp_public_api_client.models.analytics_messages_columns import (
+            AnalyticsMessagesColumns,
+        )
+        from frontapp_public_api_client.models.analytics_messages_export_columns import (
+            AnalyticsMessagesExportColumns,
+        )
+
+        services = get_services(context)
+
+        body: AnalyticsActivitiesExportsColumns | AnalyticsMessagesExportColumns
+        try:
+            if export_type == "activities":
+                activity_cols: list[AnalyticsActivitiesColumns | str] = [
+                    AnalyticsActivitiesColumns(c) for c in columns
+                ]
+                body = AnalyticsActivitiesExportsColumns(columns=activity_cols)
+            else:
+                msg_cols = [AnalyticsMessagesColumns(c) for c in columns]
+                body = AnalyticsMessagesExportColumns(columns=msg_cols)
+        except ValueError as e:
+            valid = (
+                [c.value for c in AnalyticsActivitiesColumns]
+                if export_type == "activities"
+                else [c.value for c in AnalyticsMessagesColumns]
+            )
+            return {"error": f"Invalid column for {export_type}: {e}", "valid": valid}
+
+        try:
+            export = await services.client.analytics.run_export(
+                body,
+                max_attempts=attempts_for(timeout_seconds, _EXPORT_INTERVAL),
+                interval=_EXPORT_INTERVAL,
+            )
+        except TimeoutError as e:
+            return {"error": str(e), "status": "timeout"}
+        except APIError as e:
+            return {"error": str(e), "status": "failed"}
+
+        return export.to_dict()
+
+
+def _build_report_filters(
+    filter_args: dict[str, list[str] | None],
+) -> Any:
+    """Construct the single filter object the caller specified, or None.
+
+    Caller is responsible for verifying ``len(populated) <= 1`` first
+    (Front's report spec is ``oneOf`` — combining categories is rejected
+    server-side). Returns the typed ``AccountIds`` / ``ChannelIds`` /
+    etc. filter object, or ``None`` when the caller passed no filters.
+    The return type is ``Any`` because the caller branches on the choice
+    of filter — none of the six filter classes share a common base.
+    """
+    from frontapp_public_api_client.models.account_ids import AccountIds
+    from frontapp_public_api_client.models.channel_ids import ChannelIds
+    from frontapp_public_api_client.models.inbox_ids import InboxIds
+    from frontapp_public_api_client.models.tag_ids import TagIds
+    from frontapp_public_api_client.models.team_ids import TeamIds
+    from frontapp_public_api_client.models.teammate_ids import TeammateIds
+
+    classes = {
+        "inbox_ids": InboxIds,
+        "tag_ids": TagIds,
+        "teammate_ids": TeammateIds,
+        "team_ids": TeamIds,
+        "channel_ids": ChannelIds,
+        "account_ids": AccountIds,
+    }
+    for name, ids in filter_args.items():
+        if ids:
+            return classes[name](**{name: ids})
+    return None

--- a/frontapp_mcp_server/tests/test_analytics_tools.py
+++ b/frontapp_mcp_server/tests/test_analytics_tools.py
@@ -1,0 +1,255 @@
+"""Tests for MCP analytics tools — argument shaping + helper delegation.
+
+The polling-loop semantics live in the helper (`tests/test_analytics.py`).
+These tests pin the tool layer:
+
+- ISO 8601 date strings parse and reach the helper as ``datetime``
+- ``timeout_seconds`` translates into ``max_attempts`` correctly
+- Filter category selection (single category required by spec)
+- Invalid metric / column ids return a validation error before calling
+  the client
+- ``run_analytics_export`` dispatches on ``export_type`` to the right
+  generated body shape
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+from frontapp_mcp.tools.analytics import register_tools
+
+from .conftest import create_mock_context
+
+
+@pytest.fixture
+def analytics_tools(mcp_tool_capture) -> dict[str, object]:
+    return mcp_tool_capture(register_tools)
+
+
+def _attrs_with_to_dict(payload: dict):
+    """Mock object with a ``to_dict()`` returning ``payload`` (matches the
+    attrs-style return type from ``client.analytics.run_*``)."""
+    obj = AsyncMock()
+    obj.to_dict = lambda: payload
+    return obj
+
+
+# ---------------------------------------------------------------------------
+# run_analytics_report
+# ---------------------------------------------------------------------------
+
+
+class TestRunAnalyticsReport:
+    async def test_parses_iso_dates_and_passes_metrics(self, analytics_tools):
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock()
+        lifespan.client.analytics.run_report = AsyncMock(
+            return_value=_attrs_with_to_dict(
+                {"uid": "rpt_1", "status": "done", "progress": 100, "metrics": []}
+            )
+        )
+
+        result = await analytics_tools["run_analytics_report"](
+            context,
+            start="2026-04-01T00:00:00Z",
+            end="2026-04-30T23:59:59Z",
+            metrics=["avg_first_response_time"],
+        )
+
+        assert result["status"] == "done"
+        # Helper called with parsed datetimes (ISO 'Z' → UTC).
+        call = lifespan.client.analytics.run_report.await_args
+        assert call is not None
+        assert call.kwargs["start"] == datetime(2026, 4, 1, 0, 0, 0, tzinfo=UTC)
+        assert call.kwargs["end"] == datetime(2026, 4, 30, 23, 59, 59, tzinfo=UTC)
+
+    async def test_invalid_metric_returns_error_without_calling_client(
+        self, analytics_tools
+    ):
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock(
+            side_effect=AssertionError("client invoked despite invalid metric")
+        )
+
+        result = await analytics_tools["run_analytics_report"](
+            context,
+            start="2026-04-01T00:00:00Z",
+            end="2026-04-30T23:59:59Z",
+            metrics=["definitely_not_a_metric"],
+        )
+
+        assert "error" in result
+        assert "valid_metrics" in result
+
+    async def test_multiple_filter_categories_rejected(self, analytics_tools):
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock(
+            side_effect=AssertionError("client invoked despite filter conflict")
+        )
+
+        result = await analytics_tools["run_analytics_report"](
+            context,
+            start="2026-04-01T00:00:00Z",
+            end="2026-04-30T23:59:59Z",
+            metrics=["avg_first_response_time"],
+            inbox_ids=["inb_1"],
+            tag_ids=["tag_1"],
+        )
+
+        assert "error" in result
+        assert "exactly one filter category" in result["error"]
+
+    async def test_single_filter_category_threaded_through(self, analytics_tools):
+        from frontapp_public_api_client.models.inbox_ids import InboxIds
+
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock()
+        lifespan.client.analytics.run_report = AsyncMock(
+            return_value=_attrs_with_to_dict(
+                {"uid": "rpt_1", "status": "done", "progress": 100, "metrics": []}
+            )
+        )
+
+        await analytics_tools["run_analytics_report"](
+            context,
+            start="2026-04-01T00:00:00Z",
+            end="2026-04-30T23:59:59Z",
+            metrics=["avg_first_response_time"],
+            inbox_ids=["inb_1", "inb_2"],
+        )
+        call = lifespan.client.analytics.run_report.await_args
+        assert call is not None
+        passed = call.kwargs["filters"]
+        assert isinstance(passed, InboxIds)
+        assert passed.inbox_ids == ["inb_1", "inb_2"]
+
+    async def test_timeout_seconds_translates_to_max_attempts(self, analytics_tools):
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock()
+        lifespan.client.analytics.run_report = AsyncMock(
+            return_value=_attrs_with_to_dict(
+                {"uid": "rpt_1", "status": "done", "progress": 100, "metrics": []}
+            )
+        )
+
+        await analytics_tools["run_analytics_report"](
+            context,
+            start="2026-04-01T00:00:00Z",
+            end="2026-04-30T23:59:59Z",
+            metrics=["avg_first_response_time"],
+            timeout_seconds=45,
+        )
+        call = lifespan.client.analytics.run_report.await_args
+        assert call is not None
+        # Report interval is 1.0s → 45 attempts.
+        assert call.kwargs["max_attempts"] == 45
+        assert call.kwargs["interval"] == 1.0
+
+    async def test_helper_timeout_surfaces_as_error_dict(self, analytics_tools):
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock()
+        lifespan.client.analytics.run_report = AsyncMock(
+            side_effect=TimeoutError("Analytics report rpt_x did not complete")
+        )
+
+        result = await analytics_tools["run_analytics_report"](
+            context,
+            start="2026-04-01T00:00:00Z",
+            end="2026-04-30T23:59:59Z",
+            metrics=["avg_first_response_time"],
+        )
+        assert result["status"] == "timeout"
+        assert "rpt_x" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# run_analytics_export
+# ---------------------------------------------------------------------------
+
+
+class TestRunAnalyticsExport:
+    async def test_activities_dispatch_passes_activity_columns_body(
+        self, analytics_tools
+    ):
+        from frontapp_public_api_client.models.analytics_activities_exports_columns import (
+            AnalyticsActivitiesExportsColumns,
+        )
+
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock()
+        lifespan.client.analytics.run_export = AsyncMock(
+            return_value=_attrs_with_to_dict(
+                {"id": "exp_1", "status": "done", "url": "https://x/exp_1.csv"}
+            )
+        )
+
+        result = await analytics_tools["run_analytics_export"](
+            context,
+            export_type="activities",
+            columns=["Activity ID", "Author"],
+        )
+        assert result["status"] == "done"
+        call = lifespan.client.analytics.run_export.await_args
+        assert call is not None
+        assert isinstance(call.args[0], AnalyticsActivitiesExportsColumns)
+
+    async def test_messages_dispatch_passes_messages_columns_body(
+        self, analytics_tools
+    ):
+        from frontapp_public_api_client.models.analytics_messages_export_columns import (
+            AnalyticsMessagesExportColumns,
+        )
+
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock()
+        lifespan.client.analytics.run_export = AsyncMock(
+            return_value=_attrs_with_to_dict(
+                {"id": "exp_1", "status": "done", "url": "https://x/exp_1.csv"}
+            )
+        )
+
+        await analytics_tools["run_analytics_export"](
+            context,
+            export_type="messages",
+            columns=["Author"],
+        )
+        call = lifespan.client.analytics.run_export.await_args
+        assert call is not None
+        assert isinstance(call.args[0], AnalyticsMessagesExportColumns)
+
+    async def test_invalid_column_returns_error(self, analytics_tools):
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock(
+            side_effect=AssertionError("client invoked despite invalid column")
+        )
+
+        result = await analytics_tools["run_analytics_export"](
+            context,
+            export_type="messages",
+            columns=["this_is_not_a_column"],
+        )
+        assert "error" in result
+        assert "valid" in result
+
+    async def test_export_timeout_seconds_uses_2s_interval(self, analytics_tools):
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock()
+        lifespan.client.analytics.run_export = AsyncMock(
+            return_value=_attrs_with_to_dict(
+                {"id": "exp_1", "status": "done", "url": "https://x"}
+            )
+        )
+
+        await analytics_tools["run_analytics_export"](
+            context,
+            export_type="messages",
+            columns=["Author"],
+            timeout_seconds=120,
+        )
+        call = lifespan.client.analytics.run_export.await_args
+        assert call is not None
+        # Export interval is 2.0s → 60 attempts for a 120s budget.
+        assert call.kwargs["max_attempts"] == 60
+        assert call.kwargs["interval"] == 2.0

--- a/frontapp_public_api_client/docs/guide.md
+++ b/frontapp_public_api_client/docs/guide.md
@@ -72,6 +72,7 @@ async with FrontappClient() as client:
 | `client.inboxes`        | ✅ shipped | list (+ team/teammate scopes)/get/list_conversations/list_channels/list_access/create (+ team)/grant_access/revoke_access                                            |
 | `client.teammates`      | ✅ shipped | list/get/list_inboxes/list_assigned_conversations/update                                                                                                             |
 | `client.attachments`    | ✅ shipped | download/stream + `attachments=[FileSpec(...)]` parameter on every draft / reply / comment helper                                                                    |
+| `client.analytics`      | ✅ shipped | create*report/get_report/run_report + create_export/get_export/run_export. The `run*\*` methods wrap the create-then-poll loop into a single call.                   |
 
 Outbound replies go through `client.drafts.create_reply(...)` rather than
 `client.conversations.reply(...)` — the latter still exists at the helper level for
@@ -271,6 +272,35 @@ async with FrontappClient() as client:
     )
     assert response.status_code in (200, 204)
 ```
+
+### Run an analytics report (async create→poll)
+
+Front's analytics endpoints are server-side asynchronous: a POST creates a job and
+returns an id; a follow-up GET polls until `status == "done"`. The helper wraps the loop
+into a single call.
+
+```python
+from datetime import datetime, timezone
+from frontapp_public_api_client.models.analytics_metric_id import AnalyticsMetricId
+from frontapp_public_api_client.models.inbox_ids import InboxIds
+
+async with FrontappClient() as client:
+    report = await client.analytics.run_report(
+        start=datetime(2026, 4, 1, tzinfo=timezone.utc),
+        end=datetime(2026, 4, 30, tzinfo=timezone.utc),
+        metrics=[AnalyticsMetricId.AVG_FIRST_RESPONSE_TIME],
+        filters=InboxIds(inbox_ids=["inb_abc"]),
+        max_attempts=20,
+        interval=1.0,
+    )
+    print(report.status, report.metrics)
+```
+
+`run_report` raises `TimeoutError` after `max_attempts * interval` seconds (the report
+keeps running on Front; resume with `client.analytics.get_report(uid)`). It raises
+`APIError` if Front returns `status: "failed"`. The same shape applies to
+`run_export(body, ...)` for `/analytics/exports`, plus a `too_big` terminal status that
+maps to `APIError` with a date-range narrowing hint.
 
 ### Raw generated API for uncovered resources
 

--- a/frontapp_public_api_client/frontapp_client.py
+++ b/frontapp_public_api_client/frontapp_client.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import parse_qs, quote, urlparse, urlunparse
 
 if TYPE_CHECKING:
+    from .helpers.analytics import Analytics
     from .helpers.attachments import Attachments
     from .helpers.contact_groups import ContactGroups
     from .helpers.contact_lists import ContactLists
@@ -553,6 +554,7 @@ class FrontappClient(AuthenticatedClient):
             )
 
         # Domain helper instances (lazy-loaded via properties)
+        self._analytics: Analytics | None = None
         self._attachments: Attachments | None = None
         self._conversations: Conversations | None = None
         self._contacts: Contacts | None = None
@@ -639,6 +641,22 @@ class FrontappClient(AuthenticatedClient):
         return self
 
     # Domain properties for ergonomic access
+    @property
+    def analytics(self) -> "Analytics":
+        """Ergonomic operations over Frontapp's async ``/analytics/*`` endpoints.
+
+        Wraps the create-then-poll pattern so callers can issue a single
+        ``client.analytics.run_report(...)`` (or ``run_export``) instead of
+        manually polling. See ``helpers.analytics`` for the helper surface
+        (``create_report`` / ``get_report`` / ``run_report``, plus the
+        export equivalents).
+        """
+        from .helpers.analytics import Analytics
+
+        if self._analytics is None:
+            self._analytics = Analytics(self)
+        return self._analytics
+
     @property
     def attachments(self) -> "Attachments":
         """Ergonomic operations over Frontapp attachments — upload + download.

--- a/frontapp_public_api_client/helpers/__init__.py
+++ b/frontapp_public_api_client/helpers/__init__.py
@@ -5,6 +5,7 @@ boilerplate for common workflows. Each helper is accessed as an attribute on
 ``FrontappClient`` (e.g. ``client.conversations.list(...)``).
 """
 
+from frontapp_public_api_client.helpers.analytics import Analytics
 from frontapp_public_api_client.helpers.attachments import (
     MAX_ATTACHMENT_BYTES,
     Attachments,
@@ -23,6 +24,7 @@ from frontapp_public_api_client.helpers.teammates import Teammates
 
 __all__ = [
     "MAX_ATTACHMENT_BYTES",
+    "Analytics",
     "Attachments",
     "Base",
     "ContactGroups",

--- a/frontapp_public_api_client/helpers/analytics.py
+++ b/frontapp_public_api_client/helpers/analytics.py
@@ -1,0 +1,329 @@
+"""Analytics helper facade — wraps the create→poll pattern for Front's async
+``/analytics/reports`` and ``/analytics/exports`` endpoints.
+
+Front's analytics endpoints are asynchronous on the server side: the POST
+returns immediately with an id and ``status: "running"``, and a follow-up
+GET polls until ``status == "done"`` (or ``"failed"``, or ``"too_big"``
+for exports). The legacy TypeScript MCP at ``dougborg/Frontapp-MCP``
+implemented a 10-attempt / 1-second-interval polling loop; this helper
+ports the same pattern into Python with configurable bounds and proper
+error mapping.
+
+Public surface:
+
+- ``client.analytics.create_report(...)`` — POST + return ``report_uid``
+- ``client.analytics.get_report(uid)`` — single GET (may return placeholder)
+- ``client.analytics.run_report(...)`` — one-shot create → poll → return
+- ``client.analytics.create_export(body)`` / ``get_export(id)`` / ``run_export(body)``
+
+The `run_*` methods raise ``TimeoutError`` after ``max_attempts * interval``
+seconds and ``APIError`` on a terminal ``failed`` (or ``too_big`` for
+exports) status. They honor a ``Retry-After`` response header on the
+GET poll if Front sends one (overrides ``interval`` for that single
+sleep).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from math import ceil
+from typing import TYPE_CHECKING, Any
+
+from frontapp_public_api_client.helpers.base import Base
+from frontapp_public_api_client.utils import APIError, unwrap_as
+
+if TYPE_CHECKING:
+    from frontapp_public_api_client.models.account_ids import AccountIds
+    from frontapp_public_api_client.models.analytics_activities_exports_columns import (
+        AnalyticsActivitiesExportsColumns,
+    )
+    from frontapp_public_api_client.models.analytics_export_response import (
+        AnalyticsExportResponse,
+    )
+    from frontapp_public_api_client.models.analytics_messages_export_columns import (
+        AnalyticsMessagesExportColumns,
+    )
+    from frontapp_public_api_client.models.analytics_metric_id import AnalyticsMetricId
+    from frontapp_public_api_client.models.analytics_report_response import (
+        AnalyticsReportResponse,
+    )
+    from frontapp_public_api_client.models.channel_ids import ChannelIds
+    from frontapp_public_api_client.models.inbox_ids import InboxIds
+    from frontapp_public_api_client.models.tag_ids import TagIds
+    from frontapp_public_api_client.models.team_ids import TeamIds
+    from frontapp_public_api_client.models.teammate_ids import TeammateIds
+
+# Filter types Front's report endpoint accepts (oneOf in the spec). Combined
+# at the field type to satisfy the generated request model's union.
+ReportFilters = "AccountIds | ChannelIds | InboxIds | TagIds | TeamIds | TeammateIds"
+ExportBody = "AnalyticsActivitiesExportsColumns | AnalyticsMessagesExportColumns"
+
+
+class Analytics(Base):
+    """Ergonomic operations over Frontapp's ``/analytics/*`` async endpoints."""
+
+    # -- reports ------------------------------------------------------------
+
+    async def create_report(
+        self,
+        *,
+        start: datetime,
+        end: datetime,
+        metrics: list[AnalyticsMetricId],
+        timezone: str | None = None,
+        filters: AccountIds
+        | ChannelIds
+        | InboxIds
+        | TagIds
+        | TeamIds
+        | TeammateIds
+        | None = None,
+    ) -> str:
+        """POST ``/analytics/reports``; returns the new report's ``uid``.
+
+        The report runs asynchronously on Front's side. Use ``get_report(uid)``
+        to poll the result, or ``run_report(...)`` to do the whole loop in
+        one call.
+        """
+        from frontapp_public_api_client.api.analytics import create_analytics_report
+        from frontapp_public_api_client.domain.converters import to_unset
+        from frontapp_public_api_client.models.analytics_report_request import (
+            AnalyticsReportRequest,
+        )
+
+        body = AnalyticsReportRequest(
+            start=start.timestamp(),
+            end=end.timestamp(),
+            metrics=metrics,
+            timezone=to_unset(timezone),
+            filters=to_unset(filters),
+        )
+        response = await create_analytics_report.asyncio_detailed(
+            client=self._client, body=body
+        )
+        from frontapp_public_api_client.models.analytics_report_response import (
+            AnalyticsReportResponse,
+        )
+
+        parsed = unwrap_as(response, AnalyticsReportResponse)
+        return parsed.uid
+
+    async def get_report(self, report_uid: str) -> AnalyticsReportResponse:
+        """GET ``/analytics/reports/{uid}``; returns the current report state.
+
+        While the report is still processing, the response will have
+        ``status == "running"`` (or ``"failed"`` if the report errored).
+        Use ``run_report`` to poll until ``"done"``.
+        """
+        from frontapp_public_api_client.api.analytics import get_analytics_report
+        from frontapp_public_api_client.models.analytics_report_response import (
+            AnalyticsReportResponse,
+        )
+
+        response = await get_analytics_report.asyncio_detailed(
+            client=self._client, report_uid=report_uid
+        )
+        return unwrap_as(response, AnalyticsReportResponse)
+
+    async def run_report(
+        self,
+        *,
+        start: datetime,
+        end: datetime,
+        metrics: list[AnalyticsMetricId],
+        timezone: str | None = None,
+        filters: AccountIds
+        | ChannelIds
+        | InboxIds
+        | TagIds
+        | TeamIds
+        | TeammateIds
+        | None = None,
+        max_attempts: int = 20,
+        interval: float = 1.0,
+    ) -> AnalyticsReportResponse:
+        """Create the report, poll until done, return the final result.
+
+        ``start`` / ``end`` / ``metrics`` / ``timezone`` / ``filters``
+        match ``create_report``.
+
+        Args:
+            max_attempts: Maximum number of GET polls before giving up.
+                Defaults to 20 (with the default 1.0s interval that's a
+                20s budget — long enough for typical reports, short
+                enough to fail an MCP call gracefully).
+            interval: Seconds to sleep between polls. Honors a
+                ``Retry-After`` response header if Front sends one (it
+                overrides ``interval`` for that single sleep).
+
+        Raises:
+            TimeoutError: All ``max_attempts`` polls returned non-terminal
+                status; the report id is in the message for resumption.
+            APIError: Front returned ``status: "failed"``.
+        """
+        from frontapp_public_api_client.api.analytics import get_analytics_report
+        from frontapp_public_api_client.models.analytics_report_response import (
+            AnalyticsReportResponse,
+        )
+        from frontapp_public_api_client.models.analytics_report_response_status import (
+            AnalyticsReportResponseStatus,
+        )
+
+        report_uid = await self.create_report(
+            start=start,
+            end=end,
+            metrics=metrics,
+            timezone=timezone,
+            filters=filters,
+        )
+
+        for _attempt in range(max_attempts):
+            response = await get_analytics_report.asyncio_detailed(
+                client=self._client, report_uid=report_uid
+            )
+            parsed = unwrap_as(response, AnalyticsReportResponse)
+
+            if parsed.status == AnalyticsReportResponseStatus.DONE:
+                return parsed
+            if parsed.status == AnalyticsReportResponseStatus.FAILED:
+                raise APIError(
+                    f"Analytics report {report_uid} failed",
+                    response.status_code,
+                    parsed,
+                )
+
+            sleep_for = _retry_after_or(response.headers, interval)
+            await asyncio.sleep(sleep_for)
+
+        raise TimeoutError(
+            f"Analytics report {report_uid} did not complete within "
+            f"{max_attempts} polls (~{max_attempts * interval:.0f}s); "
+            f"call client.analytics.get_report({report_uid!r}) to resume."
+        )
+
+    # -- exports ------------------------------------------------------------
+
+    async def create_export(
+        self,
+        body: AnalyticsActivitiesExportsColumns | AnalyticsMessagesExportColumns,
+    ) -> str:
+        """POST ``/analytics/exports``; returns the export's ``id``.
+
+        ``body`` is one of two typed columnar specs depending on what
+        you want to export:
+
+        - ``AnalyticsActivitiesExportsColumns`` — teammate activity rows
+        - ``AnalyticsMessagesExportColumns`` — message-level rows
+
+        Construct the spec directly from the generated models; the helper
+        passes it through unchanged.
+        """
+        from frontapp_public_api_client.api.analytics import create_analytics_export
+        from frontapp_public_api_client.models.analytics_export_response import (
+            AnalyticsExportResponse,
+        )
+
+        response = await create_analytics_export.asyncio_detailed(
+            client=self._client, body=body
+        )
+        parsed = unwrap_as(response, AnalyticsExportResponse)
+        return parsed.id
+
+    async def get_export(self, export_id: str) -> AnalyticsExportResponse:
+        """GET ``/analytics/exports/{id}``; returns the current export state."""
+        from frontapp_public_api_client.api.analytics import get_analytics_export
+        from frontapp_public_api_client.models.analytics_export_response import (
+            AnalyticsExportResponse,
+        )
+
+        response = await get_analytics_export.asyncio_detailed(
+            client=self._client, export_id=export_id
+        )
+        return unwrap_as(response, AnalyticsExportResponse)
+
+    async def run_export(
+        self,
+        body: AnalyticsActivitiesExportsColumns | AnalyticsMessagesExportColumns,
+        *,
+        max_attempts: int = 60,
+        interval: float = 2.0,
+    ) -> AnalyticsExportResponse:
+        """Create the export, poll until done, return the final result.
+
+        Defaults are tuned higher than ``run_report`` because exports
+        process bulk data (60 polls at 2.0s each = 120s budget).
+
+        Raises:
+            TimeoutError: Polls exhausted before a terminal status.
+            APIError: Front returned ``status: "failed"`` or ``status:
+                "too_big"`` (the latter means the date range was too
+                large; the caller should narrow it and retry).
+        """
+        from frontapp_public_api_client.api.analytics import get_analytics_export
+        from frontapp_public_api_client.models.analytics_export_response import (
+            AnalyticsExportResponse,
+        )
+        from frontapp_public_api_client.models.analytics_export_response_status import (
+            AnalyticsExportResponseStatus,
+        )
+
+        export_id = await self.create_export(body)
+
+        for _attempt in range(max_attempts):
+            response = await get_analytics_export.asyncio_detailed(
+                client=self._client, export_id=export_id
+            )
+            parsed = unwrap_as(response, AnalyticsExportResponse)
+
+            if parsed.status == AnalyticsExportResponseStatus.DONE:
+                return parsed
+            if parsed.status == AnalyticsExportResponseStatus.FAILED:
+                raise APIError(
+                    f"Analytics export {export_id} failed",
+                    response.status_code,
+                    parsed,
+                )
+            if parsed.status == AnalyticsExportResponseStatus.TOO_BIG:
+                raise APIError(
+                    f"Analytics export {export_id} is too large to produce; "
+                    "narrow the date range or column set and retry.",
+                    response.status_code,
+                    parsed,
+                )
+
+            sleep_for = _retry_after_or(response.headers, interval)
+            await asyncio.sleep(sleep_for)
+
+        raise TimeoutError(
+            f"Analytics export {export_id} did not complete within "
+            f"{max_attempts} polls (~{max_attempts * interval:.0f}s); "
+            f"call client.analytics.get_export({export_id!r}) to resume."
+        )
+
+
+def _retry_after_or(headers: Any, default: float) -> float:
+    """Parse ``Retry-After`` (seconds) if present and positive, else default.
+
+    Front follows RFC 7231 — the header value is delta-seconds. We don't
+    handle the HTTP-date form; if Front ever sends one it'll fail to
+    parse and we fall back to the default interval.
+    """
+    raw = headers.get("Retry-After") if hasattr(headers, "get") else None
+    if not raw:
+        return default
+    try:
+        seconds = float(raw)
+    except (TypeError, ValueError):
+        return default
+    return seconds if seconds > 0 else default
+
+
+def attempts_for(timeout_seconds: float, interval: float) -> int:
+    """How many polls fit in ``timeout_seconds`` at the given ``interval``.
+
+    Public so the MCP layer can convert its ``timeout_seconds`` parameter
+    into the helper's ``max_attempts`` argument without each tool having
+    to re-derive the formula.
+    """
+    return max(1, ceil(timeout_seconds / interval))

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,0 +1,369 @@
+"""Tests for the analytics vertical: Analytics helper (create→poll loop).
+
+Front's analytics endpoints are server-side async — POST returns
+immediately with ``status: "running"``; a follow-up GET polls until
+``status == "done"`` (or ``"failed"`` / ``"too_big"`` for exports).
+The helper's ``run_report`` and ``run_export`` collapse that into a
+single call. These tests pin the polling-loop semantics:
+
+- happy path (1+ running poll, then done)
+- immediate done (no extra GETs)
+- terminal failure status
+- timeout exhaustion
+- ``Retry-After`` header overrides the interval
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from frontapp_public_api_client.helpers.analytics import (
+    Analytics,
+    _retry_after_or,
+    attempts_for,
+)
+from frontapp_public_api_client.models.analytics_metric_id import AnalyticsMetricId
+from frontapp_public_api_client.models.analytics_report_response_status import (
+    AnalyticsReportResponseStatus,
+)
+from frontapp_public_api_client.utils import APIError
+
+
+def _report_payload(*, uid: str, status: str, progress: int = 0) -> dict:
+    """Minimal valid AnalyticsReportResponse-shaped dict."""
+    return {
+        "uid": uid,
+        "status": status,
+        "progress": progress,
+        "metrics": [],
+        "_links": {"self": "https://x"},
+    }
+
+
+def _export_payload(
+    *, id_: str, status: str, progress: int = 0, url: str | None = None
+) -> dict:
+    """Minimal valid AnalyticsExportResponse-shaped dict.
+
+    ``filters`` is required by the spec; we echo back an empty inbox-ids
+    filter since exports always carry one of the typed filter shapes.
+    """
+    payload: dict = {
+        "id": id_,
+        "status": status,
+        "progress": progress,
+        "filters": {"inbox_ids": []},
+        "_links": {"self": "https://x"},
+    }
+    if url is not None:
+        payload["url"] = url
+    return payload
+
+
+def _seq_handler(responses: list[tuple[int, dict]]) -> httpx.MockTransport:
+    """Build a MockTransport that returns ``responses[i]`` on the i-th call."""
+    call_count = {"i": 0}
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        i = call_count["i"]
+        call_count["i"] = min(i + 1, len(responses) - 1)
+        status, body = responses[i]
+        return httpx.Response(status, json=body)
+
+    return httpx.MockTransport(handler)
+
+
+# ---------------------------------------------------------------------------
+# attempts_for + _retry_after_or
+# ---------------------------------------------------------------------------
+
+
+class TestAttemptsFor:
+    def test_basic_division(self):
+        assert attempts_for(30, 1.0) == 30
+        assert attempts_for(120, 2.0) == 60
+
+    def test_rounds_up(self):
+        # 31 / 2.0 → 15.5 → 16 attempts
+        assert attempts_for(31, 2.0) == 16
+
+    def test_at_least_one_attempt(self):
+        assert attempts_for(0, 1.0) == 1
+        assert attempts_for(0.5, 5.0) == 1
+
+
+class TestRetryAfterOr:
+    def test_returns_default_when_header_absent(self):
+        assert _retry_after_or(httpx.Headers({}), 1.5) == 1.5
+
+    def test_parses_seconds(self):
+        assert _retry_after_or(httpx.Headers({"Retry-After": "5"}), 1.0) == 5.0
+
+    def test_returns_default_for_invalid(self):
+        assert _retry_after_or(httpx.Headers({"Retry-After": "Wed, ..."}), 1.0) == 1.0
+
+    def test_returns_default_for_zero_or_negative(self):
+        assert _retry_after_or(httpx.Headers({"Retry-After": "0"}), 1.0) == 1.0
+        assert _retry_after_or(httpx.Headers({"Retry-After": "-3"}), 1.0) == 1.0
+
+
+# ---------------------------------------------------------------------------
+# run_report — polling loop
+# ---------------------------------------------------------------------------
+
+
+class TestRunReport:
+    @pytest.fixture
+    def no_sleep(self, monkeypatch):
+        """Replace asyncio.sleep with a no-op so the polling loop runs at full speed."""
+        sleeps: list[float] = []
+
+        async def fake_sleep(seconds: float) -> None:
+            sleeps.append(seconds)
+
+        monkeypatch.setattr(
+            "frontapp_public_api_client.helpers.analytics.asyncio.sleep",
+            fake_sleep,
+        )
+        return sleeps
+
+    async def test_happy_path_walks_running_to_done(self, attach_transport, no_sleep):
+        # POST → 201 with running; GET#1 → running; GET#2 → done
+        transport = _seq_handler(
+            [
+                (201, _report_payload(uid="rpt_1", status="running")),
+                (200, _report_payload(uid="rpt_1", status="running", progress=50)),
+                (200, _report_payload(uid="rpt_1", status="done", progress=100)),
+            ]
+        )
+        client = attach_transport(transport)
+
+        result = await client.analytics.run_report(
+            start=datetime(2026, 1, 1, tzinfo=UTC),
+            end=datetime(2026, 1, 31, tzinfo=UTC),
+            metrics=[AnalyticsMetricId.AVG_FIRST_RESPONSE_TIME],
+        )
+
+        assert result.status == AnalyticsReportResponseStatus.DONE
+        assert result.progress == 100
+
+    async def test_immediate_done_does_not_sleep(self, attach_transport, no_sleep):
+        transport = _seq_handler(
+            [
+                (201, _report_payload(uid="rpt_1", status="running")),
+                (200, _report_payload(uid="rpt_1", status="done", progress=100)),
+            ]
+        )
+        client = attach_transport(transport)
+
+        await client.analytics.run_report(
+            start=datetime(2026, 1, 1, tzinfo=UTC),
+            end=datetime(2026, 1, 31, tzinfo=UTC),
+            metrics=[AnalyticsMetricId.AVG_FIRST_RESPONSE_TIME],
+        )
+        # Done on the first GET → no sleep should have been recorded.
+        assert no_sleep == []
+
+    async def test_failed_status_raises_api_error(self, attach_transport, no_sleep):
+        transport = _seq_handler(
+            [
+                (201, _report_payload(uid="rpt_1", status="running")),
+                (200, _report_payload(uid="rpt_1", status="failed")),
+            ]
+        )
+        client = attach_transport(transport)
+
+        with pytest.raises(APIError, match="failed"):
+            await client.analytics.run_report(
+                start=datetime(2026, 1, 1, tzinfo=UTC),
+                end=datetime(2026, 1, 31, tzinfo=UTC),
+                metrics=[AnalyticsMetricId.AVG_FIRST_RESPONSE_TIME],
+            )
+
+    async def test_timeout_when_max_attempts_exhausted(
+        self, attach_transport, no_sleep
+    ):
+        transport = _seq_handler(
+            [
+                (201, _report_payload(uid="rpt_1", status="running")),
+                (200, _report_payload(uid="rpt_1", status="running")),
+            ]
+        )
+        client = attach_transport(transport)
+
+        with pytest.raises(TimeoutError, match="rpt_1"):
+            await client.analytics.run_report(
+                start=datetime(2026, 1, 1, tzinfo=UTC),
+                end=datetime(2026, 1, 31, tzinfo=UTC),
+                metrics=[AnalyticsMetricId.AVG_FIRST_RESPONSE_TIME],
+                max_attempts=2,
+                interval=0.01,
+            )
+
+    async def test_retry_after_header_overrides_interval(
+        self, attach_transport, no_sleep
+    ):
+        recorded: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            recorded.append(request)
+            if len(recorded) == 1:
+                # POST create
+                return httpx.Response(
+                    201, json=_report_payload(uid="rpt_1", status="running")
+                )
+            if len(recorded) == 2:
+                # First GET → running with Retry-After
+                return httpx.Response(
+                    200,
+                    json=_report_payload(uid="rpt_1", status="running"),
+                    headers={"Retry-After": "5"},
+                )
+            return httpx.Response(
+                200, json=_report_payload(uid="rpt_1", status="done", progress=100)
+            )
+
+        client = attach_transport(httpx.MockTransport(handler))
+
+        await client.analytics.run_report(
+            start=datetime(2026, 1, 1, tzinfo=UTC),
+            end=datetime(2026, 1, 31, tzinfo=UTC),
+            metrics=[AnalyticsMetricId.AVG_FIRST_RESPONSE_TIME],
+            interval=1.0,
+        )
+        # First sleep used the Retry-After value (5.0), not the default interval.
+        assert no_sleep == [5.0]
+
+
+# ---------------------------------------------------------------------------
+# create_report / get_report
+# ---------------------------------------------------------------------------
+
+
+class TestCreateAndGetReport:
+    async def test_create_returns_uid(self, attach_transport, make_mock_transport):
+        client = attach_transport(
+            make_mock_transport(
+                _report_payload(uid="rpt_xyz", status="running"), status=201
+            )
+        )
+
+        uid = await client.analytics.create_report(
+            start=datetime(2026, 1, 1, tzinfo=UTC),
+            end=datetime(2026, 1, 31, tzinfo=UTC),
+            metrics=[AnalyticsMetricId.AVG_FIRST_RESPONSE_TIME],
+        )
+        assert uid == "rpt_xyz"
+
+    async def test_get_returns_full_response(
+        self, attach_transport, make_mock_transport
+    ):
+        client = attach_transport(
+            make_mock_transport(
+                _report_payload(uid="rpt_xyz", status="done", progress=100),
+                status=200,
+            )
+        )
+
+        report = await client.analytics.get_report("rpt_xyz")
+        assert report.uid == "rpt_xyz"
+        assert report.status == AnalyticsReportResponseStatus.DONE
+
+
+# ---------------------------------------------------------------------------
+# run_export — the export flow has an extra terminal state (too_big)
+# ---------------------------------------------------------------------------
+
+
+class TestRunExport:
+    @pytest.fixture
+    def no_sleep(self, monkeypatch):
+        async def fake_sleep(_seconds: float) -> None:
+            pass
+
+        monkeypatch.setattr(
+            "frontapp_public_api_client.helpers.analytics.asyncio.sleep",
+            fake_sleep,
+        )
+
+    async def test_happy_path(self, attach_transport, no_sleep):
+        from frontapp_public_api_client.models.analytics_messages_columns import (
+            AnalyticsMessagesColumns,
+        )
+        from frontapp_public_api_client.models.analytics_messages_export_columns import (
+            AnalyticsMessagesExportColumns,
+        )
+
+        transport = _seq_handler(
+            [
+                (201, _export_payload(id_="exp_1", status="running")),
+                (
+                    200,
+                    _export_payload(
+                        id_="exp_1",
+                        status="done",
+                        progress=100,
+                        url="https://x/exp_1.csv",
+                    ),
+                ),
+            ]
+        )
+        client = attach_transport(transport)
+        body = AnalyticsMessagesExportColumns(
+            columns=[AnalyticsMessagesColumns.CONVERSATION_ID]
+        )
+        result = await client.analytics.run_export(body)
+        assert result.id == "exp_1"
+        assert result.url == "https://x/exp_1.csv"
+
+    async def test_too_big_raises_api_error_with_narrowing_hint(
+        self, attach_transport, no_sleep
+    ):
+        from frontapp_public_api_client.models.analytics_messages_columns import (
+            AnalyticsMessagesColumns,
+        )
+        from frontapp_public_api_client.models.analytics_messages_export_columns import (
+            AnalyticsMessagesExportColumns,
+        )
+
+        transport = _seq_handler(
+            [
+                (201, _export_payload(id_="exp_big", status="running")),
+                (200, _export_payload(id_="exp_big", status="too_big")),
+            ]
+        )
+        client = attach_transport(transport)
+        body = AnalyticsMessagesExportColumns(
+            columns=[AnalyticsMessagesColumns.CONVERSATION_ID]
+        )
+        with pytest.raises(APIError, match="too large"):
+            await client.analytics.run_export(body)
+
+
+# ---------------------------------------------------------------------------
+# Property wiring
+# ---------------------------------------------------------------------------
+
+
+class TestWiring:
+    def test_client_analytics_returns_analytics_helper(self, mock_api_credentials):
+        from frontapp_public_api_client import FrontappClient
+
+        client = FrontappClient(**mock_api_credentials)
+        assert isinstance(client.analytics, Analytics)
+
+    def test_lazy_property_caches(self, mock_api_credentials):
+        from frontapp_public_api_client import FrontappClient
+
+        client = FrontappClient(**mock_api_credentials)
+        first = client.analytics
+        second = client.analytics
+        assert first is second
+
+
+# Reference (avoid unused-import lint when AsyncMock isn't directly invoked)
+_ = AsyncMock


### PR DESCRIPTION
Closes #6.

## Summary

Front's `/analytics/reports` and `/analytics/exports` endpoints are server-side asynchronous: POST creates a compute job and returns immediately with `status: "running"`; a follow-up GET polls until the job reaches a terminal status (`done`, `failed`, or `too_big` for exports). Without a helper, naive callers see the 201 + placeholder and don't know to retry.

This vertical ports the create-then-poll pattern from the legacy TypeScript MCP prototype (`Frontapp-MCP/frontapp_mcp.ts:2549-2575`) into the Python client + MCP layer.

## What ships

### Python client — `client.analytics`

```python
async with FrontappClient() as client:
    report = await client.analytics.run_report(
        start=datetime(2026, 4, 1, tzinfo=timezone.utc),
        end=datetime(2026, 4, 30, tzinfo=timezone.utc),
        metrics=[AnalyticsMetricId.AVG_FIRST_RESPONSE_TIME],
        filters=InboxIds(inbox_ids=["inb_abc"]),
    )
    print(report.status, report.metrics)
```

Six methods total:

- `create_report` / `get_report` / `run_report`
- `create_export` / `get_export` / `run_export`

Defaults: **20 polls × 1.0s** for reports, **60 polls × 2.0s** for exports. The `run_*` methods raise `TimeoutError` after the budget elapses (the report keeps running on Front; resume with `get_report(uid)`) and `APIError` on terminal `failed` (or `too_big` for exports — with a date-range narrowing hint). Honors `Retry-After` response headers.

### MCP server — two new tools

- `run_analytics_report(start, end, metrics, [filters], timeout_seconds=30)`
- `run_analytics_export(export_type, columns, timeout_seconds=120)`

**No two-step confirm** — these are read/query operations; the server-side job is just how Front computes the result. Filter selection in the report tool is exposed as explicit per-category id lists (`inbox_ids`, `tag_ids`, `teammate_ids`, `team_ids`, `channel_ids`, `account_ids`) rather than a raw dict — the spec is `oneOf` so the tool rejects multi-category calls before reaching the helper.

## Design decisions (from the planner)

1. **No new domain projection** — analytics results are heterogeneous metric blobs (`AnalyticsScalar` with `int | str | AnalyticsScalarValueType2 | None` values). Wrapping them in Pydantic adds complexity without benefit; the helper returns the raw attrs response and the MCP tool calls `.to_dict()` for the LLM.
2. **`timeout_seconds` → `max_attempts` conversion** lives in `attempts_for(timeout_seconds, interval)` (public so the MCP layer doesn't reimplement it). Interval stays fixed per tool (1.0s for reports, 2.0s for exports).
3. **Filter parameters in the MCP layer** — explicit `inbox_ids` / `tag_ids` / etc. parameters rather than a raw `dict`; safer for LLM callers, no duck-type ambiguity around the `oneOf` spec, validation up front before the helper sees it.
4. **Fixed-interval polling, no backoff** — matches the TS prototype.

## Tests

- **`tests/test_analytics.py`** (18 tests) — helper unit tests: happy path, immediate-done, terminal failure, timeout exhaustion, `Retry-After` override, `too_big` for exports, plus the `attempts_for` / `_retry_after_or` helpers and the lazy-property wiring.
- **`frontapp_mcp_server/tests/test_analytics_tools.py`** (10 tests) — MCP tool tests: ISO-date parsing, metric validation, filter-category conflict rejection, `timeout_seconds` → `max_attempts` conversion, `activities` vs `messages` export dispatch, helper-timeout surfacing as `{"status": "timeout"}`.

Total suite: **561 tests** (was 532 plus 1 from intervening merges → +28 from this PR).

## Docs

- `frontapp_public_api_client/docs/guide.md` — added a coverage-table row + a fully-worked `run_report` example with a typed filter.
- `frontapp_mcp_server/src/frontapp_mcp/resources/help.py` — Analytics section with the create-then-poll explanation, the filter-category constraint, and the `too_big` hint.
- `frontapp_mcp_server/src/frontapp_mcp/server.py` — instructions block gains an Analytics section so the LLM understands the create-poll semantics at session start.
- `docs/api-facts.yaml` — regenerated.

## Test plan

- [ ] CI green
- [ ] `uv run poe full-check` passes locally ✅
- [ ] All 28 new tests pass ✅
- [ ] No regressions in the existing 533 tests ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)