### PR TITLE
chore(mcp): address PR #94 review comments

### DIFF
--- a/frontapp_mcp_server/src/frontapp_mcp/resources/reference.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/resources/reference.py
@@ -75,8 +75,10 @@ class TeamRef(BaseModel):
 class CustomFieldRef(BaseModel):
     """Schema for one custom field on Front objects.
 
-    The ``scope`` discriminator is added by the resource — it's not in
-    the underlying ``CustomFieldResponse`` model.
+    Custom fields are grouped by scope at the top level of the resource
+    response (``{"global": [...], "account": [...], ...}``). This model
+    represents an individual field entry — there is no per-item ``scope``
+    property; the dict key carries that information.
     """
 
     id: str
@@ -200,6 +202,8 @@ def register_resources(mcp: FastMCP) -> None:
         mime_type="application/json",
     )
     async def custom_fields_resource(context: Context) -> str:
+        import asyncio
+
         from frontapp_public_api_client.api.custom_fields import (
             list_account_custom_fields,
             list_contact_custom_fields,
@@ -220,9 +224,14 @@ def register_resources(mcp: FastMCP) -> None:
             "link": list_link_custom_fields.asyncio_detailed,
             "teammate": list_teammate_custom_fields.asyncio_detailed,
         }
+        # Fan out the 7 list calls concurrently — sequential await would
+        # add unnecessary latency on session start (the resource gets
+        # consumed at session warm-up, before the first conversation tool).
+        responses = await asyncio.gather(
+            *(list_fn(client=services.client) for list_fn in scopes.values())
+        )
         result: dict[str, list[dict[str, Any]]] = {}
-        for scope, list_fn in scopes.items():
-            response = await list_fn(client=services.client)
+        for scope, response in zip(scopes.keys(), responses, strict=True):
             parsed = unwrap(response)
             results = getattr(parsed, "field_results", None) or []
             result[scope] = [_project(CustomFieldRef, item) for item in results]

--- a/frontapp_mcp_server/tests/test_admin_reference_resources.py
+++ b/frontapp_mcp_server/tests/test_admin_reference_resources.py
@@ -21,16 +21,35 @@ from frontapp_mcp.resources.reference import register_resources
 from frontapp_public_api_client import FrontappClient
 
 
-def _make_client(handler) -> FrontappClient:
-    """Build a FrontappClient whose httpx transport is a mock."""
-    client = FrontappClient(api_key="test-key", base_url="https://api.frontapp.test")
-    client.set_async_httpx_client(
-        httpx.AsyncClient(
-            transport=httpx.MockTransport(handler),
-            base_url="https://api.frontapp.test",
+@pytest.fixture
+async def make_client():
+    """Factory: build a FrontappClient with a mocked httpx transport.
+
+    Yields a callable that takes a request handler and returns a
+    fully-configured ``FrontappClient``. Every client created via the
+    factory is closed automatically on test teardown so the underlying
+    ``httpx.AsyncClient`` doesn't leak (the unclosed-client warning was
+    flagged on PR #94 review).
+    """
+    created: list[FrontappClient] = []
+
+    def factory(handler) -> FrontappClient:
+        client = FrontappClient(
+            api_key="test-key", base_url="https://api.frontapp.test"
         )
-    )
-    return client
+        client.set_async_httpx_client(
+            httpx.AsyncClient(
+                transport=httpx.MockTransport(handler),
+                base_url="https://api.frontapp.test",
+            )
+        )
+        created.append(client)
+        return client
+
+    yield factory
+
+    for client in created:
+        await client.get_async_httpx_client().aclose()
 
 
 def _make_context(client: FrontappClient):
@@ -71,7 +90,7 @@ def resources():
 
 
 class TestMeResource:
-    async def test_returns_workspace_identity(self, resources):
+    async def test_returns_workspace_identity(self, resources, make_client):
         def handler(request: httpx.Request) -> httpx.Response:
             assert request.url.path == "/me"
             return httpx.Response(
@@ -83,7 +102,7 @@ class TestMeResource:
                 },
             )
 
-        context = _make_context(_make_client(handler))
+        context = _make_context(make_client(handler))
         body = await resources["frontapp://me"](context)
         parsed = json.loads(body)
         # The resource wraps the single identity in a list for consistency
@@ -100,7 +119,7 @@ class TestMeResource:
 
 
 class TestCustomFieldsResource:
