### PR TITLE
feat(mcp): workspace admin Tier 1 reference resources (#80, #81, #82)

### DIFF
--- a/frontapp_mcp_server/src/frontapp_mcp/resources/help.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/resources/help.py
@@ -9,19 +9,22 @@ _HELP_MARKDOWN = """\
 
 ## Resources (slow-changing reference data, cached 60s)
 
-| URI                              | Use it to…                                                       |
-| -------------------------------- | ---------------------------------------------------------------- |
-| `frontapp://help`                | Read this reference (you're reading it).                         |
-| `frontapp://tags`                | Translate tag names ("urgent", "vip") into `tag_*` ids.          |
-| `frontapp://inboxes`             | Translate inbox names ("Support", "Sales") into `inb_*` ids.     |
-| `frontapp://teammates`           | Translate a teammate name or email into a `tea_*` id.            |
-| `frontapp://conversations/recent`| Orient at session start — 20 most recent conversations.          |
+| URI                               | Use it to…                                                                               |
+| --------------------------------- | ---------------------------------------------------------------------------------------- |
+| `frontapp://help`                 | Read this reference (you're reading it).                                                 |
+| `frontapp://me`                   | Workspace identity (`cmp_*`, name). Session-start smoke test — does NOT identify teammate. |
+| `frontapp://tags`                 | Translate tag names ("urgent", "vip") into `tag_*` ids.                                  |
+| `frontapp://inboxes`              | Translate inbox names ("Support", "Sales") into `inb_*` ids.                             |
+| `frontapp://teammates`            | Translate a teammate name or email into a `tea_*` id.                                    |
+| `frontapp://teams`                | Translate a team name ("Support") into a `tim_*` id.                                     |
+| `frontapp://custom_fields`        | Every custom field schema in the workspace, grouped by scope. Translate field name → `cf_*` id. |
+| `frontapp://conversations/recent` | Orient at session start — 20 most recent conversations.                                  |
 
 Read these resources before calling mutating tools — they give you the
-`tag_*` / `inb_*` / `tea_*` ids you'll need for `update_conversation` and
-similar tools without asking the user. (Only conversation list/read tools
-are registered today; tags / inboxes / teammates are exposed only as
-resources.)
+`tag_*` / `inb_*` / `tea_*` / `tim_*` / `cf_*` ids you'll need for
+`update_conversation` and similar tools without asking the user. (Only
+conversation list/read tools are registered today; tags / inboxes /
+teammates / teams / custom_fields are exposed only as resources.)
 
 ## Conversations
 

--- a/frontapp_mcp_server/src/frontapp_mcp/resources/reference.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/resources/reference.py
@@ -10,6 +10,9 @@ from the existing ``ResponseCachingMiddleware``.
 | ``frontapp://inboxes`` | All inboxes (id, name, privacy). |
 | ``frontapp://teammates`` | All teammates (id, username, email, name, availability). |
 | ``frontapp://conversations/recent`` | The 20 most recent conversations as light summaries. |
+| ``frontapp://me`` | Workspace company identity (id, name) — confirms the token works and which workspace it's bound to. |
+| ``frontapp://custom_fields`` | All custom field schemas, grouped by scope (global / account / contact / conversation / inbox / link / teammate). |
+| ``frontapp://teams`` | All workspace teams (id, name) — translate team names to ids. |
 """
 
 from __future__ import annotations
@@ -23,7 +26,7 @@ from pydantic import BaseModel
 
 from frontapp_mcp.projections import to_summary
 from frontapp_mcp.services import get_services
-from frontapp_public_api_client.utils import unwrap
+from frontapp_public_api_client.utils import unwrap, unwrap_as
 
 
 class TagRef(BaseModel):
@@ -47,6 +50,40 @@ class TeammateRef(BaseModel):
     first_name: str | None = None
     last_name: str | None = None
     is_available: bool | None = None
+
+
+class MeRef(BaseModel):
+    """Identity of the workspace company the API token is bound to.
+
+    Front's ``GET /me`` returns the company-level identity — id ``cmp_*``
+    and the workspace's display name — not the teammate the token
+    represents. There's no programmatic way to recover the token's
+    teammate from the API; that mapping lives in Front's admin UI.
+    Use this resource as a token-validity smoke check at session start
+    and to display the workspace name for context.
+    """
+
+    id: str
+    name: str | None = None
+
+
+class TeamRef(BaseModel):
+    id: str
+    name: str | None = None
+
+
+class CustomFieldRef(BaseModel):
+    """Schema for one custom field on Front objects.
+
+    The ``scope`` discriminator is added by the resource — it's not in
+    the underlying ``CustomFieldResponse`` model.
+    """
+
+    id: str
+    name: str | None = None
+    description: str | None = None
+    type: str | None = None
+    values: list[dict[str, Any]] | None = None
 
 
 def _project(model: type[BaseModel], item: Any) -> dict[str, Any]:
@@ -127,6 +164,85 @@ def register_resources(mcp: FastMCP) -> None:
         return await _list_field_results(
             context, list_teammates.asyncio_detailed, TeammateRef
         )
+
+    @mcp.resource(
+        uri="frontapp://me",
+        name="Workspace identity",
+        description=(
+            "Workspace company identity — `id` (cmp_*) and display name "
+            "of the workspace this API token is bound to. Use as a "
+            "session-start smoke test to confirm the token is valid, and "
+            "for displaying workspace context. Note: this does NOT identify "
+            "the teammate the token represents (Front doesn't expose that)."
+        ),
+        mime_type="application/json",
+    )
+    async def me_resource(context: Context) -> str:
+        from frontapp_public_api_client.api.token_identity import api_token_details
+        from frontapp_public_api_client.models.identity_response import (
+            IdentityResponse,
+        )
+
+        services = get_services(context)
+        response = await api_token_details.asyncio_detailed(client=services.client)
+        identity = unwrap_as(response, IdentityResponse)
+        return _dump([_project(MeRef, identity)])
+
+    @mcp.resource(
+        uri="frontapp://custom_fields",
+        name="Custom fields (all scopes)",
+        description=(
+            "All custom field schemas in the workspace, grouped by scope "
+            "(global / account / contact / conversation / inbox / link / "
+            "teammate). Use to translate a custom field name into its "
+            "`cf_*` id before reading or writing field values on objects."
+        ),
+        mime_type="application/json",
+    )
+    async def custom_fields_resource(context: Context) -> str:
+        from frontapp_public_api_client.api.custom_fields import (
+            list_account_custom_fields,
+            list_contact_custom_fields,
+            list_conversation_custom_fields,
+            list_custom_fields,
+            list_inbox_custom_fields,
+            list_link_custom_fields,
+            list_teammate_custom_fields,
+        )
+
+        services = get_services(context)
+        scopes: dict[str, Callable[..., Any]] = {
+            "global": list_custom_fields.asyncio_detailed,
+            "account": list_account_custom_fields.asyncio_detailed,
+            "contact": list_contact_custom_fields.asyncio_detailed,
+            "conversation": list_conversation_custom_fields.asyncio_detailed,
+            "inbox": list_inbox_custom_fields.asyncio_detailed,
+            "link": list_link_custom_fields.asyncio_detailed,
+            "teammate": list_teammate_custom_fields.asyncio_detailed,
+        }
+        result: dict[str, list[dict[str, Any]]] = {}
+        for scope, list_fn in scopes.items():
+            response = await list_fn(client=services.client)
+            parsed = unwrap(response)
+            results = getattr(parsed, "field_results", None) or []
+            result[scope] = [_project(CustomFieldRef, item) for item in results]
+        return json.dumps(result, sort_keys=True)
+
+    @mcp.resource(
+        uri="frontapp://teams",
+        name="Teams",
+        description=(
+            "All workspace teams (id, name). Use to translate a team name "
+            "('Support', 'Sales') into a `tim_*` id before passing to "
+            "team-scoped tools like `list_team_inboxes` or "
+            "`create_team_signature`."
+        ),
+        mime_type="application/json",
+    )
+    async def teams_resource(context: Context) -> str:
+        from frontapp_public_api_client.api.teams import list_teams
+
+        return await _list_field_results(context, list_teams.asyncio_detailed, TeamRef)
 
     @mcp.resource(
         uri="frontapp://conversations/recent",

--- a/frontapp_mcp_server/src/frontapp_mcp/server.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/server.py
@@ -419,17 +419,26 @@ automatically with exponential backoff. Expect ~60 req/min on most endpoints.
 ## Resources (read these before mutating tools)
 
   frontapp://help                  — full tool reference + workflow recipes
+  frontapp://me                    — workspace identity (cmp_*, name)
   frontapp://tags                  — all workspace tags (translate name → id)
   frontapp://inboxes               — all inboxes (translate name → id)
   frontapp://teammates             — all teammates (translate name/email → id)
+  frontapp://teams                 — all teams (translate name → tim_* id)
+  frontapp://custom_fields         — every custom field schema, grouped by scope
   frontapp://conversations/recent  — 20 most recent conversations as summaries
 
 Resources are slow-changing reference data, cached for 60 seconds. Read
 them at session start to translate human-readable names ("Support" inbox,
-"Alice Cooper" assignee) into the `inb_*` / `tea_*` / `tag_*` ids that
-mutating tools require — instead of asking the user for ids or assuming
-list-* tools exist for those resources (the only list-* tools currently
-registered are for conversations).
+"Alice Cooper" assignee, "Severity" custom field) into the `inb_*` /
+`tea_*` / `tag_*` / `tim_*` / `cf_*` ids that mutating tools require —
+instead of asking the user for ids or assuming list-* tools exist for
+those resources (the only list-* tools currently registered are for
+conversations).
+
+`frontapp://me` is the workspace company identity (`cmp_*`, name) — use
+as a session-start smoke test to confirm the token is valid; it does NOT
+identify the teammate the token represents (Front doesn't expose that
+mapping).
 """,
 )
 

--- a/frontapp_mcp_server/tests/test_admin_reference_resources.py
+++ b/frontapp_mcp_server/tests/test_admin_reference_resources.py
@@ -1,0 +1,221 @@
+"""Tests for the workspace-admin reference resources (#80, #81, #82).
+
+Covers ``frontapp://me``, ``frontapp://custom_fields``, and
+``frontapp://teams``. Uses a real ``FrontappClient`` with an
+``httpx.MockTransport`` so the unwrap path through the generated
+client code is exercised end-to-end (rather than mocking at the
+helper boundary, which doesn't exist for these reference resources —
+they call the generated ``api/<tag>`` modules directly).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+from frontapp_mcp.resources.reference import register_resources
+
+from frontapp_public_api_client import FrontappClient
+
+
+def _make_client(handler) -> FrontappClient:
+    """Build a FrontappClient whose httpx transport is a mock."""
+    client = FrontappClient(api_key="test-key", base_url="https://api.frontapp.test")
+    client.set_async_httpx_client(
+        httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            base_url="https://api.frontapp.test",
+        )
+    )
+    return client
+
+
+def _make_context(client: FrontappClient):
+    """Mock FastMCP context whose lifespan exposes the given client."""
+    context = MagicMock()
+    context.request_context = MagicMock()
+    context.request_context.lifespan_context = MagicMock()
+    context.request_context.lifespan_context.client = client
+    return context
+
+
+def _capture_resources(register_fn) -> dict[str, Any]:
+    """Run ``register_fn(mcp)`` against a FakeMCP and return ``{uri: callable}``."""
+    captured: dict[str, Any] = {}
+
+    class FakeMCP:
+        def resource(self, **kwargs):
+            uri = kwargs["uri"]
+
+            def decorator(fn):
+                captured[uri] = fn
+                return fn
+
+            return decorator
+
+    register_fn(FakeMCP())
+    return captured
+
+
+@pytest.fixture
+def resources():
+    return _capture_resources(register_resources)
+
+
+# ---------------------------------------------------------------------------
+# frontapp://me
+# ---------------------------------------------------------------------------
+
+
+class TestMeResource:
+    async def test_returns_workspace_identity(self, resources):
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/me"
+            return httpx.Response(
+                200,
+                json={
+                    "_links": {"self": "https://api.frontapp.test/me"},
+                    "id": "cmp_k30",
+                    "name": "Dunder Mifflin Paper Company, Inc.",
+                },
+            )
+
+        context = _make_context(_make_client(handler))
+        body = await resources["frontapp://me"](context)
+        parsed = json.loads(body)
+        # The resource wraps the single identity in a list for consistency
+        # with the other JSON-array reference resources.
+        assert isinstance(parsed, list)
+        assert len(parsed) == 1
+        assert parsed[0]["id"] == "cmp_k30"
+        assert parsed[0]["name"] == "Dunder Mifflin Paper Company, Inc."
+
+
+# ---------------------------------------------------------------------------
+# frontapp://custom_fields
+# ---------------------------------------------------------------------------
+
+
+class TestCustomFieldsResource:
+    async def test_combines_all_seven_scopes(self, resources):
+        # Each scope has its own URL path; we return distinct fake fields per
+        # scope so the test asserts the resource correctly tags each.
+        scope_paths = {
+            "/custom_fields": "global",
+            "/accounts/custom_fields": "account",
+            "/contacts/custom_fields": "contact",
+            "/conversations/custom_fields": "conversation",
+            "/inboxes/custom_fields": "inbox",
+            "/links/custom_fields": "link",
+            "/teammates/custom_fields": "teammate",
+        }
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            scope = scope_paths.get(request.url.path)
+            assert scope is not None, f"unexpected path: {request.url.path}"
+            return httpx.Response(
+                200,
+                json={
+                    "_links": {"self": str(request.url)},
+                    "_results": [
+                        {
+                            "_links": {"self": "x", "related": {}},
+                            "id": f"cf_{scope}",
+                            "name": f"{scope}-field",
+                            "description": f"a {scope}-scoped field",
+                            "type": "string",
+                        }
+                    ],
+                },
+            )
+
+        context = _make_context(_make_client(handler))
+        body = await resources["frontapp://custom_fields"](context)
+        parsed = json.loads(body)
+
+        # All 7 scopes should be present, each with one field.
+        assert set(parsed.keys()) == {
+            "global",
+            "account",
+            "contact",
+            "conversation",
+            "inbox",
+            "link",
+            "teammate",
+        }
+        for scope in parsed:
+            assert len(parsed[scope]) == 1
+            assert parsed[scope][0]["id"] == f"cf_{scope}"
+            assert parsed[scope][0]["name"] == f"{scope}-field"
+
+    async def test_empty_results_per_scope_handled(self, resources):
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={"_links": {"self": "x"}, "_results": []},
+            )
+
+        context = _make_context(_make_client(handler))
+        body = await resources["frontapp://custom_fields"](context)
+        parsed = json.loads(body)
+        # Every scope key still present, just empty.
+        assert set(parsed.keys()) == {
+            "global",
+            "account",
+            "contact",
+            "conversation",
+            "inbox",
+            "link",
+            "teammate",
+        }
+        for scope in parsed:
+            assert parsed[scope] == []
+
+
+# ---------------------------------------------------------------------------
+# frontapp://teams
+# ---------------------------------------------------------------------------
+
+
+class TestTeamsResource:
+    async def test_returns_team_refs(self, resources):
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/teams"
+            return httpx.Response(
+                200,
+                json={
+                    "_links": {"self": "https://api.frontapp.test/teams"},
+                    "_results": [
+                        {
+                            "_links": {"self": "x", "related": {}},
+                            "id": "tim_support",
+                            "name": "Support",
+                        },
+                        {
+                            "_links": {"self": "y", "related": {}},
+                            "id": "tim_sales",
+                            "name": "Sales",
+                        },
+                    ],
+                },
+            )
+
+        context = _make_context(_make_client(handler))
+        body = await resources["frontapp://teams"](context)
+        parsed = json.loads(body)
+        assert isinstance(parsed, list)
+        assert len(parsed) == 2
+        assert {row["id"] for row in parsed} == {"tim_support", "tim_sales"}
+        assert {row["name"] for row in parsed} == {"Support", "Sales"}
+
+    async def test_empty_workspace_returns_empty_list(self, resources):
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"_links": {"self": "x"}, "_results": []})
+
+        context = _make_context(_make_client(handler))
+        body = await resources["frontapp://teams"](context)
+        parsed = json.loads(body)
+        assert parsed == []


