### PR TITLE
feat(client,mcp): close out small workspace-admin Tier 2/3 issues (#84, #86, #93)

### DIFF
--- a/docs/api-facts.yaml
+++ b/docs/api-facts.yaml
@@ -17,8 +17,8 @@
 #      domain wiring status, full path/method/response info).
 #
 schema_version: 1
-generated_at: '2026-04-27T17:32:45+00:00'
-generated_from_commit: 4870f653ddef899c6412401a9148d38ed6d05065
+generated_at: '2026-04-27T18:18:10+00:00'
+generated_from_commit: 8e18ee7ab4925b52c84bb38b0ef0e2595840f930
 summary:
   list_endpoints_with_field_results:
     - accounts.list_account_contacts
@@ -242,6 +242,7 @@ summary:
     - teammate_groups.update_a_company_teammate_group
   tags_with_helper:
     - analytics
+    - applications
     - contact_groups
     - contact_lists
     - contacts
@@ -252,6 +253,7 @@ summary:
     - messages
     - tags
     - teammates
+    - teams
   tags_with_domain:
     - contact_lists
     - contacts
@@ -361,9 +363,9 @@ tags:
     spec_tag: Applications
     api_dir: frontapp_public_api_client/api/applications
     helper:
-      built: false
-      path: null
-      class: null
+      built: true
+      path: frontapp_public_api_client/helpers/applications.py
+      class: Applications
     domain:
       built: false
       path: null
@@ -1983,9 +1985,9 @@ tags:
     spec_tag: Teams
     api_dir: frontapp_public_api_client/api/teams
     helper:
-      built: false
-      path: null
-      class: null
+      built: true
+      path: frontapp_public_api_client/helpers/teams.py
+      class: Teams
     domain:
       built: false
       path: null

--- a/frontapp_mcp_server/src/frontapp_mcp/resources/reference.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/resources/reference.py
@@ -13,6 +13,7 @@ from the existing ``ResponseCachingMiddleware``.
 | ``frontapp://me`` | Workspace company identity (id, name) — confirms the token works and which workspace it's bound to. |
 | ``frontapp://custom_fields`` | All custom field schemas, grouped by scope (global / account / contact / conversation / inbox / link / teammate). |
 | ``frontapp://teams`` | All workspace teams (id, name) — translate team names to ids. |
+| ``frontapp://rules`` | All automation rules (read-only) — explain what automation might be firing on a conversation. |
 """
 
 from __future__ import annotations
@@ -86,6 +87,21 @@ class CustomFieldRef(BaseModel):
     description: str | None = None
     type: str | None = None
     values: list[dict[str, Any]] | None = None
+
+
+class RuleRef(BaseModel):
+    """Compact projection of an automation rule.
+
+    Front exposes rules as read-only via the API — they're created and
+    edited in Front's UI. This catalog lets the LLM explain *what
+    automation might be firing* on a conversation and avoid stepping on
+    rule-driven actions.
+    """
+
+    id: str
+    name: str | None = None
+    actions: list[str] | None = None
+    is_private: bool | None = None
 
 
 def _project(model: type[BaseModel], item: Any) -> dict[str, Any]:
@@ -236,6 +252,22 @@ def register_resources(mcp: FastMCP) -> None:
             results = getattr(parsed, "field_results", None) or []
             result[scope] = [_project(CustomFieldRef, item) for item in results]
         return json.dumps(result, sort_keys=True)
+
+    @mcp.resource(
+        uri="frontapp://rules",
+        name="Automation rules",
+        description=(
+            "All automation rules in the workspace (read-only — rules are "
+            "created and edited in Front's UI). Use to explain what "
+            "automation might be firing on a conversation, or to avoid "
+            "stepping on a rule-driven action."
+        ),
+        mime_type="application/json",
+    )
+    async def rules_resource(context: Context) -> str:
+        from frontapp_public_api_client.api.rules import list_rules
+
+        return await _list_field_results(context, list_rules.asyncio_detailed, RuleRef)
 
     @mcp.resource(
         uri="frontapp://teams",

--- a/frontapp_mcp_server/src/frontapp_mcp/server.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/server.py
@@ -450,6 +450,7 @@ automatically with exponential backoff. Expect ~60 req/min on most endpoints.
   frontapp://teammates             — all teammates (translate name/email → id)
   frontapp://teams                 — all teams (translate name → tim_* id)
   frontapp://custom_fields         — every custom field schema, grouped by scope
+  frontapp://rules                 — automation rules (read-only) — explain workspace automation
   frontapp://conversations/recent  — 20 most recent conversations as summaries
 
 Resources are slow-changing reference data, cached for 60 seconds. Read

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/__init__.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/__init__.py
@@ -11,6 +11,7 @@ from fastmcp import FastMCP
 def register_all_tools(mcp: FastMCP) -> None:
     """Register every tool module with the FastMCP instance."""
     from .analytics import register_tools as register_analytics_tools
+    from .applications import register_tools as register_applications_tools
     from .attachments import register_tools as register_attachments_tools
     from .contact_groups import register_tools as register_contact_groups_tools
     from .contact_lists import register_tools as register_contact_lists_tools
@@ -22,8 +23,10 @@ def register_all_tools(mcp: FastMCP) -> None:
     from .messages import register_tools as register_messages_tools
     from .tags import register_tools as register_tags_tools
     from .teammates import register_tools as register_teammates_tools
+    from .teams import register_tools as register_teams_tools
 
     register_analytics_tools(mcp)
+    register_applications_tools(mcp)
     register_attachments_tools(mcp)
     register_contacts_tools(mcp)
     register_contact_lists_tools(mcp)
@@ -35,6 +38,7 @@ def register_all_tools(mcp: FastMCP) -> None:
     register_messages_tools(mcp)
     register_tags_tools(mcp)
     register_teammates_tools(mcp)
+    register_teams_tools(mcp)
 
 
 __all__ = ["register_all_tools"]

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/applications.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/applications.py
@@ -1,0 +1,107 @@
+"""MCP tool for partner-app event triggering.
+
+Single endpoint — POST ``/applications/{application_uid}/events``.
+Niche partner-integration use case: a Front partner-built app
+triggers a custom event from an external system, and Front routes it
+through workflows / rules.
+
+The application catalog is not enumerable via the API. The agent
+needs to know the application_uid out of band (it's surfaced in
+Front's app-management UI, or passed in by the user).
+
+Two-step ``confirm_or_preview`` gate — even though this is "just"
+firing an event, it can trigger Front workflows that mutate
+conversation state, so the safer path is to confirm before sending.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastmcp import Context, FastMCP
+from pydantic import Field
+
+from frontapp_mcp.services import get_services
+from frontapp_mcp.tools.schemas import confirm_or_preview
+
+
+def register_tools(mcp: FastMCP) -> None:
+    """Register the application event-trigger tool."""
+
+    @mcp.tool(
+        name="trigger_application_event",
+        description=(
+            "Trigger an event on behalf of a Front partner application. "
+            "Niche partner-integration tool — the agent needs the "
+            "`application_uid` (a `app_*` id surfaced in Front's "
+            "app-management UI). The event payload references either "
+            "an internal Front object id (`app_object_id`) or an "
+            "external link (`app_object_ext_link`); pass at least one. "
+            "Two-step confirm because the event may trigger workflows "
+            "that mutate conversation state."
+        ),
+    )
+    async def trigger_application_event(
+        context: Context,
+        application_uid: Annotated[
+            str, Field(description="`app_*` uid of the partner application")
+        ],
+        event_type: Annotated[
+            str,
+            Field(
+                description=(
+                    "Event type the partner app declared. Routed to Front "
+                    "workflows that match this type."
+                )
+            ),
+        ],
+        app_object_id: Annotated[
+            str | None,
+            Field(
+                description=(
+                    "Optional Front object id (e.g. `cnv_*`, `crd_*`) the "
+                    "event is associated with."
+                )
+            ),
+        ] = None,
+        app_object_ext_link: Annotated[
+            str | None,
+            Field(
+                description=(
+                    "Optional external URL identifying the object. Pair "
+                    "with `app_object_id` or use as a standalone reference."
+                )
+            ),
+        ] = None,
+        confirm: Annotated[
+            bool, Field(description="Must be true to fire the event.")
+        ] = False,
+    ) -> dict[str, Any]:
+        services = get_services(context)
+        preview = {
+            "action": "trigger_application_event",
+            "application_uid": application_uid,
+            "event_type": event_type,
+            "app_object_id": app_object_id,
+            "app_object_ext_link": app_object_ext_link,
+        }
+        gate = await confirm_or_preview(
+            context,
+            preview=preview,
+            confirm=confirm,
+            elicit_message=(f"Trigger '{event_type}' event on app {application_uid}?"),
+        )
+        if gate is not None:
+            return gate
+
+        await services.client.applications.trigger_event(
+            application_uid,
+            event_type=event_type,
+            app_object_id=app_object_id,
+            app_object_ext_link=app_object_ext_link,
+        )
+        return {
+            "confirmed": True,
+            "application_uid": application_uid,
+            "event_type": event_type,
+        }

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/teams.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/teams.py
@@ -1,0 +1,114 @@
+"""MCP tools for Front team-membership mutations.
+
+Front exposes 4 endpoints under the ``teams`` tag — list / get reads
+plus the membership pair (``add_teammates_to_team`` /
+``remove_teammates_from_team``). The reads are surfaced via
+``frontapp://teams`` (#82); these tools cover the mutations.
+
+Concrete agent value: "reassign capacity to a team during a spike",
+"onboard new teammate Alice to the support team". Both follow the
+two-step ``confirm_or_preview`` pattern; the preview shows the count
++ ids of teammates being added/removed so the human sees what would
+happen before approving the elicitation.
+
+There is no ``create_team`` / ``delete_team`` in Front's API — teams
+are workspace-admin primitives created in Front's UI.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastmcp import Context, FastMCP
+from pydantic import Field
+
+from frontapp_mcp.services import get_services
+from frontapp_mcp.tools.schemas import confirm_or_preview
+
+
+def register_tools(mcp: FastMCP) -> None:
+    """Register team-related tools with the FastMCP server."""
+
+    @mcp.tool(
+        name="add_team_members",
+        description=(
+            "Add one or more teammates to a team. Two-step confirm: "
+            "confirm=False returns a preview of count + ids; "
+            "confirm=True executes the membership change. Use "
+            "frontapp://teams to translate a team name into a "
+            "`tim_*` id and frontapp://teammates for `tea_*` ids."
+        ),
+    )
+    async def add_team_members(
+        context: Context,
+        team_id: Annotated[str, Field(description="`tim_*` id")],
+        teammate_ids: Annotated[
+            list[str], Field(description="`tea_*` ids to add to the team.")
+        ],
+        confirm: Annotated[bool, Field(description="Must be true to apply.")] = False,
+    ) -> dict[str, Any]:
+        services = get_services(context)
+        preview = {
+            "action": "add_team_members",
+            "team_id": team_id,
+            "teammate_count": len(teammate_ids),
+            "teammate_ids": teammate_ids,
+        }
+        gate = await confirm_or_preview(
+            context,
+            preview=preview,
+            confirm=confirm,
+            elicit_message=(f"Add {len(teammate_ids)} teammate(s) to team {team_id}?"),
+        )
+        if gate is not None:
+            return gate
+
+        await services.client.teams.add_teammates(team_id, teammate_ids)
+        return {
+            "confirmed": True,
+            "team_id": team_id,
+            "added_count": len(teammate_ids),
+        }
+
+    @mcp.tool(
+        name="remove_team_members",
+        description=(
+            "Remove one or more teammates from a team. Two-step "
+            "confirm: confirm=False returns a preview of count + ids; "
+            "confirm=True executes the change. Removing a teammate "
+            "from their last team typically leaves them workspace-"
+            "scoped only — verify with the user if that's intended."
+        ),
+    )
+    async def remove_team_members(
+        context: Context,
+        team_id: Annotated[str, Field(description="`tim_*` id")],
+        teammate_ids: Annotated[
+            list[str], Field(description="`tea_*` ids to remove from the team.")
+        ],
+        confirm: Annotated[bool, Field(description="Must be true to apply.")] = False,
+    ) -> dict[str, Any]:
+        services = get_services(context)
+        preview = {
+            "action": "remove_team_members",
+            "team_id": team_id,
+            "teammate_count": len(teammate_ids),
+            "teammate_ids": teammate_ids,
+        }
+        gate = await confirm_or_preview(
+            context,
+            preview=preview,
+            confirm=confirm,
+            elicit_message=(
+                f"Remove {len(teammate_ids)} teammate(s) from team {team_id}?"
+            ),
+        )
+        if gate is not None:
+            return gate
+
+        await services.client.teams.remove_teammates(team_id, teammate_ids)
+        return {
+            "confirmed": True,
+            "team_id": team_id,
+            "removed_count": len(teammate_ids),
+        }

--- a/frontapp_mcp_server/tests/test_admin_reference_resources.py
+++ b/frontapp_mcp_server/tests/test_admin_reference_resources.py
@@ -238,3 +238,58 @@ class TestTeamsResource:
         body = await resources["frontapp://teams"](context)
         parsed = json.loads(body)
         assert parsed == []
+
+
+# ---------------------------------------------------------------------------
+# frontapp://rules (#84)
+# ---------------------------------------------------------------------------
+
+
+class TestRulesResource:
+    async def test_returns_rule_refs(self, resources, make_client):
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/rules"
+            return httpx.Response(
+                200,
+                json={
+                    "_links": {"self": "https://api.frontapp.test/rules"},
+                    "_results": [
+                        {
+                            "_links": {"self": "x", "related": {}},
+                            "id": "rul_1",
+                            "name": "Auto-archive spam",
+                            "actions": ["archive"],
+                            "is_private": False,
+                        },
+                        {
+                            "_links": {"self": "y", "related": {}},
+                            "id": "rul_2",
+                            "name": "Tag urgent",
+                            "actions": ["add_tag"],
+                            "is_private": True,
+                        },
+                    ],
+                },
+            )
+
+        context = _make_context(make_client(handler))
+        body = await resources["frontapp://rules"](context)
+        parsed = json.loads(body)
+        assert len(parsed) == 2
+        assert {row["id"] for row in parsed} == {"rul_1", "rul_2"}
+        assert {row["name"] for row in parsed} == {
+            "Auto-archive spam",
+            "Tag urgent",
+        }
+        # Confirm the actions list and privacy flag round-trip.
+        rul_1 = next(r for r in parsed if r["id"] == "rul_1")
+        assert rul_1["actions"] == ["archive"]
+        assert rul_1["is_private"] is False
+
+    async def test_empty_workspace_returns_empty_list(self, resources, make_client):
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"_links": {"self": "x"}, "_results": []})
+
+        context = _make_context(make_client(handler))
+        body = await resources["frontapp://rules"](context)
+        assert json.loads(body) == []

--- a/frontapp_mcp_server/tests/test_workspace_admin_closeouts_tools.py
+++ b/frontapp_mcp_server/tests/test_workspace_admin_closeouts_tools.py
@@ -1,0 +1,193 @@
+"""Tests for the workspace-admin closeout MCP tools (#86, #93).
+
+- ``add_team_members`` / ``remove_team_members`` (#86) — preview /
+  decline / confirm paths.
+- ``trigger_application_event`` (#93) — preview / decline / confirm
+  paths; both id-based and ext_link-based event payloads.
+
+The rules surface (#84) is a reference resource, exercised in
+``test_admin_reference_resources.py``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from frontapp_mcp.tools.applications import register_tools as register_applications
+from frontapp_mcp.tools.teams import register_tools as register_teams
+
+from .conftest import create_mock_context
+
+
+@pytest.fixture
+def teams_tools(mcp_tool_capture) -> dict[str, object]:
+    return mcp_tool_capture(register_teams)
+
+
+@pytest.fixture
+def applications_tools(mcp_tool_capture) -> dict[str, object]:
+    return mcp_tool_capture(register_applications)
+
+
+# ---------------------------------------------------------------------------
+# add_team_members / remove_team_members (#86)
+# ---------------------------------------------------------------------------
+
+
+class TestAddTeamMembers:
+    async def test_preview_does_not_call_helper(self, teams_tools):
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock(
+            side_effect=AssertionError("client invoked on preview path")
+        )
+
+        result = await teams_tools["add_team_members"](
+            context,
+            team_id="tim_1",
+            teammate_ids=["tea_a", "tea_b"],
+            confirm=False,
+        )
+        assert result["confirmed"] is False
+        assert result["preview"]["teammate_count"] == 2
+        assert result["preview"]["teammate_ids"] == ["tea_a", "tea_b"]
+        context.elicit.assert_not_called()
+
+    async def test_confirmed_calls_helper(self, teams_tools):
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock()
+        lifespan.client.teams.add_teammates = AsyncMock(return_value=True)
+
+        result = await teams_tools["add_team_members"](
+            context,
+            team_id="tim_1",
+            teammate_ids=["tea_a"],
+            confirm=True,
+        )
+        assert result["confirmed"] is True
+        assert result["added_count"] == 1
+        lifespan.client.teams.add_teammates.assert_awaited_once_with("tim_1", ["tea_a"])
+
+    async def test_declined_elicitation_does_not_call_helper(self, teams_tools):
+        context, lifespan = create_mock_context(elicit_confirm=False)
+        lifespan.client = AsyncMock(
+            side_effect=AssertionError("client invoked after decline")
+        )
+
+        result = await teams_tools["add_team_members"](
+            context,
+            team_id="tim_1",
+            teammate_ids=["tea_a"],
+            confirm=True,
+        )
+        assert result["confirmed"] is False
+        context.elicit.assert_called_once()
+
+
+class TestRemoveTeamMembers:
+    async def test_preview_includes_count_and_ids(self, teams_tools):
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock(
+            side_effect=AssertionError("client invoked on preview path")
+        )
+
+        result = await teams_tools["remove_team_members"](
+            context,
+            team_id="tim_1",
+            teammate_ids=["tea_a", "tea_b", "tea_c"],
+            confirm=False,
+        )
+        assert result["confirmed"] is False
+        assert result["preview"]["teammate_count"] == 3
+        assert result["preview"]["action"] == "remove_team_members"
+
+    async def test_confirmed_calls_helper(self, teams_tools):
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock()
+        lifespan.client.teams.remove_teammates = AsyncMock(return_value=True)
+
+        result = await teams_tools["remove_team_members"](
+            context, team_id="tim_1", teammate_ids=["tea_a"], confirm=True
+        )
+        assert result["confirmed"] is True
+        assert result["removed_count"] == 1
+        lifespan.client.teams.remove_teammates.assert_awaited_once_with(
+            "tim_1", ["tea_a"]
+        )
+
+
+# ---------------------------------------------------------------------------
+# trigger_application_event (#93)
+# ---------------------------------------------------------------------------
+
+
+class TestTriggerApplicationEvent:
+    async def test_preview_does_not_call_helper(self, applications_tools):
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock(
+            side_effect=AssertionError("client invoked on preview path")
+        )
+
+        result = await applications_tools["trigger_application_event"](
+            context,
+            application_uid="app_xyz",
+            event_type="customer_replied",
+            app_object_id="cnv_abc",
+            confirm=False,
+        )
+        assert result["confirmed"] is False
+        assert result["preview"]["event_type"] == "customer_replied"
+        assert result["preview"]["app_object_id"] == "cnv_abc"
+        context.elicit.assert_not_called()
+
+    async def test_confirmed_with_id_calls_helper(self, applications_tools):
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock()
+        lifespan.client.applications.trigger_event = AsyncMock(return_value=True)
+
+        result = await applications_tools["trigger_application_event"](
+            context,
+            application_uid="app_xyz",
+            event_type="customer_replied",
+            app_object_id="cnv_abc",
+            confirm=True,
+        )
+        assert result["confirmed"] is True
+        call = lifespan.client.applications.trigger_event.await_args
+        assert call is not None
+        assert call.args == ("app_xyz",)
+        assert call.kwargs["event_type"] == "customer_replied"
+        assert call.kwargs["app_object_id"] == "cnv_abc"
+        assert call.kwargs["app_object_ext_link"] is None
+
+    async def test_confirmed_with_ext_link_passes_through(self, applications_tools):
+        context, lifespan = create_mock_context()
+        lifespan.client = AsyncMock()
+        lifespan.client.applications.trigger_event = AsyncMock(return_value=True)
+
+        await applications_tools["trigger_application_event"](
+            context,
+            application_uid="app_xyz",
+            event_type="external_event",
+            app_object_ext_link="https://example.com/x",
+            confirm=True,
+        )
+        call = lifespan.client.applications.trigger_event.await_args
+        assert call is not None
+        assert call.kwargs["app_object_ext_link"] == "https://example.com/x"
+        assert call.kwargs["app_object_id"] is None
+
+    async def test_declined_does_not_call_helper(self, applications_tools):
+        context, lifespan = create_mock_context(elicit_confirm=False)
+        lifespan.client = AsyncMock(
+            side_effect=AssertionError("client invoked after decline")
+        )
+
+        result = await applications_tools["trigger_application_event"](
+            context,
+            application_uid="app_xyz",
+            event_type="x",
+            app_object_id="cnv_y",
+            confirm=True,
+        )
+        assert result["confirmed"] is False

--- a/frontapp_public_api_client/frontapp_client.py
+++ b/frontapp_public_api_client/frontapp_client.py
@@ -20,6 +20,7 @@ from urllib.parse import parse_qs, quote, urlparse, urlunparse
 
 if TYPE_CHECKING:
     from .helpers.analytics import Analytics
+    from .helpers.applications import Applications
     from .helpers.attachments import Attachments
     from .helpers.contact_groups import ContactGroups
     from .helpers.contact_lists import ContactLists
@@ -31,6 +32,7 @@ if TYPE_CHECKING:
     from .helpers.messages import Messages
     from .helpers.tags import Tags
     from .helpers.teammates import Teammates
+    from .helpers.teams import Teams
 
 import httpx
 from dotenv import load_dotenv
@@ -556,6 +558,7 @@ class FrontappClient(AuthenticatedClient):
 
         # Domain helper instances (lazy-loaded via properties)
         self._analytics: Analytics | None = None
+        self._applications: Applications | None = None
         self._attachments: Attachments | None = None
         self._conversations: Conversations | None = None
         self._contacts: Contacts | None = None
@@ -567,6 +570,7 @@ class FrontappClient(AuthenticatedClient):
         self._inboxes: Inboxes | None = None
         self._knowledge_bases: KnowledgeBases | None = None
         self._teammates: Teammates | None = None
+        self._teams: Teams | None = None
 
         # Extract client-level parameters that shouldn't go to the transport
         # Event hooks for observability - start with our defaults
@@ -658,6 +662,21 @@ class FrontappClient(AuthenticatedClient):
         if self._analytics is None:
             self._analytics = Analytics(self)
         return self._analytics
+
+    @property
+    def applications(self) -> "Applications":
+        """Ergonomic operations over Front's ``/applications/{uid}/events``
+        endpoint — partner-app event triggering.
+
+        Niche use case (partner integrations); the application catalog
+        is not enumerable via the API. See ``helpers.applications`` for
+        the single ``trigger_event`` method.
+        """
+        from .helpers.applications import Applications
+
+        if self._applications is None:
+            self._applications = Applications(self)
+        return self._applications
 
     @property
     def attachments(self) -> "Attachments":
@@ -823,6 +842,21 @@ class FrontappClient(AuthenticatedClient):
         if self._teammates is None:
             self._teammates = Teammates(self)
         return self._teammates
+
+    @property
+    def teams(self) -> "Teams":
+        """Ergonomic operations over Front's ``/teams*`` endpoints.
+
+        Covers list / get reads plus the membership mutation pair
+        (``add_teammates`` / ``remove_teammates``). Front exposes no
+        team create or delete via the API — those are admin actions in
+        Front's UI.
+        """
+        from .helpers.teams import Teams
+
+        if self._teams is None:
+            self._teams = Teams(self)
+        return self._teams
 
     # Event hooks for observability
     async def _capture_pagination_metadata(self, response: httpx.Response) -> None:

--- a/frontapp_public_api_client/helpers/__init__.py
+++ b/frontapp_public_api_client/helpers/__init__.py
@@ -6,6 +6,7 @@ boilerplate for common workflows. Each helper is accessed as an attribute on
 """
 
 from frontapp_public_api_client.helpers.analytics import Analytics
+from frontapp_public_api_client.helpers.applications import Applications
 from frontapp_public_api_client.helpers.attachments import (
     MAX_ATTACHMENT_BYTES,
     Attachments,
@@ -22,10 +23,12 @@ from frontapp_public_api_client.helpers.knowledge_bases import KnowledgeBases
 from frontapp_public_api_client.helpers.messages import Messages
 from frontapp_public_api_client.helpers.tags import Tags
 from frontapp_public_api_client.helpers.teammates import Teammates
+from frontapp_public_api_client.helpers.teams import Teams
 
 __all__ = [
     "MAX_ATTACHMENT_BYTES",
     "Analytics",
+    "Applications",
     "Attachments",
     "Base",
     "ContactGroups",
@@ -39,4 +42,5 @@ __all__ = [
     "Messages",
     "Tags",
     "Teammates",
+    "Teams",
 ]

--- a/frontapp_public_api_client/helpers/applications.py
+++ b/frontapp_public_api_client/helpers/applications.py
@@ -1,0 +1,61 @@
+"""Applications helper — partner-app event trigger.
+
+The single endpoint under Front's ``applications`` tag is
+``trigger_app_event`` (POST ``/applications/{application_uid}/events``).
+It's a partner-integration primitive: a Front partner-built app
+triggers a custom event from an external system, and Front routes it
+through workflows / rules.
+
+Niche use case for the typical agent — included here for completeness
+of the workspace-admin partition (#16). The application catalog is
+not enumerable via the API; partners need to know their app uid out
+of band (it's surfaced in Front's app-management UI).
+"""
+
+from __future__ import annotations
+
+from frontapp_public_api_client.helpers.base import Base
+
+
+class Applications(Base):
+    """Ergonomic operations over Front's ``/applications*`` endpoints."""
+
+    async def trigger_event(
+        self,
+        application_uid: str,
+        *,
+        event_type: str,
+        app_object_id: str | None = None,
+        app_object_ext_link: str | None = None,
+    ) -> bool:
+        """Trigger an event on behalf of a Front partner application.
+
+        Front's ``AppEvent`` payload requires ``event_type`` plus an
+        ``app_object`` referencing either an internal ``id`` or an
+        external link. At least one of ``app_object_id`` or
+        ``app_object_ext_link`` should be provided; the helper passes
+        through whichever is set.
+
+        Returns ``True`` on Front's 204 No Content response. Raises
+        ``APIError`` on failure.
+        """
+        from frontapp_public_api_client.api.applications import trigger_app_event
+        from frontapp_public_api_client.domain.converters import to_unset
+        from frontapp_public_api_client.models.app_event import AppEvent
+        from frontapp_public_api_client.models.app_event_app_object import (
+            AppEventAppObject,
+        )
+        from frontapp_public_api_client.utils import is_success, unwrap
+
+        app_object = AppEventAppObject(
+            id=to_unset(app_object_id),
+            ext_link=to_unset(app_object_ext_link),
+        )
+        body = AppEvent(event_type=event_type, app_object=app_object)
+        response = await trigger_app_event.asyncio_detailed(
+            application_uid, client=self._client, body=body
+        )
+        if is_success(response):
+            return True
+        unwrap(response)
+        return False

--- a/frontapp_public_api_client/helpers/teams.py
+++ b/frontapp_public_api_client/helpers/teams.py
@@ -1,0 +1,84 @@
+"""Teams helper facade — list/get + add/remove teammate mutations.
+
+Front exposes 4 endpoints under the ``teams`` tag: ``list_teams`` /
+``get_team`` (reads) and ``add_teammates_to_team`` /
+``remove_teammates_from_team`` (membership mutations). The
+``frontapp://teams`` MCP reference resource (#82) handles the read
+catalog browsing path; this helper exposes the full surface for direct
+Python callers and for the MCP mutation tools (#86) that need to
+modify team membership.
+
+There is no ``create_team`` / ``delete_team`` in Front's API — teams
+are workspace-admin primitives created in Front's UI.
+"""
+
+from __future__ import annotations
+
+import builtins
+
+from frontapp_public_api_client.helpers.base import Base
+
+
+class Teams(Base):
+    """Ergonomic operations over Front's ``/teams*`` endpoints."""
+
+    async def list(self):
+        """List every team in the workspace (no pagination)."""
+        from frontapp_public_api_client.api.teams import list_teams
+        from frontapp_public_api_client.utils import unwrap
+
+        response = await list_teams.asyncio_detailed(client=self._client)
+        parsed = unwrap(response)
+        return list(getattr(parsed, "field_results", None) or [])
+
+    async def get(self, team_id: str):
+        """Fetch one team by id (returns full ``TeamResponse``)."""
+        from frontapp_public_api_client.api.teams import get_team
+        from frontapp_public_api_client.models.team_response import TeamResponse
+        from frontapp_public_api_client.utils import unwrap_as
+
+        response = await get_team.asyncio_detailed(team_id, client=self._client)
+        return unwrap_as(response, TeamResponse)
+
+    async def add_teammates(
+        self, team_id: str, teammate_ids: builtins.list[str]
+    ) -> bool:
+        """Add teammates to a team (POST /teams/{id}/teammates).
+
+        Returns ``True`` on success (Front returns 204 No Content).
+        Raises an ``APIError`` subclass on failure.
+        """
+        from frontapp_public_api_client.api.teams import add_teammates_to_team
+        from frontapp_public_api_client.models.teammate_ids import TeammateIds
+        from frontapp_public_api_client.utils import is_success, unwrap
+
+        body = TeammateIds(teammate_ids=teammate_ids)
+        response = await add_teammates_to_team.asyncio_detailed(
+            team_id, client=self._client, body=body
+        )
+        if is_success(response):
+            return True
+        # Re-route through unwrap to raise the typed APIError.
+        unwrap(response)
+        return False
+
+    async def remove_teammates(
+        self, team_id: str, teammate_ids: builtins.list[str]
+    ) -> bool:
+        """Remove teammates from a team (DELETE /teams/{id}/teammates).
+
+        Returns ``True`` on success (Front returns 204 No Content).
+        Raises an ``APIError`` subclass on failure.
+        """
+        from frontapp_public_api_client.api.teams import remove_teammates_from_team
+        from frontapp_public_api_client.models.teammate_ids import TeammateIds
+        from frontapp_public_api_client.utils import is_success, unwrap
+
+        body = TeammateIds(teammate_ids=teammate_ids)
+        response = await remove_teammates_from_team.asyncio_detailed(
+            team_id, client=self._client, body=body
+        )
+        if is_success(response):
+            return True
+        unwrap(response)
+        return False

--- a/tests/test_workspace_admin_closeouts.py
+++ b/tests/test_workspace_admin_closeouts.py
@@ -1,0 +1,172 @@
+"""Tests for the workspace-admin closeout helpers (#86, #93).
+
+Helper-level coverage of the small Tier 3 verticals shipped together:
+
+- ``client.teams.{list, get, add_teammates, remove_teammates}`` (#86)
+- ``client.applications.trigger_event`` (#93)
+
+The rules surface (#84) is a reference resource only — its tests live
+in ``frontapp_mcp_server/tests/test_admin_reference_resources.py``.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from frontapp_public_api_client.helpers.applications import Applications
+from frontapp_public_api_client.helpers.teams import Teams
+from frontapp_public_api_client.models.team_response import TeamResponse
+
+
+def _team_preview_payload(id_: str = "tim_1", name: str = "Support") -> dict:
+    """Slim TeamPreviewResponse — required: _links, id, name."""
+    return {
+        "_links": {"self": "https://x", "related": {}},
+        "id": id_,
+        "name": name,
+    }
+
+
+def _team_full_payload(id_: str = "tim_1", name: str = "Support") -> dict:
+    """Full TeamResponse — required: _links, id, name, inboxes, members."""
+    return {
+        "_links": {"self": "https://x", "related": {}},
+        "id": id_,
+        "name": name,
+        "inboxes": [],
+        "members": [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Teams helper (#86)
+# ---------------------------------------------------------------------------
+
+
+class TestTeamsHelper:
+    async def test_list_returns_field_results(
+        self, attach_transport, make_mock_transport
+    ):
+        client = attach_transport(
+            make_mock_transport(
+                {
+                    "_links": {"self": "x"},
+                    "_results": [
+                        _team_preview_payload("tim_1", "Support"),
+                        _team_preview_payload("tim_2", "Sales"),
+                    ],
+                }
+            )
+        )
+        teams = await client.teams.list()
+        assert {t.id for t in teams} == {"tim_1", "tim_2"}
+        assert {t.name for t in teams} == {"Support", "Sales"}
+
+    async def test_get_returns_full_team_response(
+        self, attach_transport, make_mock_transport
+    ):
+        client = attach_transport(make_mock_transport(_team_full_payload()))
+        team = await client.teams.get("tim_1")
+        assert isinstance(team, TeamResponse)
+        assert team.id == "tim_1"
+        assert team.name == "Support"
+
+    async def test_add_teammates_sends_correct_body(self, attach_transport):
+        recorded: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            recorded.append(request)
+            return httpx.Response(204)
+
+        client = attach_transport(httpx.MockTransport(handler))
+        result = await client.teams.add_teammates("tim_1", ["tea_a", "tea_b"])
+        assert result is True
+        assert recorded[0].method == "POST"
+        assert recorded[0].url.path == "/teams/tim_1/teammates"
+        body = json.loads(recorded[0].content)
+        assert body == {"teammate_ids": ["tea_a", "tea_b"]}
+
+    async def test_remove_teammates_sends_correct_body(self, attach_transport):
+        recorded: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            recorded.append(request)
+            return httpx.Response(204)
+
+        client = attach_transport(httpx.MockTransport(handler))
+        result = await client.teams.remove_teammates("tim_1", ["tea_a"])
+        assert result is True
+        assert recorded[0].method == "DELETE"
+        assert recorded[0].url.path == "/teams/tim_1/teammates"
+
+
+class TestTeamsWiring:
+    def test_client_teams_returns_helper(self, mock_api_credentials):
+        from frontapp_public_api_client import FrontappClient
+
+        client = FrontappClient(**mock_api_credentials)
+        assert isinstance(client.teams, Teams)
+
+    def test_lazy_property_caches(self, mock_api_credentials):
+        from frontapp_public_api_client import FrontappClient
+
+        client = FrontappClient(**mock_api_credentials)
+        assert client.teams is client.teams
+
+
+# ---------------------------------------------------------------------------
+# Applications helper (#93)
+# ---------------------------------------------------------------------------
+
+
+class TestApplicationsHelper:
+    async def test_trigger_event_with_id_sends_correct_payload(self, attach_transport):
+        recorded: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            recorded.append(request)
+            return httpx.Response(204)
+
+        client = attach_transport(httpx.MockTransport(handler))
+        result = await client.applications.trigger_event(
+            "app_xyz",
+            event_type="customer_replied",
+            app_object_id="cnv_abc",
+        )
+        assert result is True
+        assert recorded[0].method == "POST"
+        assert recorded[0].url.path == "/applications/app_xyz/events"
+        body = json.loads(recorded[0].content)
+        assert body["event_type"] == "customer_replied"
+        assert body["app_object"]["id"] == "cnv_abc"
+
+    async def test_trigger_event_with_ext_link(self, attach_transport):
+        recorded: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            recorded.append(request)
+            return httpx.Response(204)
+
+        client = attach_transport(httpx.MockTransport(handler))
+        await client.applications.trigger_event(
+            "app_xyz",
+            event_type="external_event",
+            app_object_ext_link="https://example.com/issue/42",
+        )
+        body = json.loads(recorded[0].content)
+        assert body["app_object"]["ext_link"] == "https://example.com/issue/42"
+
+
+class TestApplicationsWiring:
+    def test_client_applications_returns_helper(self, mock_api_credentials):
+        from frontapp_public_api_client import FrontappClient
+
+        client = FrontappClient(**mock_api_credentials)
+        assert isinstance(client.applications, Applications)
+
+
+# Suppress unused-import warning when pytest collects without running every test
+_ = pytest


### PR DESCRIPTION
Closes **#84**, **#86**, **#93**. Part of #16 (workspace admin partition).

Three small / deferred items bundled together since each is a half-day-or-less unit. All three follow the canonical patterns from earlier verticals — no new design decisions.

## #84 — `frontapp://rules` reference resource

Read-only catalog of Front's automation rules. Lets the LLM explain what automation might be firing on a conversation, or avoid stepping on rule-driven actions.

- `RuleRef` projection (id / name / actions / is_private) in `resources/reference.py`.
- Resource registered alongside the other `frontapp://*` reference URIs.
- Test in `test_admin_reference_resources.py`.

## #86 — Teams add/remove teammate mutations

New `client.teams` helper class. The reference resource at `frontapp://teams` (shipped via #82) already handles the read catalog; this fills out the helper surface for direct Python callers and for the new mutation tools.

- `helpers/teams.py` with `Teams(Base)`: `list()`, `get(team_id)`, `add_teammates(team_id, ids)`, `remove_teammates(team_id, ids)`.
- `tools/teams.py` with `add_team_members` / `remove_team_members` MCP tools using the standard two-step `confirm_or_preview` gate. Preview surfaces count + ids of teammates being added/removed.

## #93 — Applications event trigger

Single-endpoint vertical for Front partner-app event triggering (POST `/applications/{uid}/events`). Niche but rounds out the workspace-admin partition.

- `helpers/applications.py` with `Applications(Base).trigger_event(uid, event_type, app_object_id?, app_object_ext_link?)`.
- `tools/applications.py` with `trigger_application_event` mutation tool gated with `confirm_or_preview` (the event may trigger Front workflows, so confirm before sending).

## Tests

20 new tests covering all three areas (helper + MCP tool):

- 2 reference-resource tests for rules (in `test_admin_reference_resources.py`).
- 4 helper unit tests for teams + 5 MCP tool tests (preview / confirm / decline / declined-elicit paths).
- 2 helper unit tests for applications + 4 MCP tool tests.
- Wiring smoke tests for `client.teams` + `client.applications` lazy properties.

**624 tests pass total** (+20 from this PR).

## Test plan

- [ ] CI green
- [ ] `uv run poe full-check` passes locally ✅
- [ ] All 20 new tests pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)