### PR TITLE
feat(client,mcp): knowledge_bases read + contribute vertical (#83)

### DIFF
--- a/docs/api-facts.yaml
+++ b/docs/api-facts.yaml
@@ -17,8 +17,8 @@
 #      domain wiring status, full path/method/response info).
 #
 schema_version: 1
-generated_at: '2026-04-27T15:54:45+00:00'
-generated_from_commit: 48172d1a7373084ab7c2ddb083548c57c8940826
+generated_at: '2026-04-27T17:32:45+00:00'
+generated_from_commit: 4870f653ddef899c6412401a9148d38ed6d05065
 summary:
   list_endpoints_with_field_results:
     - accounts.list_account_contacts
@@ -248,6 +248,7 @@ summary:
     - conversations
     - drafts
     - inboxes
+    - knowledge_bases
     - messages
     - tags
     - teammates
@@ -1208,9 +1209,9 @@ tags:
     spec_tag: Knowledge Bases
     api_dir: frontapp_public_api_client/api/knowledge_bases
     helper:
-      built: false
-      path: null
-      class: null
+      built: true
+      path: frontapp_public_api_client/helpers/knowledge_bases.py
+      class: KnowledgeBases
     domain:
       built: false
       path: null

--- a/frontapp_mcp_server/src/frontapp_mcp/projections.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/projections.py
@@ -8,6 +8,8 @@ without one importing private symbols from the other.
 
 from __future__ import annotations
 
+from typing import Any
+
 from pydantic import BaseModel, Field
 
 from frontapp_public_api_client.domain import (
@@ -218,17 +220,109 @@ def to_contact_list_summary(item: ContactList | ContactGroupRef) -> ContactListS
     return ContactListSummary(id=item.id, name=item.name, is_private=item.is_private)
 
 
+# ---------------------------------------------------------------------------
+# Knowledge base projections (#83)
+#
+# Helper returns raw attrs models; tools project to slim summaries for
+# list/catalog responses so the LLM context isn't bloated with article
+# bodies. ``get_kb_article(with_content=True)`` returns the full
+# ``to_dict()`` shape — no projection — since the body IS the payload.
+# ---------------------------------------------------------------------------
+
+
+class KbRef(BaseModel):
+    """Compact projection of a knowledge base for catalog browsing.
+
+    ``KnowledgeBaseSlimResponse`` carries an id, type, and locale list
+    but no display name — that's only available via the full
+    ``with_content=True`` get. Browse with the slim listing; fetch the
+    full payload (`get_kb(knowledge_base_id, with_content=True)`) to
+    get the workspace's human-readable name.
+    """
+
+    id: str | None = None
+    type: str | None = None  # "external" | "internal"
+    locales: list[str] | None = None
+
+
+class KbArticleSummary(BaseModel):
+    """Compact projection of a KB article (slim — no body, no title).
+
+    Front's slim article response carries `id`, `slug`, and `locales`
+    but no `subject` field (subject only appears on the full
+    ``with_content=True`` response). The slug is human-readable
+    (e.g. ``how-to-reset-password``), so use it as the picker key.
+    """
+
+    id: str | None = None
+    slug: str | None = None
+    locales: list[str] | None = None
+    updated_at: float | None = None
+
+
+class KbCategoryRef(BaseModel):
+    """Compact projection of a KB category (slim — no name, no description)."""
+
+    id: str | None = None
+    slug: str | None = None
+    is_hidden: bool | None = None
+    locales: list[str] | None = None
+
+
+def to_kb_ref(item: Any) -> KbRef:
+    """Project a ``KnowledgeBaseSlimResponse`` (attrs) to ``KbRef``."""
+    from frontapp_public_api_client.domain.converters import unwrap_unset
+
+    raw_type = unwrap_unset(getattr(item, "type_", None), None)
+    type_value = raw_type.value if raw_type is not None else None
+    return KbRef(
+        id=unwrap_unset(getattr(item, "id", None), None),
+        type=type_value,
+        locales=unwrap_unset(getattr(item, "locales", None), None),
+    )
+
+
+def to_kb_article_summary(item: Any) -> KbArticleSummary:
+    """Project a ``KnowledgeBaseArticleSlimResponse`` (attrs) to ``KbArticleSummary``."""
+    from frontapp_public_api_client.domain.converters import unwrap_unset
+
+    return KbArticleSummary(
+        id=unwrap_unset(getattr(item, "id", None), None),
+        slug=unwrap_unset(getattr(item, "slug", None), None),
+        locales=unwrap_unset(getattr(item, "locales", None), None),
+        updated_at=unwrap_unset(getattr(item, "updated_at", None), None),
+    )
+
+
+def to_kb_category_ref(item: Any) -> KbCategoryRef:
+    """Project a ``KnowledgeBaseCategorySlimResponse`` (attrs) to ``KbCategoryRef``."""
+    from frontapp_public_api_client.domain.converters import unwrap_unset
+
+    return KbCategoryRef(
+        id=unwrap_unset(getattr(item, "id", None), None),
+        slug=unwrap_unset(getattr(item, "slug", None), None),
+        is_hidden=unwrap_unset(getattr(item, "is_hidden", None), None),
+        locales=unwrap_unset(getattr(item, "locales", None), None),
+    )
+
+
 __all__ = [
     "ContactListSummary",
     "ContactSummary",
     "ConversationSummary",
     "DraftSummary",
     "InboxSummary",
+    "KbArticleSummary",
+    "KbCategoryRef",
+    "KbRef",
     "TagCatalogSummary",
     "to_contact_list_summary",
     "to_contact_summary",
     "to_draft_summary",
     "to_inbox_summary",
+    "to_kb_article_summary",
+    "to_kb_category_ref",
+    "to_kb_ref",
     "to_summary",
     "to_tag_catalog_summary",
 ]

--- a/frontapp_mcp_server/src/frontapp_mcp/resources/help.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/resources/help.py
@@ -228,6 +228,71 @@ preferred name-to-id lookup at session start.
 | `list_assigned_conversations` | `GET /teammates/{id}/conversations` | Conversations currently assigned to this teammate. Returns `ConversationSummary`s. |
 | `update_teammate` | `PATCH /teammates/{id}` | Update username / first_name / last_name / is_available. Email and admin status are NOT changeable here. Two-step confirm. |
 
+## Knowledge Base
+
+Front's KB — articles and categories grouped under one or more KBs.
+Wrapped here for two distinct workflows: **retrieval** (find content to
+paraphrase in replies) and **contribute** (turn a conversation
+resolution into a new article).
+
+| Tool | Endpoint | Purpose |
+| ---- | -------- | ------- |
+| `list_knowledge_bases` | `GET /knowledge_bases` | Catalog of every KB. Returns id + name. |
+| `get_kb` | `GET /knowledge_bases/{id}` (`/content` variants for `with_content=True`) | Single KB detail. |
+| `list_kb_categories` | `GET /knowledge_bases/{id}/categories` | Cursor-paginated categories list. |
+| `list_kb_articles` | `GET /knowledge_bases/{id}/articles` | Cursor-paginated slim articles (no body). |
+| `list_kb_articles_in_category` | `GET /knowledge_base_categories/{id}/articles` | Slim articles scoped to one category. |
+| `get_kb_article` | `GET /knowledge_base_articles/{id}` (`/content` variants) | Full article body — defaults `with_content=True`. |
+| `create_kb_article` | `POST /knowledge_bases/{id}/articles[/locales/{locale}/articles]` | Create a NEW article AS A DRAFT. Two-step confirm. |
+| `update_kb_article` | `PATCH /knowledge_base_articles/{id}/content[/locales/{locale}/content]` | Edit subject/body/author. Cannot flip status. Two-step confirm. |
+| `create_kb_category` | `POST /knowledge_bases/{id}/categories[/locales/{locale}/categories]` | Two-step confirm. |
+| `update_kb_category` | `PATCH /knowledge_base_categories/{id}/content[/locales/{locale}/content]` | Two-step confirm. |
+
+### Drafts only — agents never publish
+
+`create_kb_article` always creates a `status: "draft"` article — there
+is no `status` parameter on the tool. `update_kb_article` cannot change
+the publication state either; the existing draft/published state is
+preserved. **A human flips drafts to published in Front's UI.**
+
+Mirrors ADR-0016's drafts-first outbound philosophy: agents draft,
+humans send/publish. The Python helper layer
+(`client.knowledge_bases`) does retain the `status` kwarg so library
+callers (Python scripts) can publish programmatically — the MCP tools
+are the agent-safety boundary, not the helper.
+
+### Locale
+
+Every KB tool accepts an optional `locale` arg (e.g. `"en"`, `"fr"`).
+Omit for the workspace's default locale.
+
+### Workflow recipe — "answer this customer with a KB article"
+
+```
+list_knowledge_bases() → [{id: "knb_main", name: "Public KB"}, ...]
+list_kb_articles(knowledge_base_id="knb_main", limit=50)
+  → [{id, subject, status}, ...]   # agent picks the relevant article by subject
+get_kb_article(article_id="kba_xyz", with_content=True)
+  → {subject, content: "<article body>", ...}
+# Agent paraphrases or quotes content into a draft reply via create_draft_reply.
+```
+
+### Workflow recipe — "this conversation resolved a novel issue; capture it"
+
+```
+list_knowledge_bases() → pick the right KB
+list_kb_categories(knowledge_base_id="knb_main") → pick a category
+create_kb_article(
+    knowledge_base_id="knb_main",
+    subject="How to reset 2FA when phone is lost",
+    content="<article body...>",
+    category_id="kbc_security",
+    confirm=True,  # after human approves the elicitation
+)
+  → {confirmed: true, article: {id: "kba_new", status: "draft", ...}}
+# Article lands as a draft in Front's UI; human reviews and publishes.
+```
+
 ## Analytics
 
 Front's analytics endpoints are server-side asynchronous: the POST returns

--- a/frontapp_mcp_server/src/frontapp_mcp/server.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/server.py
@@ -375,6 +375,31 @@ endpoint for fetching them back out.
   and writes them to a local file. Two-step confirm protects the local
   filesystem; the response includes only metadata (path, size).
 
+## Knowledge Base
+
+Front's Knowledge Base — articles + categories grouped under one or more
+KBs — is wrapped here for both retrieval and authoring. Two workflows:
+
+**Retrieval** (find article content to quote / paraphrase in a reply):
+  list_knowledge_bases → list_kb_categories | list_kb_articles |
+  list_kb_articles_in_category → get_kb_article (with body)
+
+**Contribute** (turn a conversation resolution into a new article, or
+update an existing one):
+  create_kb_article — creates a NEW article AS A DRAFT (never published)
+  update_kb_article — edits subject/body/author of an existing article;
+    cannot flip draft↔published
+  create_kb_category / update_kb_category — organize content
+
+**Drafts only** — agents never publish KB articles. By design, mirroring
+drafts-first outbound for replies (ADR-0016): create_kb_article always
+creates a draft; update_kb_article preserves whatever publication state
+the article already had. To publish a draft, a human flips it in Front's
+UI. There is no programmatic publish path in this MCP.
+
+Locale: every KB read/write tool accepts an optional `locale` arg (e.g.
+'en', 'fr'). Omit for the workspace's default locale.
+
 ## Analytics
 
 Front's analytics endpoints are server-side asynchronous: a POST creates
@@ -485,6 +510,12 @@ _READ_ONLY_TOOLS = [
     "list_team_contact_groups",
     "list_teammate_contact_groups",
     "list_contacts_in_group",
+    "list_knowledge_bases",
+    "get_kb",
+    "list_kb_articles",
+    "list_kb_articles_in_category",
+    "get_kb_article",
+    "list_kb_categories",
 ]
 
 mcp.add_middleware(

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/__init__.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/__init__.py
@@ -18,6 +18,7 @@ def register_all_tools(mcp: FastMCP) -> None:
     from .conversations import register_tools as register_conversations_tools
     from .drafts import register_tools as register_drafts_tools
     from .inboxes import register_tools as register_inboxes_tools
+    from .knowledge_bases import register_tools as register_knowledge_bases_tools
     from .messages import register_tools as register_messages_tools
     from .tags import register_tools as register_tags_tools
     from .teammates import register_tools as register_teammates_tools
@@ -30,6 +31,7 @@ def register_all_tools(mcp: FastMCP) -> None:
     register_conversations_tools(mcp)
     register_drafts_tools(mcp)
     register_inboxes_tools(mcp)
+    register_knowledge_bases_tools(mcp)
     register_messages_tools(mcp)
     register_tags_tools(mcp)
     register_teammates_tools(mcp)

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/knowledge_bases.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/knowledge_bases.py
@@ -1,0 +1,421 @@
+"""MCP tools for Front's Knowledge Base — read + contribute (drafts only).
+
+Two distinct workflows the same tool surface supports:
+
+1. **Retrieval** — list KBs, list categories, list / get articles. Reads,
+   no confirm gate.
+2. **Contribute** — create / update articles + categories. Two-step
+   ``confirm_or_preview`` gate on every mutation.
+
+## Drafts only
+
+Per the project policy (mirroring ADR-0016's drafts-first outbound
+philosophy applied to KB content): **the MCP tools never publish a KB
+article.** ``create_kb_article`` and ``update_kb_article`` do not accept
+a ``status`` argument; the tools always pass ``status="draft"`` to the
+helper for create, and omit ``status`` from update bodies so the
+existing draft / published state is preserved. Publishing is a
+human-in-Front's-UI action.
+
+The Python helper layer (``client.knowledge_bases.create_article`` /
+``update_article``) **does** retain the ``status`` kwarg for library
+callers — Python scripts can publish programmatically. The MCP tools
+are the agent-safety boundary, not the helper.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastmcp import Context, FastMCP
+from pydantic import Field
+
+from frontapp_mcp.projections import (
+    KbArticleSummary,
+    KbCategoryRef,
+    KbRef,
+    to_kb_article_summary,
+    to_kb_category_ref,
+    to_kb_ref,
+)
+from frontapp_mcp.services import get_services
+from frontapp_mcp.tools.schemas import confirm_or_preview
+
+
+def _content_preview(content: str | None, max_chars: int = 200) -> str | None:
+    """Truncate content to a short preview for the confirm-gate display."""
+    if content is None:
+        return None
+    if len(content) <= max_chars:
+        return content
+    return content[:max_chars] + "…"
+
+
+def register_tools(mcp: FastMCP) -> None:
+    """Register knowledge_bases-related tools with the FastMCP server."""
+
+    # ------------------------------------------------------------------
+    # Reads
+    # ------------------------------------------------------------------
+
+    @mcp.tool(
+        name="list_knowledge_bases",
+        description=(
+            "List every knowledge base in the workspace. Use to find a "
+            "`knb_*` id before listing articles or categories. Returns "
+            "id + name pairs."
+        ),
+    )
+    async def list_knowledge_bases(context: Context) -> list[KbRef]:
+        services = get_services(context)
+        kbs = await services.client.knowledge_bases.list()
+        return [to_kb_ref(kb) for kb in kbs]
+
+    @mcp.tool(
+        name="get_kb",
+        description=(
+            "Fetch one knowledge base by id. Set `with_content=True` to "
+            "include the localized body; pass `locale='fr'` (or another "
+            "locale code) for non-default locales."
+        ),
+    )
+    async def get_kb(
+        context: Context,
+        knowledge_base_id: Annotated[str, Field(description="`knb_*` id")],
+        with_content: Annotated[
+            bool, Field(description="Include the KB body content.")
+        ] = False,
+        locale: Annotated[
+            str | None,
+            Field(
+                description=("Locale code (e.g. 'en', 'fr'). None = default locale.")
+            ),
+        ] = None,
+    ) -> dict[str, Any]:
+        services = get_services(context)
+        kb = await services.client.knowledge_bases.get(
+            knowledge_base_id, with_content=with_content, locale=locale
+        )
+        return kb.to_dict()
+
+    @mcp.tool(
+        name="list_kb_articles",
+        description=(
+            "List articles in a knowledge base (slim — no body content). "
+            "Cursor-paginated; pass `page_token` from the previous response "
+            "to fetch the next page. Use `get_kb_article(article_id, "
+            "with_content=True)` afterwards to fetch full body for an "
+            "article you've picked."
+        ),
+    )
+    async def list_kb_articles(
+        context: Context,
+        knowledge_base_id: Annotated[str, Field(description="`knb_*` id")],
+        limit: Annotated[
+            int | None, Field(description="Max items per page (default ~50).")
+        ] = None,
+        page_token: Annotated[
+            str | None, Field(description="Cursor from previous page's response.")
+        ] = None,
+    ) -> list[KbArticleSummary]:
+        services = get_services(context)
+        articles = await services.client.knowledge_bases.list_articles(
+            knowledge_base_id, limit=limit, page_token=page_token
+        )
+        return [to_kb_article_summary(a) for a in articles]
+
+    @mcp.tool(
+        name="list_kb_articles_in_category",
+        description=(
+            "List articles within a specific category (slim). Cursor-"
+            "paginated. Use to scope retrieval to a topic-relevant subset "
+            "of the KB."
+        ),
+    )
+    async def list_kb_articles_in_category(
+        context: Context,
+        category_id: Annotated[str, Field(description="`kbc_*` id")],
+        limit: Annotated[int | None, Field(description="Max items per page.")] = None,
+        page_token: Annotated[
+            str | None, Field(description="Cursor from previous page.")
+        ] = None,
+    ) -> list[KbArticleSummary]:
+        services = get_services(context)
+        articles = await services.client.knowledge_bases.list_articles_in_category(
+            category_id, limit=limit, page_token=page_token
+        )
+        return [to_kb_article_summary(a) for a in articles]
+
+    @mcp.tool(
+        name="get_kb_article",
+        description=(
+            "Fetch a single article. By default returns the full body "
+            "content (`with_content=True`) — the agent's primary use "
+            "case is to quote or paraphrase the content. Pass "
+            "`with_content=False` for catalog-style metadata only. "
+            "`locale='fr'` etc. fetches a non-default locale; defaults "
+            "to the workspace's default locale."
+        ),
+    )
+    async def get_kb_article(
+        context: Context,
+        article_id: Annotated[str, Field(description="`kba_*` id")],
+        with_content: Annotated[
+            bool, Field(description="Include body content (default True).")
+        ] = True,
+        locale: Annotated[
+            str | None,
+            Field(description="Locale code; None = default locale."),
+        ] = None,
+    ) -> dict[str, Any]:
+        services = get_services(context)
+        article = await services.client.knowledge_bases.get_article(
+            article_id, with_content=with_content, locale=locale
+        )
+        return article.to_dict()
+
+    @mcp.tool(
+        name="list_kb_categories",
+        description=(
+            "List categories in a knowledge base. Cursor-paginated. Use "
+            "to find a `kbc_*` id before listing articles in a category "
+            "or creating a new article under one."
+        ),
+    )
+    async def list_kb_categories(
+        context: Context,
+        knowledge_base_id: Annotated[str, Field(description="`knb_*` id")],
+        limit: Annotated[int | None, Field(description="Max items per page.")] = None,
+        page_token: Annotated[
+            str | None, Field(description="Cursor from previous page.")
+        ] = None,
+    ) -> list[KbCategoryRef]:
+        services = get_services(context)
+        categories = await services.client.knowledge_bases.list_categories(
+            knowledge_base_id, limit=limit, page_token=page_token
+        )
+        return [to_kb_category_ref(c) for c in categories]
+
+    # ------------------------------------------------------------------
+    # Contribute mutations (drafts only — see module docstring)
+    # ------------------------------------------------------------------
+
+    @mcp.tool(
+        name="create_kb_article",
+        description=(
+            "Create a NEW knowledge-base article AS A DRAFT. The agent "
+            "cannot publish — drafts await human review in Front's UI "
+            "(by design, mirroring drafts-first outbound for replies). "
+            "Two-step confirm: confirm=False returns a preview; "
+            "confirm=True creates the draft."
+        ),
+    )
+    async def create_kb_article(
+        context: Context,
+        knowledge_base_id: Annotated[str, Field(description="`knb_*` id")],
+        subject: Annotated[str | None, Field(description="Article title.")] = None,
+        content: Annotated[
+            str | None,
+            Field(description="Article body (HTML or markdown)."),
+        ] = None,
+        category_id: Annotated[
+            str | None,
+            Field(description="Optional `kbc_*` to file the article under."),
+        ] = None,
+        author_id: Annotated[
+            str | None,
+            Field(description="Optional `tea_*` of the authoring teammate."),
+        ] = None,
+        locale: Annotated[
+            str | None,
+            Field(description="Locale code; None = default locale."),
+        ] = None,
+        confirm: Annotated[
+            bool, Field(description="Must be true to create the draft.")
+        ] = False,
+    ) -> dict[str, Any]:
+        services = get_services(context)
+        preview = {
+            "action": "create_kb_article",
+            "knowledge_base_id": knowledge_base_id,
+            "subject": subject,
+            "body_preview": _content_preview(content),
+            "category_id": category_id,
+            "author_id": author_id,
+            "locale": locale,
+            "status": "draft",  # always — see module docstring
+        }
+        gate = await confirm_or_preview(
+            context,
+            preview=preview,
+            confirm=confirm,
+            elicit_message=(
+                f"Create draft KB article '{subject}' in {knowledge_base_id}?"
+            ),
+        )
+        if gate is not None:
+            return gate
+
+        # Always pass status='draft' — MCP layer never publishes.
+        article = await services.client.knowledge_bases.create_article(
+            knowledge_base_id,
+            subject=subject,
+            content=content,
+            category_id=category_id,
+            author_id=author_id,
+            status="draft",
+            locale=locale,
+        )
+        return {"confirmed": True, "article": article.to_dict()}
+
+    @mcp.tool(
+        name="update_kb_article",
+        description=(
+            "Update an existing KB article. Cannot change `status` — "
+            "the tool preserves whatever publication state the article "
+            "already has. (To publish a draft, a human flips it in "
+            "Front's UI.) Two-step confirm."
+        ),
+    )
+    async def update_kb_article(
+        context: Context,
+        article_id: Annotated[str, Field(description="`kba_*` id")],
+        subject: Annotated[str | None, Field(description="New title.")] = None,
+        content: Annotated[str | None, Field(description="New body content.")] = None,
+        author_id: Annotated[
+            str | None, Field(description="New author `tea_*` id.")
+        ] = None,
+        locale: Annotated[
+            str | None,
+            Field(description="Locale code; None = default locale."),
+        ] = None,
+        confirm: Annotated[bool, Field(description="Must be true to apply.")] = False,
+    ) -> dict[str, Any]:
+        services = get_services(context)
+        preview = {
+            "action": "update_kb_article",
+            "article_id": article_id,
+            "subject": subject,
+            "body_preview": _content_preview(content),
+            "author_id": author_id,
+            "locale": locale,
+            "note": "status unchanged — agents cannot flip draft/published",
+        }
+        gate = await confirm_or_preview(
+            context,
+            preview=preview,
+            confirm=confirm,
+            elicit_message=f"Update KB article {article_id}?",
+        )
+        if gate is not None:
+            return gate
+
+        # Note: status omitted entirely — preserves the article's existing
+        # publication state. Agents cannot publish or unpublish via the
+        # MCP layer; that's a human-in-Front's-UI action.
+        article = await services.client.knowledge_bases.update_article(
+            article_id,
+            subject=subject,
+            content=content,
+            author_id=author_id,
+            status=None,
+            locale=locale,
+        )
+        return {"confirmed": True, "article": article.to_dict()}
+
+    @mcp.tool(
+        name="create_kb_category",
+        description=(
+            "Create a new category within a knowledge base. Categories "
+            "organize articles. Two-step confirm."
+        ),
+    )
+    async def create_kb_category(
+        context: Context,
+        knowledge_base_id: Annotated[str, Field(description="`knb_*` id")],
+        name: Annotated[str, Field(description="Category name.")],
+        parent_category_id: Annotated[
+            str | None,
+            Field(description="Optional parent `kbc_*` for nesting."),
+        ] = None,
+        description: Annotated[
+            str | None,
+            Field(description="Freeform description."),
+        ] = None,
+        locale: Annotated[
+            str | None,
+            Field(description="Locale code; None = default locale."),
+        ] = None,
+        confirm: Annotated[bool, Field(description="Must be true to create.")] = False,
+    ) -> dict[str, Any]:
+        services = get_services(context)
+        preview = {
+            "action": "create_kb_category",
+            "knowledge_base_id": knowledge_base_id,
+            "name": name,
+            "parent_category_id": parent_category_id,
+            "description": description,
+            "locale": locale,
+        }
+        gate = await confirm_or_preview(
+            context,
+            preview=preview,
+            confirm=confirm,
+            elicit_message=f"Create KB category '{name}' in {knowledge_base_id}?",
+        )
+        if gate is not None:
+            return gate
+
+        category = await services.client.knowledge_bases.create_category(
+            knowledge_base_id,
+            name=name,
+            parent_category_id=parent_category_id,
+            description=description,
+            locale=locale,
+        )
+        return {"confirmed": True, "category": category.to_dict()}
+
+    @mcp.tool(
+        name="update_kb_category",
+        description=(
+            "Update an existing KB category (name and/or description). "
+            "Two-step confirm."
+        ),
+    )
+    async def update_kb_category(
+        context: Context,
+        category_id: Annotated[str, Field(description="`kbc_*` id")],
+        name: Annotated[str | None, Field(description="New name.")] = None,
+        description: Annotated[
+            str | None, Field(description="New description.")
+        ] = None,
+        locale: Annotated[
+            str | None,
+            Field(description="Locale code; None = default locale."),
+        ] = None,
+        confirm: Annotated[bool, Field(description="Must be true to apply.")] = False,
+    ) -> dict[str, Any]:
+        services = get_services(context)
+        preview = {
+            "action": "update_kb_category",
+            "category_id": category_id,
+            "name": name,
+            "description": description,
+            "locale": locale,
+        }
+        gate = await confirm_or_preview(
+            context,
+            preview=preview,
+            confirm=confirm,
+            elicit_message=f"Update KB category {category_id}?",
+        )
+        if gate is not None:
+            return gate
+
+        category = await services.client.knowledge_bases.update_category(
+            category_id,
+            name=name,
+            description=description,
+            locale=locale,
+        )
+        return {"confirmed": True, "category": category.to_dict()}

--- a/frontapp_mcp_server/tests/test_knowledge_bases_tools.py
+++ b/frontapp_mcp_server/tests/test_knowledge_bases_tools.py
@@ -1,0 +1,324 @@
+"""Tests for MCP knowledge_bases tools (#83).
+
+Covers the 6 read tools (no confirm) and the 4 contribute mutations
+(two-step confirm). The drafts-only policy is the most important
+property — these tests pin that:
+
+- ``create_kb_article`` always passes ``status="draft"`` to the helper,
+  with no way for the agent to override.
+- ``update_kb_article`` calls the helper with ``status=None`` (the
+  helper treats this as "omit the field from the PATCH body, preserving
+  the existing publication state") — agents cannot flip
+  draft↔published.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from frontapp_mcp.projections import KbArticleSummary, KbCategoryRef, KbRef
+from frontapp_mcp.tools.knowledge_bases import register_tools
+
+from .conftest import create_mock_context
+
+
+@pytest.fixture
+def kb_tools(mcp_tool_capture) -> dict[str, object]:
+    return mcp_tool_capture(register_tools)
+
+
+def _attrs_with_to_dict(payload: dict):
+    """Mock attrs response with a ``to_dict()`` returning ``payload``."""
+    obj = MagicMock()
+    obj.to_dict = lambda: payload
+    return obj
+
+
+# ---------------------------------------------------------------------------
+# Read tools — projection + delegation
+# ---------------------------------------------------------------------------
+
+
+class TestRead:
+    async def test_list_knowledge_bases_projects(self, kb_tools):
+        context, lifespan = create_mock_context()
+        kb = MagicMock()
+        kb.id = "knb_1"
+        kb.type_ = MagicMock(value="external")
+        kb.locales = ["en"]
+        lifespan.client = AsyncMock()
+        lifespan.client.knowledge_bases.list = AsyncMock(return_value=[kb])
+
+        result = await kb_tools["list_knowledge_bases"](context)
+        assert len(result) == 1
+        assert isinstance(result[0], KbRef)
+        assert result[0].id == "knb_1"
+        assert result[0].type == "external"
+
+    async def test_get_kb_returns_dict(self, kb_tools):
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock()
+        lifespan.client.knowledge_bases.get = AsyncMock(
+            return_value=_attrs_with_to_dict({"id": "knb_1", "name": "Public KB"})
+        )
+        result = await kb_tools["get_kb"](
+            context, knowledge_base_id="knb_1", with_content=True
+        )
+        assert result["id"] == "knb_1"
+        assert result["name"] == "Public KB"
+        # Confirm we threaded with_content/locale through.
+        call = lifespan.client.knowledge_bases.get.await_args
+        assert call is not None
+        assert call.kwargs["with_content"] is True
+
+    async def test_list_kb_articles_projects_each(self, kb_tools):
+        context, lifespan = create_mock_context()
+        article = MagicMock()
+        article.id = "kba_1"
+        article.slug = "how-to"
+        article.locales = ["en"]
+        article.updated_at = 1700000000.0
+        lifespan.client = AsyncMock()
+        lifespan.client.knowledge_bases.list_articles = AsyncMock(
+            return_value=[article]
+        )
+
+        result = await kb_tools["list_kb_articles"](context, knowledge_base_id="knb_1")
+        assert len(result) == 1
+        assert isinstance(result[0], KbArticleSummary)
+        assert result[0].id == "kba_1"
+        assert result[0].slug == "how-to"
+
+    async def test_list_kb_articles_in_category(self, kb_tools):
+        context, lifespan = create_mock_context()
+        a = MagicMock()
+        a.id = "kba_1"
+        a.slug = "x"
+        a.locales = ["en"]
+        a.updated_at = None
+        lifespan.client = AsyncMock()
+        lifespan.client.knowledge_bases.list_articles_in_category = AsyncMock(
+            return_value=[a]
+        )
+
+        result = await kb_tools["list_kb_articles_in_category"](
+            context, category_id="kbc_1"
+        )
+        assert len(result) == 1
+        assert result[0].id == "kba_1"
+
+    async def test_get_kb_article_returns_dict(self, kb_tools):
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock()
+        lifespan.client.knowledge_bases.get_article = AsyncMock(
+            return_value=_attrs_with_to_dict(
+                {"id": "kba_1", "name": "Hello", "content": "<p>body</p>"}
+            )
+        )
+
+        result = await kb_tools["get_kb_article"](context, article_id="kba_1")
+        assert result["id"] == "kba_1"
+        assert result["content"] == "<p>body</p>"
+        # Default with_content=True for this tool
+        call = lifespan.client.knowledge_bases.get_article.await_args
+        assert call is not None
+        assert call.kwargs["with_content"] is True
+
+    async def test_list_kb_categories_projects(self, kb_tools):
+        context, lifespan = create_mock_context()
+        cat = MagicMock()
+        cat.id = "kbc_1"
+        cat.slug = "security"
+        cat.is_hidden = False
+        cat.locales = ["en"]
+        lifespan.client = AsyncMock()
+        lifespan.client.knowledge_bases.list_categories = AsyncMock(return_value=[cat])
+
+        result = await kb_tools["list_kb_categories"](
+            context, knowledge_base_id="knb_1"
+        )
+        assert isinstance(result[0], KbCategoryRef)
+        assert result[0].slug == "security"
+        assert result[0].is_hidden is False
+
+
+# ---------------------------------------------------------------------------
+# create_kb_article — DRAFTS ONLY policy
+# ---------------------------------------------------------------------------
+
+
+class TestCreateArticleDraftsOnly:
+    async def test_preview_path_does_not_call_helper(self, kb_tools):
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock(
+            side_effect=AssertionError("client invoked on preview path")
+        )
+
+        result = await kb_tools["create_kb_article"](
+            context,
+            knowledge_base_id="knb_1",
+            subject="Hello",
+            content="body",
+            confirm=False,
+        )
+        assert result["confirmed"] is False
+        # The preview surfaces status: "draft" so the human sees what
+        # publication state will result.
+        assert result["preview"]["status"] == "draft"
+        context.elicit.assert_not_called()
+
+    async def test_confirmed_calls_helper_with_draft_status(self, kb_tools):
+        """The MCP layer's drafts-only policy: status='draft' is hardcoded
+        regardless of any value the agent might try to pass. The tool
+        signature has no `status` parameter."""
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock()
+        lifespan.client.knowledge_bases.create_article = AsyncMock(
+            return_value=_attrs_with_to_dict({"id": "kba_new", "status": "draft"})
+        )
+
+        result = await kb_tools["create_kb_article"](
+            context,
+            knowledge_base_id="knb_1",
+            subject="Hello",
+            content="body",
+            confirm=True,
+        )
+
+        assert result["confirmed"] is True
+        call = lifespan.client.knowledge_bases.create_article.await_args
+        assert call is not None
+        # The crucial assertion for the drafts-only policy.
+        assert call.kwargs["status"] == "draft"
+
+    async def test_tool_signature_has_no_status_arg(self, kb_tools):
+        """Belt-and-suspenders: even if a future change tries to add a
+        status arg, this test catches it."""
+        import inspect
+
+        sig = inspect.signature(kb_tools["create_kb_article"])
+        assert "status" not in sig.parameters
+
+
+# ---------------------------------------------------------------------------
+# update_kb_article — never flips publication state
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateArticleDraftsOnly:
+    async def test_preview_path_does_not_call_helper(self, kb_tools):
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock(
+            side_effect=AssertionError("client invoked on preview path")
+        )
+
+        result = await kb_tools["update_kb_article"](
+            context, article_id="kba_1", subject="new title", confirm=False
+        )
+        assert result["confirmed"] is False
+        # The preview note clarifies that status is preserved.
+        assert "status unchanged" in result["preview"]["note"]
+
+    async def test_confirmed_calls_helper_with_status_none(self, kb_tools):
+        """The MCP layer's drafts-only update policy: status=None is
+        passed to the helper, which omits it from the PATCH body —
+        preserving whatever publication state the article had."""
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock()
+        lifespan.client.knowledge_bases.update_article = AsyncMock(
+            return_value=_attrs_with_to_dict({"id": "kba_1"})
+        )
+
+        await kb_tools["update_kb_article"](
+            context, article_id="kba_1", subject="edited", confirm=True
+        )
+
+        call = lifespan.client.knowledge_bases.update_article.await_args
+        assert call is not None
+        assert call.kwargs["status"] is None
+
+    async def test_tool_signature_has_no_status_arg(self, kb_tools):
+        import inspect
+
+        sig = inspect.signature(kb_tools["update_kb_article"])
+        assert "status" not in sig.parameters
+
+
+# ---------------------------------------------------------------------------
+# Categories — standard preview/confirm flow
+# ---------------------------------------------------------------------------
+
+
+class TestCategoryMutations:
+    async def test_create_kb_category_preview(self, kb_tools):
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock(
+            side_effect=AssertionError("client invoked on preview path")
+        )
+
+        result = await kb_tools["create_kb_category"](
+            context,
+            knowledge_base_id="knb_1",
+            name="Security",
+            confirm=False,
+        )
+        assert result["confirmed"] is False
+        assert result["preview"]["name"] == "Security"
+
+    async def test_create_kb_category_confirmed(self, kb_tools):
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock()
+        lifespan.client.knowledge_bases.create_category = AsyncMock(
+            return_value=_attrs_with_to_dict({"id": "kbc_new", "name": "Security"})
+        )
+
+        result = await kb_tools["create_kb_category"](
+            context,
+            knowledge_base_id="knb_1",
+            name="Security",
+            confirm=True,
+        )
+        assert result["confirmed"] is True
+        call = lifespan.client.knowledge_bases.create_category.await_args
+        assert call is not None
+        assert call.kwargs["name"] == "Security"
+
+    async def test_update_kb_category_omits_unset_fields(self, kb_tools):
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock()
+        lifespan.client.knowledge_bases.update_category = AsyncMock(
+            return_value=_attrs_with_to_dict({"id": "kbc_1", "name": "Renamed"})
+        )
+
+        await kb_tools["update_kb_category"](
+            context, category_id="kbc_1", name="Renamed", confirm=True
+        )
+        call = lifespan.client.knowledge_bases.update_category.await_args
+        assert call is not None
+        assert call.kwargs["name"] == "Renamed"
+        assert call.kwargs["description"] is None
+
+
+# ---------------------------------------------------------------------------
+# Decline path
+# ---------------------------------------------------------------------------
+
+
+class TestDeclinedElicitation:
+    async def test_create_article_declined_does_not_call_helper(self, kb_tools):
+        context, lifespan = create_mock_context(elicit_confirm=False)
+        lifespan.client = AsyncMock(
+            side_effect=AssertionError("client invoked after decline")
+        )
+
+        result = await kb_tools["create_kb_article"](
+            context,
+            knowledge_base_id="knb_1",
+            subject="x",
+            content="y",
+            confirm=True,
+        )
+        assert result["confirmed"] is False
+        assert result["result"] == "cancelled"
+        context.elicit.assert_called_once()

--- a/frontapp_public_api_client/docs/guide.md
+++ b/frontapp_public_api_client/docs/guide.md
@@ -60,19 +60,20 @@ async with FrontappClient() as client:
 
 ## Available helpers today
 
-| Helper                  | Status     | Covers                                                                                                                                                               |
-| ----------------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `client.conversations`  | ✅ shipped | list/get/search/update/reply/list_messages/list_comments/add_comment                                                                                                 |
-| `client.drafts`         | ✅ shipped | list_for_conversation/create_on_channel/create_reply/edit/delete                                                                                                     |
-| `client.contacts`       | ✅ shipped | list/get/search_by_email/list_for_team/list_for_teammate/list_conversations/list_notes/create (+team/teammate)/update/merge/delete/add_note/add_handle/delete_handle |
-| `client.contact_lists`  | ✅ shipped | list/list_for_team/list_for_teammate/list_members/create (+team/teammate)/delete/add_contacts/remove_contacts                                                        |
-| `client.contact_groups` | ✅ shipped | Same shape as contact_lists. **Front has deprecated this surface** — prefer contact_lists for new code                                                               |
-| `client.messages`       | ✅ shipped | get/seen_status/mark_seen                                                                                                                                            |
-| `client.tags`           | ✅ shipped | list (+ company/team/teammate scopes)/get/list_children/list_tagged_conversations/apply_to_conversation/remove_from_conversation/create/create_child/update/delete   |
-| `client.inboxes`        | ✅ shipped | list (+ team/teammate scopes)/get/list_conversations/list_channels/list_access/create (+ team)/grant_access/revoke_access                                            |
-| `client.teammates`      | ✅ shipped | list/get/list_inboxes/list_assigned_conversations/update                                                                                                             |
-| `client.attachments`    | ✅ shipped | download/stream + `attachments=[FileSpec(...)]` parameter on every draft / reply / comment helper                                                                    |
-| `client.analytics`      | ✅ shipped | create*report/get_report/run_report + create_export/get_export/run_export. The `run*\*` methods wrap the create-then-poll loop into a single call.                   |
+| Helper                   | Status     | Covers                                                                                                                                                                                                                                                                                                |
+| ------------------------ | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `client.conversations`   | ✅ shipped | list/get/search/update/reply/list_messages/list_comments/add_comment                                                                                                                                                                                                                                  |
+| `client.drafts`          | ✅ shipped | list_for_conversation/create_on_channel/create_reply/edit/delete                                                                                                                                                                                                                                      |
+| `client.contacts`        | ✅ shipped | list/get/search_by_email/list_for_team/list_for_teammate/list_conversations/list_notes/create (+team/teammate)/update/merge/delete/add_note/add_handle/delete_handle                                                                                                                                  |
+| `client.contact_lists`   | ✅ shipped | list/list_for_team/list_for_teammate/list_members/create (+team/teammate)/delete/add_contacts/remove_contacts                                                                                                                                                                                         |
+| `client.contact_groups`  | ✅ shipped | Same shape as contact_lists. **Front has deprecated this surface** — prefer contact_lists for new code                                                                                                                                                                                                |
+| `client.messages`        | ✅ shipped | get/seen_status/mark_seen                                                                                                                                                                                                                                                                             |
+| `client.tags`            | ✅ shipped | list (+ company/team/teammate scopes)/get/list_children/list_tagged_conversations/apply_to_conversation/remove_from_conversation/create/create_child/update/delete                                                                                                                                    |
+| `client.inboxes`         | ✅ shipped | list (+ team/teammate scopes)/get/list_conversations/list_channels/list_access/create (+ team)/grant_access/revoke_access                                                                                                                                                                             |
+| `client.teammates`       | ✅ shipped | list/get/list_inboxes/list_assigned_conversations/update                                                                                                                                                                                                                                              |
+| `client.attachments`     | ✅ shipped | download/stream + `attachments=[FileSpec(...)]` parameter on every draft / reply / comment helper                                                                                                                                                                                                     |
+| `client.analytics`       | ✅ shipped | create*report/get_report/run_report + create_export/get_export/run_export. The `run*\*` methods wrap the create-then-poll loop into a single call.                                                                                                                                                    |
+| `client.knowledge_bases` | ✅ shipped | list/get + list/iter articles + list/iter categories (with optional `with_content` and `locale` args) + create*article/update_article/create_category/update_category. Hides the `\_a*`infix and the locale-default vs locale-specified split (single`locale=None` kwarg routes to the right module). |
 
 Outbound replies go through `client.drafts.create_reply(...)` rather than
 `client.conversations.reply(...)` — the latter still exists at the helper level for
@@ -301,6 +302,43 @@ keeps running on Front; resume with `client.analytics.get_report(uid)`). It rais
 `APIError` if Front returns `status: "failed"`. The same shape applies to
 `run_export(body, ...)` for `/analytics/exports`, plus a `too_big` terminal status that
 maps to `APIError` with a date-range narrowing hint.
+
+### Read & contribute to a knowledge base
+
+The `client.knowledge_bases` helper covers retrieval (browse + read articles for
+paraphrasing into replies) and contribute (create new articles, update existing ones).
+
+```python
+async with FrontappClient() as client:
+    # Retrieval: pick a KB, walk its articles, fetch one in full.
+    kbs = await client.knowledge_bases.list()
+    async for slim in client.knowledge_bases.iter_articles(kbs[0].id):
+        if slim.slug == "how-to-reset-2fa":
+            article = await client.knowledge_bases.get_article(
+                slim.id, with_content=True
+            )
+            print(article.content)
+            break
+
+    # Contribute: file a new article as a draft.
+    new_article = await client.knowledge_bases.create_article(
+        kbs[0].id,
+        subject="How to reset 2FA when phone is lost",
+        content="<p>Step-by-step guide…</p>",
+        category_id="kbc_security",
+        # status defaults to "draft" — see policy note below.
+    )
+    print(new_article.id, new_article.status)  # "kba_new", "draft"
+```
+
+The `status` kwarg on `create_article` defaults to `"draft"` (matching the typical
+agent-authored-content pattern). Library callers can pass `status="published"`
+explicitly if they want to publish — but the MCP tool layer locks this down to drafts
+only (mirroring ADR-0016's drafts-first outbound philosophy applied to KB content). See
+issue \#83 for the full policy.
+
+The `locale=None` kwarg on every read/write method routes to Front's default-locale
+endpoint; pass `locale="fr"` (or another locale code) to hit the per-locale variant.
 
 ### Raw generated API for uncovered resources
 

--- a/frontapp_public_api_client/frontapp_client.py
+++ b/frontapp_public_api_client/frontapp_client.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     from .helpers.conversations import Conversations
     from .helpers.drafts import Drafts
     from .helpers.inboxes import Inboxes
+    from .helpers.knowledge_bases import KnowledgeBases
     from .helpers.messages import Messages
     from .helpers.tags import Tags
     from .helpers.teammates import Teammates
@@ -564,6 +565,7 @@ class FrontappClient(AuthenticatedClient):
         self._messages: Messages | None = None
         self._tags: Tags | None = None
         self._inboxes: Inboxes | None = None
+        self._knowledge_bases: KnowledgeBases | None = None
         self._teammates: Teammates | None = None
 
         # Extract client-level parameters that shouldn't go to the transport
@@ -786,6 +788,27 @@ class FrontappClient(AuthenticatedClient):
         if self._inboxes is None:
             self._inboxes = Inboxes(self)
         return self._inboxes
+
+    @property
+    def knowledge_bases(self) -> "KnowledgeBases":
+        """Ergonomic operations over Front's knowledge_bases surface.
+
+        Covers the read + contribute path: list KBs, list / iter / get
+        articles + categories (with optional ``with_content`` and
+        ``locale`` arguments), create / update articles + categories.
+        Pure-admin operations (KB-create, deletes) are deferred to
+        issue #87.
+
+        See ``helpers.knowledge_bases`` for the full method list and
+        the locale-routing behavior. Note: the ``status`` argument on
+        ``create_article`` defaults to ``"draft"`` — agent-authored
+        content stays unpublished until a human reviews.
+        """
+        from .helpers.knowledge_bases import KnowledgeBases
+
+        if self._knowledge_bases is None:
+            self._knowledge_bases = KnowledgeBases(self)
+        return self._knowledge_bases
 
     @property
     def teammates(self) -> "Teammates":

--- a/frontapp_public_api_client/helpers/__init__.py
+++ b/frontapp_public_api_client/helpers/__init__.py
@@ -18,6 +18,7 @@ from frontapp_public_api_client.helpers.contacts import Contacts
 from frontapp_public_api_client.helpers.conversations import Conversations
 from frontapp_public_api_client.helpers.drafts import Drafts
 from frontapp_public_api_client.helpers.inboxes import Inboxes
+from frontapp_public_api_client.helpers.knowledge_bases import KnowledgeBases
 from frontapp_public_api_client.helpers.messages import Messages
 from frontapp_public_api_client.helpers.tags import Tags
 from frontapp_public_api_client.helpers.teammates import Teammates
@@ -34,6 +35,7 @@ __all__ = [
     "Drafts",
     "FileSpec",
     "Inboxes",
+    "KnowledgeBases",
     "Messages",
     "Tags",
     "Teammates",

--- a/frontapp_public_api_client/helpers/knowledge_bases.py
+++ b/frontapp_public_api_client/helpers/knowledge_bases.py
@@ -1,0 +1,594 @@
+"""Knowledge Base helper facade — reads + contribute path.
+
+Wraps Front's three KB-tagged generated modules (`knowledge_bases`,
+`knowledge_base_articles`, `knowledge_base_categories`) into one
+ergonomic surface. Two distinct workflows the same helper supports:
+
+1. **Retrieval** (read): list KBs → list categories → list / iter
+   articles → get article body. Used to surface relevant KB content
+   during a conversation or paraphrase into a reply.
+2. **Contribute** (mutate): create article, update article (with
+   locale-aware content), create category, update category. Used to
+   convert a conversation resolution into a new KB article, or amend
+   an existing article with new info.
+
+The helper hides two generated-API quirks from callers:
+
+- **`_a_` infix** on 11 of the 26 KB modules
+  (`get_a_knowledge_base_article`, `list_articles_in_a_knowledge_base`,
+  etc.). Callers see `get_article(article_id)`,
+  `list_articles(knowledge_base_id)`.
+- **Locale variants**: every read-with-content / create / update has
+  a default-locale and a specified-locale generated module. The helper
+  takes a single ``locale=None`` argument that routes to the right
+  module — ``locale=None`` hits the default-locale variant; any other
+  value (e.g. ``locale="fr"``) hits the specified-locale variant.
+
+Out of scope (covered by issue #87):
+
+- ``create_a_knowledge_base`` / ``update_knowledge_base*`` (KB-level admin)
+- ``delete_an_article`` / ``delete_a_knowledge_base_category`` (destructive)
+"""
+
+from __future__ import annotations
+
+import builtins
+from collections.abc import AsyncIterator
+from typing import TYPE_CHECKING, Literal
+
+from frontapp_public_api_client.helpers.base import Base
+
+if TYPE_CHECKING:
+    from frontapp_public_api_client.models.knowledge_base_article_response import (
+        KnowledgeBaseArticleResponse,
+    )
+    from frontapp_public_api_client.models.knowledge_base_article_slim_response import (
+        KnowledgeBaseArticleSlimResponse,
+    )
+    from frontapp_public_api_client.models.knowledge_base_category_response import (
+        KnowledgeBaseCategoryResponse,
+    )
+    from frontapp_public_api_client.models.knowledge_base_category_slim_response import (
+        KnowledgeBaseCategorySlimResponse,
+    )
+    from frontapp_public_api_client.models.knowledge_base_response import (
+        KnowledgeBaseResponse,
+    )
+    from frontapp_public_api_client.models.knowledge_base_slim_response import (
+        KnowledgeBaseSlimResponse,
+    )
+
+
+class KnowledgeBases(Base):
+    """Ergonomic operations over Front's ``/knowledge_bases*`` endpoints."""
+
+    # -- knowledge bases ----------------------------------------------------
+
+    async def list(self) -> builtins.list[KnowledgeBaseSlimResponse]:
+        """List every knowledge base in the workspace.
+
+        Front's ``/knowledge_bases`` endpoint is a flat list with no
+        pagination — returns all KBs in one response. Callers that need
+        to walk a *very* large set should fall back to the generated
+        endpoint directly (they would have already seen this comment if
+        they did).
+        """
+        from frontapp_public_api_client.api.knowledge_bases import (
+            list_knowledge_bases,
+        )
+        from frontapp_public_api_client.utils import unwrap
+
+        response = await list_knowledge_bases.asyncio_detailed(client=self._client)
+        parsed = unwrap(response)
+        return list(getattr(parsed, "field_results", None) or [])
+
+    async def get(
+        self,
+        knowledge_base_id: str,
+        *,
+        with_content: bool = False,
+        locale: str | None = None,
+    ) -> KnowledgeBaseSlimResponse | KnowledgeBaseResponse:
+        """Fetch one knowledge base.
+
+        Args:
+            knowledge_base_id: ``knb_*`` id.
+            with_content: When ``True``, returns the full
+                ``KnowledgeBaseResponse`` (including localized body).
+                When ``False`` (default), returns the slim variant
+                without body content.
+            locale: When ``with_content=True``, ``None`` (default) hits
+                the default-locale endpoint; any other value hits the
+                specified-locale variant. Ignored when
+                ``with_content=False``.
+        """
+        from frontapp_public_api_client.utils import unwrap_as
+
+        if with_content:
+            from frontapp_public_api_client.models.knowledge_base_response import (
+                KnowledgeBaseResponse,
+            )
+
+            if locale is None:
+                from frontapp_public_api_client.api.knowledge_bases import (
+                    get_a_knowledge_base_with_content_in_default_locale as _get,
+                )
+
+                response = await _get.asyncio_detailed(
+                    knowledge_base_id, client=self._client
+                )
+            else:
+                from frontapp_public_api_client.api.knowledge_bases import (
+                    get_a_knowledge_base_with_content_in_specified_locale as _get,
+                )
+
+                response = await _get.asyncio_detailed(
+                    knowledge_base_id, locale, client=self._client
+                )
+            return unwrap_as(response, KnowledgeBaseResponse)
+
+        from frontapp_public_api_client.api.knowledge_bases import get_a_knowledge_base
+        from frontapp_public_api_client.models.knowledge_base_slim_response import (
+            KnowledgeBaseSlimResponse,
+        )
+
+        response = await get_a_knowledge_base.asyncio_detailed(
+            knowledge_base_id, client=self._client
+        )
+        return unwrap_as(response, KnowledgeBaseSlimResponse)
+
+    # -- articles -----------------------------------------------------------
+
+    async def list_articles(
+        self,
+        knowledge_base_id: str,
+        *,
+        limit: int | None = None,
+        page_token: str | None = None,
+    ) -> builtins.list[KnowledgeBaseArticleSlimResponse]:
+        """List one page of articles in a KB (cursor-paginated)."""
+        from frontapp_public_api_client.api.knowledge_base_articles import (
+            list_articles_in_a_knowledge_base,
+        )
+        from frontapp_public_api_client.domain.converters import to_unset
+        from frontapp_public_api_client.utils import unwrap
+
+        response = await list_articles_in_a_knowledge_base.asyncio_detailed(
+            knowledge_base_id,
+            client=self._client,
+            limit=to_unset(limit),
+            page_token=to_unset(page_token),
+        )
+        parsed = unwrap(response)
+        return list(getattr(parsed, "field_results", None) or [])
+
+    async def iter_articles(
+        self,
+        knowledge_base_id: str,
+        *,
+        limit: int | None = None,
+        max_pages: int | None = None,
+        max_items: int | None = None,
+    ) -> AsyncIterator[KnowledgeBaseArticleSlimResponse]:
+        """Walk every article in a KB, paginated.
+
+        Yields slim article responses (no content body). Use
+        ``get_article(id, with_content=True)`` to fetch the full body
+        for a single article after picking it from the list.
+        """
+        from frontapp_public_api_client.api.knowledge_base_articles import (
+            list_articles_in_a_knowledge_base,
+        )
+        from frontapp_public_api_client.domain.converters import to_unset
+
+        async for item in self._paginate(
+            list_articles_in_a_knowledge_base.asyncio_detailed,
+            max_items=max_items,
+            max_pages=max_pages,
+            knowledge_base_id=knowledge_base_id,
+            limit=to_unset(limit),
+        ):
+            yield item
+
+    async def list_articles_in_category(
+        self,
+        category_id: str,
+        *,
+        limit: int | None = None,
+        page_token: str | None = None,
+    ) -> builtins.list[KnowledgeBaseArticleSlimResponse]:
+        """List one page of articles under a specific category."""
+        from frontapp_public_api_client.api.knowledge_base_articles import (
+            list_articles_in_a_category,
+        )
+        from frontapp_public_api_client.domain.converters import to_unset
+        from frontapp_public_api_client.utils import unwrap
+
+        response = await list_articles_in_a_category.asyncio_detailed(
+            category_id,
+            client=self._client,
+            limit=to_unset(limit),
+            page_token=to_unset(page_token),
+        )
+        parsed = unwrap(response)
+        return list(getattr(parsed, "field_results", None) or [])
+
+    async def iter_articles_in_category(
+        self,
+        category_id: str,
+        *,
+        limit: int | None = None,
+        max_pages: int | None = None,
+        max_items: int | None = None,
+    ) -> AsyncIterator[KnowledgeBaseArticleSlimResponse]:
+        """Walk every article in a category, paginated."""
+        from frontapp_public_api_client.api.knowledge_base_articles import (
+            list_articles_in_a_category,
+        )
+        from frontapp_public_api_client.domain.converters import to_unset
+
+        async for item in self._paginate(
+            list_articles_in_a_category.asyncio_detailed,
+            max_items=max_items,
+            max_pages=max_pages,
+            category_id=category_id,
+            limit=to_unset(limit),
+        ):
+            yield item
+
+    async def get_article(
+        self,
+        article_id: str,
+        *,
+        with_content: bool = False,
+        locale: str | None = None,
+    ) -> KnowledgeBaseArticleSlimResponse | KnowledgeBaseArticleResponse:
+        """Fetch one article.
+
+        Args:
+            article_id: ``kba_*`` id.
+            with_content: When ``True``, returns the full
+                ``KnowledgeBaseArticleResponse`` including the body.
+                When ``False`` (default), returns the slim variant
+                without body — useful for catalog browsing.
+            locale: When ``with_content=True``, ``None`` (default) hits
+                the default-locale endpoint; any other value hits the
+                specified-locale variant. Ignored when
+                ``with_content=False``.
+        """
+        from frontapp_public_api_client.utils import unwrap_as
+
+        if with_content:
+            from frontapp_public_api_client.models.knowledge_base_article_response import (
+                KnowledgeBaseArticleResponse,
+            )
+
+            if locale is None:
+                from frontapp_public_api_client.api.knowledge_base_articles import (
+                    get_knowledge_base_article_with_content_in_default_locale as _get,
+                )
+
+                response = await _get.asyncio_detailed(article_id, client=self._client)
+            else:
+                from frontapp_public_api_client.api.knowledge_base_articles import (
+                    get_knowledge_base_article_with_content_in_specified_locale as _get,
+                )
+
+                response = await _get.asyncio_detailed(
+                    article_id, locale, client=self._client
+                )
+            return unwrap_as(response, KnowledgeBaseArticleResponse)
+
+        from frontapp_public_api_client.api.knowledge_base_articles import (
+            get_a_knowledge_base_article,
+        )
+        from frontapp_public_api_client.models.knowledge_base_article_slim_response import (
+            KnowledgeBaseArticleSlimResponse,
+        )
+
+        response = await get_a_knowledge_base_article.asyncio_detailed(
+            article_id, client=self._client
+        )
+        return unwrap_as(response, KnowledgeBaseArticleSlimResponse)
+
+    async def create_article(
+        self,
+        knowledge_base_id: str,
+        *,
+        subject: str | None = None,
+        content: str | None = None,
+        category_id: str | None = None,
+        author_id: str | None = None,
+        status: Literal["draft", "published"] = "draft",
+        locale: str | None = None,
+    ) -> KnowledgeBaseArticleResponse:
+        """Create a new article in a knowledge base.
+
+        Args:
+            knowledge_base_id: ``knb_*`` id.
+            subject: Article title.
+            content: Article body (HTML or markdown — Front renders both).
+            category_id: Optional category to file the article under.
+            author_id: Optional ``tea_*`` id of the authoring teammate.
+            status: ``"draft"`` (default) or ``"published"``.
+                ``"draft"`` is the safer default for agent-authored content.
+            locale: ``None`` (default) hits the default-locale endpoint;
+                any other value hits the specified-locale variant.
+        """
+        from frontapp_public_api_client.domain.converters import to_unset
+        from frontapp_public_api_client.models.knowledge_base_article_create import (
+            KnowledgeBaseArticleCreate,
+        )
+        from frontapp_public_api_client.models.knowledge_base_article_create_status import (
+            KnowledgeBaseArticleCreateStatus,
+        )
+        from frontapp_public_api_client.models.knowledge_base_article_response import (
+            KnowledgeBaseArticleResponse,
+        )
+        from frontapp_public_api_client.utils import unwrap_as
+
+        body = KnowledgeBaseArticleCreate(
+            category_id=to_unset(category_id),
+            author_id=to_unset(author_id),
+            subject=to_unset(subject),
+            content=to_unset(content),
+            status=KnowledgeBaseArticleCreateStatus(status),
+        )
+
+        if locale is None:
+            from frontapp_public_api_client.api.knowledge_bases import (
+                create_article_in_a_knowledge_base_in_default_locale as _create,
+            )
+
+            response = await _create.asyncio_detailed(
+                knowledge_base_id, client=self._client, body=body
+            )
+        else:
+            from frontapp_public_api_client.api.knowledge_bases import (
+                create_article_in_a_knowledge_base_in_specified_locale as _create,
+            )
+
+            response = await _create.asyncio_detailed(
+                knowledge_base_id, locale, client=self._client, body=body
+            )
+        return unwrap_as(response, KnowledgeBaseArticleResponse)
+
+    async def update_article(
+        self,
+        article_id: str,
+        *,
+        subject: str | None = None,
+        content: str | None = None,
+        author_id: str | None = None,
+        status: Literal["draft", "published"] | None = None,
+        locale: str | None = None,
+    ) -> KnowledgeBaseArticleResponse:
+        """Update an existing article.
+
+        Only fields explicitly passed are sent in the PATCH; omitted
+        fields preserve their current value (including ``status`` —
+        leave it ``None`` to avoid flipping draft↔published).
+        """
+        from frontapp_public_api_client.domain.converters import to_unset
+        from frontapp_public_api_client.models.knowledge_base_article_patch import (
+            KnowledgeBaseArticlePatch,
+        )
+        from frontapp_public_api_client.models.knowledge_base_article_patch_status import (
+            KnowledgeBaseArticlePatchStatus,
+        )
+        from frontapp_public_api_client.models.knowledge_base_article_response import (
+            KnowledgeBaseArticleResponse,
+        )
+        from frontapp_public_api_client.utils import unwrap_as
+
+        body = KnowledgeBaseArticlePatch(
+            author_id=to_unset(author_id),
+            subject=to_unset(subject),
+            content=to_unset(content),
+            status=(
+                KnowledgeBaseArticlePatchStatus(status)
+                if status is not None
+                else to_unset(None)
+            ),
+        )
+
+        if locale is None:
+            from frontapp_public_api_client.api.knowledge_base_articles import (
+                update_article_content_in_default_locale as _update,
+            )
+
+            response = await _update.asyncio_detailed(
+                article_id, client=self._client, body=body
+            )
+        else:
+            from frontapp_public_api_client.api.knowledge_base_articles import (
+                update_article_content_in_specified_locale as _update,
+            )
+
+            response = await _update.asyncio_detailed(
+                article_id, locale, client=self._client, body=body
+            )
+        return unwrap_as(response, KnowledgeBaseArticleResponse)
+
+    # -- categories ---------------------------------------------------------
+
+    async def list_categories(
+        self,
+        knowledge_base_id: str,
+        *,
+        limit: int | None = None,
+        page_token: str | None = None,
+    ) -> builtins.list[KnowledgeBaseCategorySlimResponse]:
+        """List one page of categories in a KB (cursor-paginated)."""
+        from frontapp_public_api_client.api.knowledge_base_categories import (
+            list_categories_in_a_knowledge_base,
+        )
+        from frontapp_public_api_client.domain.converters import to_unset
+        from frontapp_public_api_client.utils import unwrap
+
+        response = await list_categories_in_a_knowledge_base.asyncio_detailed(
+            knowledge_base_id,
+            client=self._client,
+            limit=to_unset(limit),
+            page_token=to_unset(page_token),
+        )
+        parsed = unwrap(response)
+        return list(getattr(parsed, "field_results", None) or [])
+
+    async def iter_categories(
+        self,
+        knowledge_base_id: str,
+        *,
+        limit: int | None = None,
+        max_pages: int | None = None,
+        max_items: int | None = None,
+    ) -> AsyncIterator[KnowledgeBaseCategorySlimResponse]:
+        """Walk every category in a KB, paginated."""
+        from frontapp_public_api_client.api.knowledge_base_categories import (
+            list_categories_in_a_knowledge_base,
+        )
+        from frontapp_public_api_client.domain.converters import to_unset
+
+        async for item in self._paginate(
+            list_categories_in_a_knowledge_base.asyncio_detailed,
+            max_items=max_items,
+            max_pages=max_pages,
+            knowledge_base_id=knowledge_base_id,
+            limit=to_unset(limit),
+        ):
+            yield item
+
+    async def get_category(
+        self,
+        category_id: str,
+        *,
+        with_content: bool = False,
+        locale: str | None = None,
+    ) -> KnowledgeBaseCategorySlimResponse | KnowledgeBaseCategoryResponse:
+        """Fetch one category.
+
+        ``with_content=True`` returns the localized full response;
+        ``with_content=False`` (default) returns the slim variant.
+        """
+        from frontapp_public_api_client.utils import unwrap_as
+
+        if with_content:
+            from frontapp_public_api_client.models.knowledge_base_category_response import (
+                KnowledgeBaseCategoryResponse,
+            )
+
+            if locale is None:
+                from frontapp_public_api_client.api.knowledge_base_categories import (
+                    get_knowledge_base_category_content_in_default_locale as _get,
+                )
+
+                response = await _get.asyncio_detailed(category_id, client=self._client)
+            else:
+                from frontapp_public_api_client.api.knowledge_base_categories import (
+                    get_knowledge_base_category_with_content_in_specified_locale as _get,
+                )
+
+                response = await _get.asyncio_detailed(
+                    category_id, locale, client=self._client
+                )
+            return unwrap_as(response, KnowledgeBaseCategoryResponse)
+
+        from frontapp_public_api_client.api.knowledge_base_categories import (
+            get_a_knowledge_base_category,
+        )
+        from frontapp_public_api_client.models.knowledge_base_category_slim_response import (
+            KnowledgeBaseCategorySlimResponse,
+        )
+
+        response = await get_a_knowledge_base_category.asyncio_detailed(
+            category_id, client=self._client
+        )
+        return unwrap_as(response, KnowledgeBaseCategorySlimResponse)
+
+    async def create_category(
+        self,
+        knowledge_base_id: str,
+        *,
+        name: str,
+        parent_category_id: str | None = None,
+        description: str | None = None,
+        locale: str | None = None,
+    ) -> KnowledgeBaseCategoryResponse:
+        """Create a new category in a knowledge base.
+
+        ``name`` is required. ``parent_category_id`` allows nesting
+        under an existing category; ``description`` is freeform text.
+        """
+        from frontapp_public_api_client.domain.converters import to_unset
+        from frontapp_public_api_client.models.knowledge_base_category_create import (
+            KnowledgeBaseCategoryCreate,
+        )
+        from frontapp_public_api_client.models.knowledge_base_category_response import (
+            KnowledgeBaseCategoryResponse,
+        )
+        from frontapp_public_api_client.utils import unwrap_as
+
+        body = KnowledgeBaseCategoryCreate(
+            name=name,
+            parent_category_id=to_unset(parent_category_id),
+            description=to_unset(description),
+        )
+
+        if locale is None:
+            from frontapp_public_api_client.api.knowledge_bases import (
+                create_knowledge_base_category_in_default_locale as _create,
+            )
+
+            response = await _create.asyncio_detailed(
+                knowledge_base_id, client=self._client, body=body
+            )
+        else:
+            from frontapp_public_api_client.api.knowledge_bases import (
+                create_knowledge_base_category_in_specified_locale as _create,
+            )
+
+            response = await _create.asyncio_detailed(
+                knowledge_base_id, locale, client=self._client, body=body
+            )
+        return unwrap_as(response, KnowledgeBaseCategoryResponse)
+
+    async def update_category(
+        self,
+        category_id: str,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+        locale: str | None = None,
+    ) -> KnowledgeBaseCategoryResponse:
+        """Update an existing category. Only specified fields are sent."""
+        from frontapp_public_api_client.domain.converters import to_unset
+        from frontapp_public_api_client.models.knowledge_base_category_patch import (
+            KnowledgeBaseCategoryPatch,
+        )
+        from frontapp_public_api_client.models.knowledge_base_category_response import (
+            KnowledgeBaseCategoryResponse,
+        )
+        from frontapp_public_api_client.utils import unwrap_as
+
+        body = KnowledgeBaseCategoryPatch(
+            name=to_unset(name),
+            description=to_unset(description),
+        )
+
+        if locale is None:
+            from frontapp_public_api_client.api.knowledge_base_categories import (
+                update_knowledge_base_category_in_default_locale as _update,
+            )
+
+            response = await _update.asyncio_detailed(
+                category_id, client=self._client, body=body
+            )
+        else:
+            from frontapp_public_api_client.api.knowledge_base_categories import (
+                update_knowledge_base_category_in_specified_locale as _update,
+            )
+
+            response = await _update.asyncio_detailed(
+                category_id, locale, client=self._client, body=body
+            )
+        return unwrap_as(response, KnowledgeBaseCategoryResponse)

--- a/tests/test_knowledge_bases.py
+++ b/tests/test_knowledge_bases.py
@@ -1,0 +1,444 @@
+"""Tests for the knowledge_bases vertical: KnowledgeBases helper.
+
+Covers the read + contribute path. The helper hides two generated-API
+quirks (the `_a_` infix on 11 modules and the locale-default vs
+locale-specified split); these tests pin both:
+
+- Locale routing: ``locale=None`` hits default-locale endpoints;
+  ``locale='fr'`` hits specified-locale endpoints (verified by the
+  mocked URL path).
+- ``with_content`` routing on get / get_article / get_category.
+- ``create_article`` defaults to ``status='draft'`` and accepts
+  ``status='published'`` (helper-level — the MCP tool layer is what
+  locks down draft-only).
+- ``update_article`` with ``status=None`` omits `status` from the
+  PATCH body (preserving the existing publication state).
+- Pagination: `iter_articles` walks `_pagination.next` correctly.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from frontapp_public_api_client.helpers.knowledge_bases import KnowledgeBases
+from frontapp_public_api_client.models.knowledge_base_article_response import (
+    KnowledgeBaseArticleResponse,
+)
+from frontapp_public_api_client.models.knowledge_base_article_slim_response import (
+    KnowledgeBaseArticleSlimResponse,
+)
+from frontapp_public_api_client.models.knowledge_base_category_response import (
+    KnowledgeBaseCategoryResponse,
+)
+from frontapp_public_api_client.models.knowledge_base_slim_response import (
+    KnowledgeBaseSlimResponse,
+)
+
+# ---------------------------------------------------------------------------
+# Test fixtures + helpers
+# ---------------------------------------------------------------------------
+
+
+def _kb_payload(id_: str = "knb_1") -> dict:
+    """Slim KB shape — required: _links, id, type, locales."""
+    return {
+        "_links": {"self": "https://x", "related": {}},
+        "id": id_,
+        "type": "external",
+        "locales": ["en"],
+    }
+
+
+def _kb_full_payload(id_: str = "knb_1", name: str = "Public KB") -> dict:
+    """Full KB shape — required: _links, id, name, status, type, locale."""
+    return {
+        "_links": {"self": "https://x", "related": {}},
+        "id": id_,
+        "name": name,
+        "status": "published",
+        "type": "external",
+        "locale": "en",
+    }
+
+
+def _article_slim_payload(id_: str = "kba_1", slug: str = "how-to") -> dict:
+    """Slim article shape — required: _links, id, slug, locales."""
+    return {
+        "_links": {"self": "https://x", "related": {}},
+        "id": id_,
+        "slug": slug,
+        "locales": ["en"],
+    }
+
+
+def _article_full_payload(
+    id_: str = "kba_1", subject: str = "How to", body: str = "<p>body</p>"
+) -> dict:
+    """Full article shape — required: _links, id, slug, name, status,
+    keywords, content, locale, attachments."""
+    return {
+        "_links": {"self": "https://x", "related": {}},
+        "id": id_,
+        "slug": subject.lower().replace(" ", "-"),
+        "name": subject,
+        "status": "draft",
+        "keywords": [],
+        "content": body,
+        "locale": "en",
+        "attachments": [],
+    }
+
+
+def _category_slim_payload(id_: str = "kbc_1", slug: str = "cat") -> dict:
+    """Slim category shape — required: _links, id, slug, is_hidden, locales."""
+    return {
+        "_links": {"self": "https://x", "related": {}},
+        "id": id_,
+        "slug": slug,
+        "is_hidden": False,
+        "locales": ["en"],
+    }
+
+
+def _category_full_payload(id_: str = "kbc_1", name: str = "Cat") -> dict:
+    """Full category shape — required: _links, id, name, description,
+    is_hidden, locale."""
+    return {
+        "_links": {"self": "https://x", "related": {}},
+        "id": id_,
+        "name": name,
+        "description": "desc",
+        "is_hidden": False,
+        "locale": "en",
+    }
+
+
+def _record(transport_handler):
+    """Wrap a handler so we can record the request URL + method + body."""
+    recorded: list[httpx.Request] = []
+
+    def wrapper(request: httpx.Request) -> httpx.Response:
+        recorded.append(request)
+        return transport_handler(request)
+
+    return httpx.MockTransport(wrapper), recorded
+
+
+# ---------------------------------------------------------------------------
+# list / get KB
+# ---------------------------------------------------------------------------
+
+
+class TestListAndGetKb:
+    async def test_list_returns_field_results(
+        self, attach_transport, make_mock_transport
+    ):
+        client = attach_transport(
+            make_mock_transport(
+                {"_links": {"self": "x"}, "_results": [_kb_payload("knb_1")]}
+            )
+        )
+        kbs = await client.knowledge_bases.list()
+        assert len(kbs) == 1
+        assert kbs[0].id == "knb_1"
+        # Slim KB doesn't carry a name — only id, type, locales.
+        # `with_content=True` get is required to retrieve the workspace name.
+
+    async def test_get_slim_default(self, attach_transport, make_mock_transport):
+        client = attach_transport(make_mock_transport(_kb_payload()))
+        kb = await client.knowledge_bases.get("knb_1")
+        assert isinstance(kb, KnowledgeBaseSlimResponse)
+        assert kb.id == "knb_1"
+
+    async def test_get_with_content_default_locale_routes_to_content_endpoint(
+        self, attach_transport
+    ):
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/knowledge_bases/knb_1/content"
+            return httpx.Response(200, json=_kb_full_payload())
+
+        client = attach_transport(httpx.MockTransport(handler))
+        kb = await client.knowledge_bases.get("knb_1", with_content=True)
+        assert kb.id == "knb_1"
+        assert kb.name == "Public KB"
+
+    async def test_get_with_content_specified_locale_routes_correctly(
+        self, attach_transport
+    ):
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/knowledge_bases/knb_1/locales/fr/content"
+            return httpx.Response(200, json=_kb_full_payload())
+
+        client = attach_transport(httpx.MockTransport(handler))
+        kb = await client.knowledge_bases.get("knb_1", with_content=True, locale="fr")
+        assert kb.id == "knb_1"
+
+
+# ---------------------------------------------------------------------------
+# Articles — list / iter / get
+# ---------------------------------------------------------------------------
+
+
+class TestArticles:
+    async def test_list_returns_slim_articles(
+        self, attach_transport, make_mock_transport
+    ):
+        client = attach_transport(
+            make_mock_transport(
+                {
+                    "_links": {"self": "x"},
+                    "_results": [_article_slim_payload("kba_1")],
+                }
+            )
+        )
+        articles = await client.knowledge_bases.list_articles("knb_1")
+        assert len(articles) == 1
+        assert articles[0].id == "kba_1"
+
+    async def test_iter_walks_pagination(self, attach_transport):
+        page1 = {
+            "_links": {"self": "x"},
+            "_results": [_article_slim_payload("kba_1")],
+            "_pagination": {
+                "next": "https://api.frontapp.test/knowledge_bases/knb_1/articles?page_token=PG2"
+            },
+        }
+        page2 = {
+            "_links": {"self": "x"},
+            "_results": [_article_slim_payload("kba_2")],
+            "_pagination": {"next": None},
+        }
+        call_count = {"i": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            i = call_count["i"]
+            call_count["i"] += 1
+            return httpx.Response(200, json=page1 if i == 0 else page2)
+
+        client = attach_transport(httpx.MockTransport(handler))
+        ids = [a.id async for a in client.knowledge_bases.iter_articles("knb_1")]
+        assert ids == ["kba_1", "kba_2"]
+
+    async def test_list_in_category(self, attach_transport, make_mock_transport):
+        client = attach_transport(
+            make_mock_transport(
+                {
+                    "_links": {"self": "x"},
+                    "_results": [_article_slim_payload("kba_5")],
+                }
+            )
+        )
+        articles = await client.knowledge_bases.list_articles_in_category("kbc_1")
+        assert len(articles) == 1
+        assert articles[0].id == "kba_5"
+
+    async def test_get_article_slim(self, attach_transport, make_mock_transport):
+        client = attach_transport(make_mock_transport(_article_slim_payload()))
+        article = await client.knowledge_bases.get_article("kba_1")
+        assert isinstance(article, KnowledgeBaseArticleSlimResponse)
+
+    async def test_get_article_with_content_routes_to_content_endpoint(
+        self, attach_transport
+    ):
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/knowledge_base_articles/kba_1/content"
+            return httpx.Response(200, json=_article_full_payload())
+
+        client = attach_transport(httpx.MockTransport(handler))
+        article = await client.knowledge_bases.get_article("kba_1", with_content=True)
+        assert isinstance(article, KnowledgeBaseArticleResponse)
+
+    async def test_get_article_with_specified_locale_routes_correctly(
+        self, attach_transport
+    ):
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert (
+                request.url.path == "/knowledge_base_articles/kba_1/locales/fr/content"
+            )
+            return httpx.Response(200, json=_article_full_payload())
+
+        client = attach_transport(httpx.MockTransport(handler))
+        article = await client.knowledge_bases.get_article(
+            "kba_1", with_content=True, locale="fr"
+        )
+        assert article.id == "kba_1"
+
+
+# ---------------------------------------------------------------------------
+# Articles — create / update
+# ---------------------------------------------------------------------------
+
+
+class TestCreateArticle:
+    async def test_defaults_to_draft_status(self, attach_transport):
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.method == "POST"
+            assert request.url.path == "/knowledge_bases/knb_1/articles"
+            body = json.loads(request.content)
+            assert body["status"] == "draft"
+            assert body["subject"] == "Hello"
+            assert body["content"] == "<p>body</p>"
+            return httpx.Response(201, json=_article_full_payload(id_="kba_new"))
+
+        client = attach_transport(httpx.MockTransport(handler))
+        article = await client.knowledge_bases.create_article(
+            "knb_1", subject="Hello", content="<p>body</p>"
+        )
+        assert article.id == "kba_new"
+
+    async def test_published_status_passes_through(self, attach_transport):
+        """Helper level retains status kwarg for library callers
+        (Python scripts can publish programmatically). MCP tool
+        layer is the safety boundary."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            body = json.loads(request.content)
+            assert body["status"] == "published"
+            return httpx.Response(201, json=_article_full_payload())
+
+        client = attach_transport(httpx.MockTransport(handler))
+        await client.knowledge_bases.create_article(
+            "knb_1", subject="x", content="y", status="published"
+        )
+
+    async def test_specified_locale_routes_correctly(self, attach_transport):
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/knowledge_bases/knb_1/locales/fr/articles"
+            return httpx.Response(201, json=_article_full_payload())
+
+        client = attach_transport(httpx.MockTransport(handler))
+        await client.knowledge_bases.create_article(
+            "knb_1", subject="x", content="y", locale="fr"
+        )
+
+
+class TestUpdateArticle:
+    async def test_status_none_omits_field(self, attach_transport):
+        """The update tool's drafts-only policy depends on this:
+        omitting status preserves the existing publication state."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.method == "PATCH"
+            body = json.loads(request.content)
+            assert "status" not in body
+            assert body["subject"] == "edited"
+            return httpx.Response(200, json=_article_full_payload())
+
+        client = attach_transport(httpx.MockTransport(handler))
+        await client.knowledge_bases.update_article("kba_1", subject="edited")
+
+    async def test_specified_locale_routes_correctly(self, attach_transport):
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert (
+                request.url.path == "/knowledge_base_articles/kba_1/locales/de/content"
+            )
+            return httpx.Response(200, json=_article_full_payload())
+
+        client = attach_transport(httpx.MockTransport(handler))
+        await client.knowledge_bases.update_article("kba_1", subject="x", locale="de")
+
+
+# ---------------------------------------------------------------------------
+# Categories
+# ---------------------------------------------------------------------------
+
+
+class TestCategories:
+    async def test_list(self, attach_transport, make_mock_transport):
+        client = attach_transport(
+            make_mock_transport(
+                {
+                    "_links": {"self": "x"},
+                    "_results": [_category_slim_payload("kbc_1")],
+                }
+            )
+        )
+        cats = await client.knowledge_bases.list_categories("knb_1")
+        assert len(cats) == 1
+        assert cats[0].id == "kbc_1"
+
+    async def test_iter_walks_pagination(self, attach_transport):
+        page1 = {
+            "_links": {"self": "x"},
+            "_results": [_category_slim_payload("kbc_1")],
+            "_pagination": {
+                "next": "https://api.frontapp.test/knowledge_bases/knb_1/categories?page_token=N"
+            },
+        }
+        page2 = {
+            "_links": {"self": "x"},
+            "_results": [_category_slim_payload("kbc_2")],
+            "_pagination": {"next": None},
+        }
+        call_count = {"i": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            i = call_count["i"]
+            call_count["i"] += 1
+            return httpx.Response(200, json=page1 if i == 0 else page2)
+
+        client = attach_transport(httpx.MockTransport(handler))
+        ids = [c.id async for c in client.knowledge_bases.iter_categories("knb_1")]
+        assert ids == ["kbc_1", "kbc_2"]
+
+    async def test_create_with_required_name(self, attach_transport):
+        def handler(request: httpx.Request) -> httpx.Response:
+            body = json.loads(request.content)
+            assert body["name"] == "Security"
+            assert request.url.path == "/knowledge_bases/knb_1/categories"
+            return httpx.Response(201, json=_category_full_payload(id_="kbc_new"))
+
+        client = attach_transport(httpx.MockTransport(handler))
+        cat = await client.knowledge_bases.create_category("knb_1", name="Security")
+        assert isinstance(cat, KnowledgeBaseCategoryResponse)
+        assert cat.id == "kbc_new"
+
+    async def test_create_with_specified_locale_routes_correctly(
+        self, attach_transport
+    ):
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/knowledge_bases/knb_1/locales/es/categories"
+            return httpx.Response(201, json=_category_full_payload())
+
+        client = attach_transport(httpx.MockTransport(handler))
+        await client.knowledge_bases.create_category(
+            "knb_1", name="Seguridad", locale="es"
+        )
+
+    async def test_update_only_name(self, attach_transport):
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.method == "PATCH"
+            body = json.loads(request.content)
+            assert body == {"name": "Renamed"}
+            return httpx.Response(200, json=_category_full_payload())
+
+        client = attach_transport(httpx.MockTransport(handler))
+        await client.knowledge_bases.update_category("kbc_1", name="Renamed")
+
+
+# ---------------------------------------------------------------------------
+# Wiring
+# ---------------------------------------------------------------------------
+
+
+class TestWiring:
+    def test_client_property_returns_helper(self, mock_api_credentials):
+        from frontapp_public_api_client import FrontappClient
+
+        client = FrontappClient(**mock_api_credentials)
+        assert isinstance(client.knowledge_bases, KnowledgeBases)
+
+    def test_lazy_property_caches(self, mock_api_credentials):
+        from frontapp_public_api_client import FrontappClient
+
+        client = FrontappClient(**mock_api_credentials)
+        first = client.knowledge_bases
+        second = client.knowledge_bases
+        assert first is second
+
+
+# Suppress unused-import warning when pytest collects without running every test
+_ = pytest


### PR DESCRIPTION
Closes #83. Part of #16 (workspace admin partition — PR-B following PR-A's Tier 1 reference resources).

## Summary

Front's Knowledge Base — articles + categories grouped under one or more KBs — wrapped here for both retrieval and authoring.

**Two distinct agent workflows the same vertical supports:**

1. **Retrieval**: list KBs → list categories → list / iter articles → get article body. Agent surfaces relevant KB content during a conversation or paraphrases into a reply.
2. **Contribute**: `create_article`, `update_article`, `create_category`, `update_category`. Agent converts a conversation resolution into a new draft article, or amends an existing one.

## Drafts only at the MCP layer

Per the policy decision (mirroring ADR-0016's drafts-first outbound philosophy applied to KB content): **the MCP tools never publish a KB article.**

- `create_kb_article` — no `status` argument; the tool always passes `status=\"draft\"` to the helper.
- `update_kb_article` — no `status` argument; the tool calls the helper with `status=None` so the existing publication state is preserved.
- The Python helper layer (`client.knowledge_bases.create_article` / `update_article`) **does** retain the `status` kwarg for library callers — Python scripts can publish programmatically. The MCP tools are the agent-safety boundary, not the helper.

The tool docstrings, `server.py` `instructions=` block, and the help resource all explicitly call this out so the LLM doesn't speculate about a hidden publish path. Two belt-and-suspenders tests assert that `\"status\"` is not in `inspect.signature(tool)` for both `create_kb_article` and `update_kb_article`.

## What ships

### `client.knowledge_bases` (Python helper)

- `list()`, `get(kb_id, with_content, locale)`
- `list_articles(kb_id)`, `iter_articles(kb_id)`, `list_articles_in_category(category_id)`, `iter_articles_in_category(category_id)`
- `get_article(article_id, with_content, locale)`
- `create_article(kb_id, ...)`, `update_article(article_id, ...)` (helper retains `status` kwarg)
- `list_categories(kb_id)`, `iter_categories(kb_id)`, `get_category(category_id, with_content, locale)`
- `create_category(kb_id, name, ...)`, `update_category(category_id, ...)`

The helper hides two generated-API quirks: the `_a_` infix on 11 of 26 KB modules, and the default-locale vs specified-locale split (single `locale=None` kwarg routes to the right module).

### MCP tools (10 total)

- 6 reads (cached 30s via `_READ_ONLY_TOOLS`):
  `list_knowledge_bases`, `get_kb`, `list_kb_articles`, `list_kb_articles_in_category`, `get_kb_article` (default `with_content=True`), `list_kb_categories`.
- 4 contribute mutations (two-step `confirm_or_preview` gate):
  `create_kb_article` (drafts only — no status arg),
  `update_kb_article` (no status arg — preserves existing state),
  `create_kb_category`, `update_kb_category`.

### Projections

3 slim Pydantic projections (`KbRef`, `KbArticleSummary`, `KbCategoryRef`). **Slim-shape note:** the underlying `*_slim_response` generated models don't carry `name`/`subject`; only `id`, `slug`, `locales`. Catalog browsing uses slug; agents fetch full content via `get_kb_article(with_content=True)`.

## Tests

- `tests/test_knowledge_bases.py` — 22 helper unit tests covering list/get with `with_content` routing, locale routing, article/category create + update, status-default-to-draft, status-omitted-on-update, pagination via `_paginate`.
- `frontapp_mcp_server/tests/test_knowledge_bases_tools.py` — 16 MCP tool tests covering preview/confirm/decline paths, slim-response projection, drafts-only enforcement on `create_kb_article` / `update_kb_article`, plus inspect-signature assertions that `status` is not on the tool surface.

**604 tests pass total** (+38 from this PR).

## Out of scope (filed separately)

- KB-level admin: `create_a_knowledge_base`, `update_knowledge_base*`, `delete_an_article`, `delete_a_knowledge_base_category` — covered by **#87**.

## Test plan

- [ ] CI green
- [ ] `uv run poe full-check` passes locally ✅
- [ ] All 38 new tests pass ✅
- [ ] Manual end-to-end (with a real Front workspace if available): list KBs, browse articles, fetch one with content, create a draft article via the MCP `create_kb_article` tool, verify it lands as a draft in Front's UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)