-    async def test_combines_all_seven_scopes(self, resources):
+    async def test_combines_all_seven_scopes(self, resources, make_client):
         # Each scope has its own URL path; we return distinct fake fields per
         # scope so the test asserts the resource correctly tags each.
         scope_paths = {
@@ -132,7 +151,7 @@ class TestCustomFieldsResource:
                 },
             )
 
-        context = _make_context(_make_client(handler))
+        context = _make_context(make_client(handler))
         body = await resources["frontapp://custom_fields"](context)
         parsed = json.loads(body)
 
@@ -151,14 +170,14 @@ class TestCustomFieldsResource:
             assert parsed[scope][0]["id"] == f"cf_{scope}"
             assert parsed[scope][0]["name"] == f"{scope}-field"
 
-    async def test_empty_results_per_scope_handled(self, resources):
+    async def test_empty_results_per_scope_handled(self, resources, make_client):
         def handler(_request: httpx.Request) -> httpx.Response:
             return httpx.Response(
                 200,
                 json={"_links": {"self": "x"}, "_results": []},
             )
 
-        context = _make_context(_make_client(handler))
+        context = _make_context(make_client(handler))
         body = await resources["frontapp://custom_fields"](context)
         parsed = json.loads(body)
         # Every scope key still present, just empty.
@@ -181,7 +200,7 @@ class TestCustomFieldsResource:
 
 
 class TestTeamsResource:
-    async def test_returns_team_refs(self, resources):
+    async def test_returns_team_refs(self, resources, make_client):
         def handler(request: httpx.Request) -> httpx.Response:
             assert request.url.path == "/teams"
             return httpx.Response(
@@ -203,7 +222,7 @@ class TestTeamsResource:
                 },
             )
 
-        context = _make_context(_make_client(handler))
+        context = _make_context(make_client(handler))
         body = await resources["frontapp://teams"](context)
         parsed = json.loads(body)
         assert isinstance(parsed, list)
@@ -211,11 +230,11 @@ class TestTeamsResource:
         assert {row["id"] for row in parsed} == {"tim_support", "tim_sales"}
         assert {row["name"] for row in parsed} == {"Support", "Sales"}
 
-    async def test_empty_workspace_returns_empty_list(self, resources):
+    async def test_empty_workspace_returns_empty_list(self, resources, make_client):
         def handler(_request: httpx.Request) -> httpx.Response:
             return httpx.Response(200, json={"_links": {"self": "x"}, "_results": []})
 
-        context = _make_context(_make_client(handler))
+        context = _make_context(make_client(handler))
         body = await resources["frontapp://teams"](context)
         parsed = json.loads(body)
         assert parsed == []


### PR DESCRIPTION
Follow-up addressing the three Copilot review comments left on the merged PR #94. Small + scoped: no behavior change, just performance + hygiene + a docstring correction.

## What changed

### 1. `asyncio.gather` for the custom_fields fan-out
`frontapp://custom_fields` was awaiting 7 per-scope list calls sequentially. Switched to concurrent fan-out — output is byte-identical (same dict-of-lists shape, same key order via `sort_keys=True`), but session-start latency drops from \"7 × one round-trip\" to \"max(round-trip)\".

### 2. AsyncClient cleanup in tests
`_make_client(handler)` constructed an `httpx.AsyncClient` per test but never closed it. Converted to a `make_client` async fixture that tracks every client created during the test and `aclose()`s each one in teardown. Updates the 5 test methods to take `make_client` as a fixture parameter.

### 3. `CustomFieldRef` docstring correction
The original docstring claimed a `scope` discriminator was added per item by the resource. Wrong — the resource groups by scope at the top-level dict key, not as a per-item field. Rewrote the docstring to reflect the actual shape.

## Test plan

- [ ] CI green
- [ ] `uv run poe full-check` passes locally ✅ (566 tests pass; the existing 5 admin-reference tests still pass after the fixture rewrite — verified via `pytest -v`)

## Review comment trail

Closes the three threads from #94:

- [#discussion_r3148855770](https://github.com/dougborg/frontapp-openapi-client/pull/94#discussion_r3148855770) — fan-out concurrency
- [#discussion_r3148855818](https://github.com/dougborg/frontapp-openapi-client/pull/94#discussion_r3148855818) — AsyncClient cleanup
- [#discussion_r3148855835](https://github.com/dougborg/frontapp-openapi-client/pull/94#discussion_r3148855835) — CustomFieldRef docstring

🤖 Generated with [Claude Code](https://claude.com/claude-code)