### PR DESCRIPTION
Closes #80, #81, #82. Part of #16 (workspace admin partition).

## Summary

Three new MCP reference resources expose workspace-admin reads that an LLM consumes at session start, alongside the existing `frontapp://tags` / `inboxes` / `teammates` / `conversations/recent`.

| URI | Use it to… |
| --- | --- |
| `frontapp://me` | Confirm the API token works and display the workspace identity (`cmp_*`, name) |
| `frontapp://custom_fields` | Translate a custom field name into a `cf_*` id, grouped by scope (global / account / contact / conversation / inbox / link / teammate) |
| `frontapp://teams` | Translate a team name (\"Support\", \"Sales\") into a `tim_*` id |

## Important note on `frontapp://me`

The original issue (#80) claimed this would bootstrap `author_id` on drafts and comments. **That was wrong** — Front's `GET /me` returns the workspace company identity (`id: cmp_*`, name: workspace display name), **not** the teammate that the token represents. There's no programmatic way to recover the token-to-teammate mapping from the API; that lives in Front's admin UI.

The resource is still useful as:
- A session-start smoke test confirming the token works
- A source for the workspace's display name (for context in agent responses)

The docstring on `MeRef` and the `server.py` `instructions=` block both call this out explicitly so the LLM doesn't try to misuse it.

## Implementation

- Three new Pydantic ref models in `resources/reference.py`: `MeRef`, `CustomFieldRef`, `TeamRef`.
- Three new resources registered via `register_resources(mcp)`. The custom_fields fan-out is the one wrinkle: 7 separate `list_*_custom_fields.asyncio_detailed` calls combined into one dict-of-lists JSON doc, grouped by scope.
- `server.py` `instructions=` block: \"Resources\" section updated with the three new URIs and the workspace-vs-teammate note.
- `resources/help.py`: Resources table updated with the same.

## Tests

New file `frontapp_mcp_server/tests/test_admin_reference_resources.py` — 5 tests covering all three resources end-to-end via `httpx.MockTransport` on a real `FrontappClient` (not mocked at the helper boundary, since these resources call generated `api/<tag>` modules directly):

- `TestMeResource.test_returns_workspace_identity` — confirms `cmp_*`/name shape comes through.
- `TestCustomFieldsResource.test_combines_all_seven_scopes` — distinct fake fields per scope; the resource correctly tags each.
- `TestCustomFieldsResource.test_empty_results_per_scope_handled` — every scope key still present, just empty.
- `TestTeamsResource.test_returns_team_refs` — multi-team list.
- `TestTeamsResource.test_empty_workspace_returns_empty_list`.

566 tests pass (+5 from this PR).

## Test plan

- [ ] CI green
- [ ] `uv run poe full-check` passes locally ✅
- [ ] All 5 new tests pass ✅
- [ ] Manual end-to-end (with a real Front workspace if available): load `frontapp://me` → confirm `cmp_*`; `frontapp://custom_fields` → confirm field schemas; `frontapp://teams` → confirm `tim_*` names match the workspace.

## What's next

This is **PR-A** of the #16 workspace-admin partition (see umbrella comment on #16 for the full plan). PR-B is **#83** — the Knowledge Base read + contribute vertical, the next big chunk after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)