### PR TITLE
fix(mcp): drop ctx.elicit() from confirm_or_preview gate (#104)

### DIFF
--- a/frontapp_mcp_server/README.md
+++ b/frontapp_mcp_server/README.md
@@ -14,8 +14,9 @@ and cursor pagination.
 - **Conversations vertical live today** — 8 tools: list / get / search / list_messages /
   list_comments / reply / update / add_comment. More verticals (contacts, messages,
   tags, inboxes, analytics) are tracked as GitHub issues.
-- **Two-step confirmation**: mutations require `confirm=true` and elicit explicit user
-  approval via `ctx.elicit`.
+- **Two-step confirmation**: mutations are gated behind `confirm=false` (preview only) →
+  `confirm=true` (execute). The agent must surface the preview to the user before
+  re-invoking with `confirm=true`.
 - **Built-in resilience**: automatic retries, 429 rate-limit handling with exponential
   backoff, and cursor-paginated list helpers inherited from the
   `frontapp-openapi-client` transport layer.

--- a/frontapp_mcp_server/docs/adr/0010-mcp-server-architecture.md
+++ b/frontapp_mcp_server/docs/adr/0010-mcp-server-architecture.md
@@ -65,7 +65,7 @@ point that the server calls at startup:
 ```
 tools/
 ├── __init__.py        # register_all_tools fan-out
-├── schemas.py         # confirm_or_preview, ConfirmationResult, require_confirmation
+├── schemas.py         # confirm_or_preview gate
 ├── conversations.py   # 7 tools (5 read, 2 mutate)
 ├── contacts.py        # 12 tools
 ├── drafts.py          # 5 tools (drafts-first outbound — see ADR-0016)
@@ -93,12 +93,7 @@ async def update_conversation(
     services = get_services(context)
     preview = {"action": "update_conversation", "id": conversation_id, "status": status}
 
-    gate = await confirm_or_preview(
-        context,
-        preview=preview,
-        confirm=confirm,
-        elicit_message=f"Update conversation {conversation_id}?",
-    )
+    gate = confirm_or_preview(preview=preview, confirm=confirm)
     if gate is not None:
         return gate
 
@@ -106,18 +101,18 @@ async def update_conversation(
     return {"status": "updated", "id": conversation_id}
 ```
 
-`confirm_or_preview` (in `tools/schemas.py`) collapses the preview-then-elicit cascade
-into one call: it returns the response dict to bail with on the preview path or declined
-elicitation, or `None` when the caller should proceed with the mutation. Internally it
-wraps `ctx.elicit(message, ConfirmationSchema)` (via `require_confirmation`) and
-dispatches the returned `ConfirmationResult` (`CONFIRMED` / `CANCELLED` / `DECLINED`) —
-those names are now an internal detail of the helper and only get imported by tools that
-need to branch on `DECLINED` vs `CANCELLED` directly.
+`confirm_or_preview` (in `tools/schemas.py`) is the single shared gate: it returns the
+response dict the tool should bail with on the preview path (`confirm=False`), or `None`
+when the caller should proceed with the mutation.
 
-The `confirm=False` preview path is the agent's contract: it sees what would happen, can
-narrate it to the user, then re-invokes with `confirm=True` to actually apply. The
-elicitation step is a second backstop — if the user is sitting at the client, they
-explicitly approve before the call lands on Front.
+The contract is **two-call**: the LLM first invokes the tool with `confirm=False` to get
+the preview, surfaces it to the user, and only re-invokes with `confirm=True` after the
+user has agreed. The agent is responsible for showing the preview — there is no
+server-side elicitation. (An earlier revision used `ctx.elicit` for a second backstop;
+that layer was removed because elicitation is unreliable across MCP clients including
+Claude Desktop. Per the MCP spec, clients SHOULD prompt; servers SHOULD NOT. The
+`destructiveHint` annotation is the recommended client-side cue and is tracked
+separately.)
 
 The confirm gate is **per-tool**, not transport-level. Every mutating tool wires it in
 the same shape; the helpers (ADR-0007) themselves don't gate.
@@ -144,10 +139,10 @@ review. Outbound replies are exclusively created as drafts via the `drafts` vert
 draft lands in Front's UI; a human reviews and clicks send.
 
 Draft mutations still use the §3 two-step confirm pattern (`confirm=False` returns a
-preview; `confirm=True` plus `require_confirmation` executes), so the agent sees a
-preview before the draft is even created. The drafts-first guarantee is at a higher
-level: even after the draft lands, sending requires a human in Front's UI — there is no
-programmatic send. See ADR-0016 → "Drafts-first outbound" for the full reasoning.
+preview; `confirm=True` executes), so the agent sees a preview before the draft is even
+created. The drafts-first guarantee is at a higher level: even after the draft lands,
+sending requires a human in Front's UI — there is no programmatic send. See ADR-0016 →
+"Drafts-first outbound" for the full reasoning.
 
 The `instructions=` block on the `FastMCP(...)` call documents this contract for the
 agent at session start, including the rule "There is no programmatic 'send a reply now'
@@ -276,14 +271,14 @@ Encoded in the `/new-vertical` skill. Mirror the canonical template
 2. For each helper method, write a `@mcp.tool(name=..., description=...)` async function
    that calls the helper through `get_services(context)`.
 3. Mutations get `confirm: bool = False` and run the gate via `confirm_or_preview`
-   (single helper call instead of the 6-line preview/elicit/dispatch cascade).
+   (single helper call instead of an inline preview/dispatch cascade).
 4. Wire `register_<resource>_tools(mcp)` into `tools/__init__.py:register_all_tools`.
 5. Add read-only tool names to `_READ_ONLY_TOOLS` in `server.py` for caching.
 6. Extend the `instructions=` block in `server.py` with a section on the new vertical
    (domain model, tool-selection guide, safety pattern).
 7. Update `resources/help.py` Markdown — the help drift pitfall.
 8. Tests: `test_<resource>_tools.py` covers reads and the two-step confirm flow for
-   every mutating tool — confirm/elicitation cases live alongside the happy-path tests
+   every mutating tool — preview and confirm cases live alongside the happy-path tests
    in the same module (e.g. `test_conversations_tools.py`).
 
 ### Why FastMCP
@@ -291,7 +286,6 @@ Encoded in the `/new-vertical` skill. Mirror the canonical template
 The MCP protocol has multiple Python implementations; FastMCP was chosen because:
 
 - Built-in lifespan management via `@asynccontextmanager`
-- First-class `ctx.elicit()` for the two-step confirm pattern
 - Pydantic-native parameter annotations (ADR-0016 → "Tool Interface Pattern")
 - Response caching middleware ships with the framework
 - Maintained, with an active community and faster cadence on protocol updates than
@@ -310,8 +304,7 @@ when FastMCP upstream merges the equivalent fix.
 - [`tools/conversations.py`](https://github.com/dougborg/frontapp-openapi-client/blob/main/frontapp_mcp_server/src/frontapp_mcp/tools/conversations.py)
   — canonical tool-module template
 - [`tools/schemas.py`](https://github.com/dougborg/frontapp-openapi-client/blob/main/frontapp_mcp_server/src/frontapp_mcp/tools/schemas.py)
-  — `confirm_or_preview` (canonical gate) plus the underlying `require_confirmation` and
-  `ConfirmationResult` primitives
+  — `confirm_or_preview` (canonical gate)
 - [`projections.py`](https://github.com/dougborg/frontapp-openapi-client/blob/main/frontapp_mcp_server/src/frontapp_mcp/projections.py)
   — summary projections for tool responses
 - [ADR-0007: Domain Helper Classes](https://github.com/dougborg/frontapp-openapi-client/blob/main/frontapp_public_api_client/docs/adr/0007-domain-helper-classes.md)

--- a/frontapp_mcp_server/docs/adr/0016-tool-interface-pattern.md
+++ b/frontapp_mcp_server/docs/adr/0016-tool-interface-pattern.md
@@ -19,11 +19,16 @@ decide:
 
 ## Decision
 
-Adopt the **Pydantic parameter annotations** pattern combined with **FastMCP
-elicitation** for destructive operations. Frontapp tools use per-parameter
+Adopt the **Pydantic parameter annotations** pattern combined with a **two-call
+preview/execute gate** for destructive operations. Frontapp tools use per-parameter
 `Annotated[T, Field(description=...)]` directly rather than a nested request model +
 `Unpack()` decorator — most tools have short argument lists and the per-parameter form
 reads more naturally in the `@mcp.tool(...)` decorator shape.
+
+The original revision of this ADR also relied on `ctx.elicit` for a server-side
+confirmation prompt. That layer was removed because elicitation is unreliable across MCP
+clients, notably broken in Claude Desktop. Per the MCP Tools spec, clients SHOULD
+prompt; servers SHOULD NOT.
 
 The `Unpack()` decorator infrastructure (`frontapp_mcp/unpack.py`) is kept in-repo as an
 option for future tools with wide or deeply-nested request bodies.
@@ -108,14 +113,7 @@ with a consistent shape:
     "confirmed": False,
 }
 
-# confirm=True, user cancelled elicitation
-{
-    "preview": {...},
-    "confirmed": False,
-    "result": "cancelled" | "declined",
-}
-
-# confirm=True, user approved, API succeeded
+# confirm=True, API succeeded
 {
     "confirmed": True,
     "status_code": 202,  # HTTP status from Front
@@ -136,12 +134,7 @@ Every mutation tool takes `confirm: bool = False` and runs the gate via the
 ```python
 preview = {"action": "...", "conversation_id": conversation_id, ...}
 
-gate = await confirm_or_preview(
-    context,
-    preview=preview,
-    confirm=confirm,
-    elicit_message=f"Send reply to conversation {conversation_id}?",
-)
+gate = confirm_or_preview(preview=preview, confirm=confirm)
 if gate is not None:
     return gate
 
@@ -151,28 +144,35 @@ return {"confirmed": True, "status_code": response.status_code}
 ```
 
 `confirm_or_preview` returns the dict the tool should bail with on the preview path
-(`confirm=False`) or declined elicitation, or `None` when the caller should proceed. The
-6-line `if not confirm: ... require_confirmation ... ConfirmationResult.CONFIRMED`
-cascade was duplicated across ~40 mutating tools before being extracted into this
-helper.
+(`confirm=False`), or `None` when the caller should proceed. The contract is
+**two-call**: the LLM first invokes the tool with `confirm=False` to get the preview,
+surfaces it to the user, and only re-invokes with `confirm=True` after the user has
+agreed.
 
-The pattern has two independent safety gates:
+The single safety gate is in-band:
 
 1. **Preview vs. execute**: `confirm=False` prevents accidental mutations from ambiguous
-   LLM tool selection (the LLM has to explicitly re-call with `confirm=True`).
-2. **Host elicitation**: `ctx.elicit` prompts the user even once the LLM has set
-   `confirm=True`, so a misaligned LLM can't unilaterally apply changes.
+   LLM tool selection. The LLM must show the preview to the user and explicitly re-call
+   with `confirm=True` once the user has agreed.
+
+Earlier revisions of this ADR also relied on `ctx.elicit` for a server-side confirmation
+prompt. That layer was removed because elicitation is unreliable across MCP clients
+(notably broken in Claude Desktop and several others — the elicit call never resolves,
+so the user never sees the prompt and the mutation never executes). Per the MCP Tools
+spec, **clients SHOULD prompt users; servers SHOULD NOT**. Spec-compliant clients should
+be configured to prompt for tools annotated with `destructiveHint=True`; that work is
+tracked separately.
 
 #### 5. Drafts-first outbound
 
-For customer-facing replies there is a **third** gate beyond preview + elicitation: the
-agent never sends, it only drafts. The Frontapp drafts vertical (`create_draft_reply`,
+For customer-facing replies there is a **second** gate beyond preview/execute: the agent
+never sends, it only drafts. The Frontapp drafts vertical (`create_draft_reply`,
 `create_draft_on_channel`, `edit_draft`, `delete_draft`) exposes the full reply surface,
 but Front's API has no programmatic `send_draft` — the human reviews the draft in
 Front's UI and clicks send themselves.
 
 The earlier `reply_to_conversation` tool (which sent immediately on `confirm=True`) was
-removed in the drafts vertical PR. Even a misaligned LLM that gets past elicitation
+removed in the drafts vertical PR. Even a misaligned LLM that gets past the preview gate
 cannot send to a customer; the strongest action it can take is creating a draft that a
 human still has to approve and dispatch.
 
@@ -186,52 +186,26 @@ rule is specifically for outbound messaging.
 
 #### 6. Shared schemas
 
-Common schemas live in `frontapp_mcp/tools/schemas.py`:
+The shared confirmation gate lives in `frontapp_mcp/tools/schemas.py`:
 
 ```python
 # frontapp_mcp/tools/schemas.py
-class ConfirmationSchema(BaseModel):
-    """Schema for user confirmation elicitation."""
-    confirm: bool = Field(..., description="Confirm the action (true to proceed)")
-
-
-class ConfirmationResult(StrEnum):
-    CONFIRMED = "confirmed"
-    CANCELLED = "cancelled"
-    DECLINED = "declined"
-
-
-async def require_confirmation(context: Context, message: str) -> ConfirmationResult:
-    elicit_result = await context.elicit(message, ConfirmationSchema)
-    if elicit_result.action != "accept":
-        return ConfirmationResult.CANCELLED
-    if not elicit_result.data.confirm:
-        return ConfirmationResult.DECLINED
-    return ConfirmationResult.CONFIRMED
-
-
-async def confirm_or_preview(
-    context: Context,
+def confirm_or_preview(
     *,
     preview: dict[str, Any],
     confirm: bool,
-    elicit_message: str,
 ) -> dict[str, Any] | None:
-    """Standard preview-then-elicit gate. Returns the response dict the
-    caller should return verbatim, or None when the caller should proceed.
+    """Two-call preview/execute gate. Returns the response dict the caller
+    should return verbatim on the preview path (`confirm=False`), or None
+    when the caller should proceed with the mutation.
     """
     if not confirm:
         return {"preview": preview, "confirmed": False}
-    result = await require_confirmation(context, elicit_message)
-    if result is not ConfirmationResult.CONFIRMED:
-        return {"preview": preview, "confirmed": False, "result": result.value}
     return None
 ```
 
 Every mutation tool imports `confirm_or_preview` and calls it once instead of
-hand-rolling the cascade. `ConfirmationResult` and `require_confirmation` are now
-internal details; tools only import them directly when they need to branch on `DECLINED`
-vs `CANCELLED` (rare).
+hand-rolling the cascade.
 
 ### Benefits
 
@@ -241,9 +215,9 @@ vs `CANCELLED` (rare).
 - **IDE support**: autocomplete and type checking work everywhere
 - **Testability**: mutation tools in preview mode (`confirm=False`) can be tested
   without any API mocks
-- **Consistency**: every mutation follows the same two-step confirm shape
-- **Safety**: destructive operations require both an LLM affirm (`confirm=True`) and a
-  user affirm (elicitation accept)
+- **Consistency**: every mutation follows the same two-call preview/execute shape
+- **Safety**: destructive operations require an explicit re-invocation with
+  `confirm=True` after the user has agreed to the preview
 
 ## Consequences
 
@@ -252,7 +226,7 @@ vs `CANCELLED` (rare).
 - Type-safe tool interfaces prevent runtime errors
 - Self-documenting parameters improve LLM tool selection and developer UX
 - Validation errors are clear and actionable
-- Elicitation prevents accidental destructive operations
+- Two-call preview/execute prevents accidental destructive operations
 - Shared helpers keep the confirm flow identical across tools
 
 ### Negative
@@ -261,12 +235,9 @@ vs `CANCELLED` (rare).
   by dropping to Unpack for such tools)
 - Two-step confirm means every mutation is at minimum a two-call flow, which is by
   design but trades latency for safety
-- Elicitation round-trips add a user interaction step
 
 ### Neutral
 
-- Currently 3 of 8 tools use elicitation (all three are mutations); future verticals are
-  expected to follow the same ratio
 - Preview dicts duplicate some argument structure, but the duplication is what lets
   users catch problems before they're applied
 
@@ -300,19 +271,15 @@ async def create_draft_reply(
 
 **Rejected**: no IDE support, no validation, no documentation.
 
-### Response-field confirmation (no elicitation)
+### Server-side elicitation (`ctx.elicit`)
 
-```python
-async def create_draft_reply(...) -> dict:
-    if not confirmed:
-        return {"status": "pending", "confirmation_required": True}
-    # else apply
-```
-
-**Rejected**: requires two full LLM round trips instead of one round trip plus host
-elicitation, and bypasses the MCP host's UI for preview/confirm. The current pattern
-lets Claude Desktop (and similar) show a proper dialog rather than surface a JSON field
-the LLM has to interpret.
+Earlier revisions of this ADR specified `ctx.elicit` as a second backstop after the
+preview step — the server would prompt the user for confirmation even after
+`confirm=True`. **Reverted**: elicitation is unreliable across MCP clients and is broken
+outright in Claude Desktop (the elicit call never resolves, so the user never sees the
+prompt and the mutation never executes). Per the MCP Tools spec, clients SHOULD prompt;
+servers SHOULD NOT. The recommended client-side cue is the `destructiveHint` annotation,
+tracked separately.
 
 ### Single confirm gate (no preview step)
 
@@ -324,7 +291,7 @@ the intended action before committing, without requiring a speculative API call.
 
 Live today across the conversations and drafts verticals:
 
-**Mutations** (two-step confirm + elicitation):
+**Mutations** (two-call preview/execute):
 
 - `create_draft_reply` / `create_draft_on_channel` / `edit_draft` / `delete_draft` — the
   drafts vertical (`tools/drafts.py`); customer-facing outbound always goes through
@@ -332,7 +299,7 @@ Live today across the conversations and drafts verticals:
 - `update_conversation` — archive/reopen, reassign, retag, move inbox
 - `add_conversation_comment` — internal teammate note
 
-**Reads** (no elicitation, cached 30s via `ResponseCachingMiddleware`):
+**Reads** (no confirm gate, cached 30s via `ResponseCachingMiddleware`):
 
 - `list_conversations`, `get_conversation`, `search_conversations`,
   `list_conversation_messages`, `list_conversation_comments`
@@ -344,4 +311,4 @@ follow the same pattern.
 
 - [ADR-0017: Automated Tool Documentation](0017-automated-tool-documentation.md)
 - [ADR-0011: Pydantic Domain Models](https://github.com/dougborg/frontapp-openapi-client/blob/main/frontapp_public_api_client/docs/adr/0011-pydantic-domain-models.md)
-- [FastMCP](https://github.com/jlowin/fastmcp) — elicitation API
+- [FastMCP](https://github.com/jlowin/fastmcp)

--- a/frontapp_mcp_server/docs/adr/0017-automated-tool-documentation.md
+++ b/frontapp_mcp_server/docs/adr/0017-automated-tool-documentation.md
@@ -48,16 +48,17 @@ async def create_draft_reply(
     """Create a draft reply on an existing Front conversation.
 
     🟡 MEDIUM-RISK OPERATION: creates Front-side state, but the human
-    reviews the draft and clicks send themselves. Requires two-step
-    confirmation via ``ctx.elicit``.
+    reviews the draft and clicks send themselves. Two-step confirm: the
+    agent must surface the preview to the user before re-invoking with
+    ``confirm=True``.
 
     **Workflow**:
     1. Call with ``confirm=False`` — returns a preview of the draft. No
        side effects.
-    2. Call with ``confirm=True`` — elicits explicit user approval, then
-       POSTs to ``/conversations/{id}/drafts``. The draft appears in Front
-       for the human to review and send. There is no programmatic
-       ``send_draft``.
+    2. Call with ``confirm=True`` (after the user has agreed to the
+       preview) — POSTs to ``/conversations/{id}/drafts``. The draft
+       appears in Front for the human to review and send. There is no
+       programmatic ``send_draft``.
 
     **Related tools**:
     - ``edit_draft`` — full-replacement edit of an existing draft
@@ -70,7 +71,7 @@ async def create_draft_reply(
     - ``frontapp://help`` — full tool reference
 
     Args:
-        context: FastMCP context for services + elicitation
+        context: FastMCP context for services
         conversation_id: Front conversation id, e.g. ``"cnv_abc123"``
         body: Reply body (HTML or plain text)
         channel_id: Channel to send through, e.g. ``"cha_xyz"`` (required

--- a/frontapp_mcp_server/docs/examples.md
+++ b/frontapp_mcp_server/docs/examples.md
@@ -60,7 +60,8 @@ Model:
   )
   → {"preview": {"action": "create_draft_reply", "body_preview": "…"}, "confirmed": False}
 
-  # 2. Create draft — confirm=True triggers ctx.elicit to ask the user to approve.
+  # 2. Create draft — only re-invoke with confirm=True after the user has agreed
+  #    to the preview from step 1.
   create_draft_reply(
     conversation_id="cnv_abc",
     body="Hi! We've shipped your replacement — tracking 1Z999AA10123456784.",
@@ -85,7 +86,7 @@ Model:
   )
   → {"preview": {...}, "confirmed": False}
 
-  # Apply — elicits approval
+  # Apply — re-invoke with confirm=True after the user has agreed
   update_conversation(..., confirm=True)
   → {"confirmed": True, "status_code": 200}
 ```
@@ -125,11 +126,14 @@ Every tool that changes data takes a `confirm: bool = False` parameter:
 
 1. **`confirm=False`** — returns a `preview` dict showing exactly what would be sent. No
    side effects, no rate-limit cost beyond the tool call itself.
-2. **`confirm=True`** — elicits explicit user approval via the MCP host's `ctx.elicit`
-   flow (e.g. a Claude Desktop dialog), _then_ executes.
+2. **`confirm=True`** — executes the mutation. The agent must surface the preview from
+   step 1 to the user and only re-invoke with `confirm=True` after the user has
+   explicitly agreed.
 
 This keeps the LLM from silently sending customer-facing messages, archiving active
-conversations, or tagging things without a human in the loop.
+conversations, or tagging things without a human in the loop. Spec-compliant MCP clients
+should also be configured to prompt before destructive tool calls; the `destructiveHint`
+annotation work is tracked separately.
 
 ## Front search syntax cheat sheet
 

--- a/frontapp_mcp_server/src/frontapp_mcp/resources/help.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/resources/help.py
@@ -372,8 +372,9 @@ create_draft_reply(..., confirm=True)
 Every tool that changes data on the Front side takes `confirm: bool = False`.
 - `confirm=False` returns a dict with a `preview` key showing exactly what will
   be sent. No side effects.
-- `confirm=True` elicits explicit user approval via the MCP host's
-  `ctx.elicit` flow, then executes.
+- `confirm=True` executes the mutation. The agent is responsible for surfacing
+  the preview to the user and only re-invoking with `confirm=True` after
+  the user has agreed.
 
 ## Rate limits
 

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/applications.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/applications.py
@@ -85,12 +85,7 @@ def register_tools(mcp: FastMCP) -> None:
             "app_object_id": app_object_id,
             "app_object_ext_link": app_object_ext_link,
         }
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=(f"Trigger '{event_type}' event on app {application_uid}?"),
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/attachments.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/attachments.py
@@ -97,15 +97,7 @@ def register_tools(mcp: FastMCP) -> None:
             "parent_exists": True,
             "will_overwrite": path.exists(),
         }
-        message = f"Download attachment to {path}?" + (
-            " (will OVERWRITE existing file)" if path.exists() else ""
-        )
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=message,
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/contact_groups.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/contact_groups.py
@@ -129,12 +129,7 @@ def register_tools(mcp: FastMCP) -> None:
     ) -> dict[str, Any]:
         services = get_services(context)
         preview = {"action": "create_contact_group", "name": name}
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=f"Create workspace-scoped contact group {name!r}?",
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 
@@ -161,12 +156,7 @@ def register_tools(mcp: FastMCP) -> None:
             "team_id": team_id,
             "name": name,
         }
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=f"Create contact group {name!r} for team {team_id}?",
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 
@@ -194,14 +184,7 @@ def register_tools(mcp: FastMCP) -> None:
             "teammate_id": teammate_id,
             "name": name,
         }
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=(
-                f"Create private contact group {name!r} for teammate {teammate_id}?"
-            ),
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 
@@ -229,14 +212,7 @@ def register_tools(mcp: FastMCP) -> None:
             "contact_group_id": contact_group_id,
             "note": "Dissolves the group; contacts NOT deleted.",
         }
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=(
-                f"Delete contact group {contact_group_id}? (Members are kept.)"
-            ),
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 
@@ -268,14 +244,7 @@ def register_tools(mcp: FastMCP) -> None:
             "contact_ids": contact_ids,
             "count": len(contact_ids),
         }
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=(
-                f"Add {len(contact_ids)} contact(s) to group {contact_group_id}?"
-            ),
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 
@@ -321,14 +290,7 @@ def register_tools(mcp: FastMCP) -> None:
                 ),
                 "confirmed": False,
             }
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=(
-                f"Remove {len(contact_ids)} contact(s) from group {contact_group_id}?"
-            ),
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/contact_lists.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/contact_lists.py
@@ -121,15 +121,7 @@ def register_tools(mcp: FastMCP) -> None:
     ) -> dict[str, Any]:
         services = get_services(context)
         preview = {"action": "create_contact_list", "name": name}
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=(
-                f"Create workspace-scoped contact list {name!r}? (Targets the "
-                "oldest active workspace.)"
-            ),
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 
@@ -157,12 +149,7 @@ def register_tools(mcp: FastMCP) -> None:
             "team_id": team_id,
             "name": name,
         }
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=f"Create contact list {name!r} for team {team_id}?",
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 
@@ -189,14 +176,7 @@ def register_tools(mcp: FastMCP) -> None:
             "teammate_id": teammate_id,
             "name": name,
         }
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=(
-                f"Create private contact list {name!r} for teammate {teammate_id}?"
-            ),
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 
@@ -224,15 +204,7 @@ def register_tools(mcp: FastMCP) -> None:
             "contact_list_id": contact_list_id,
             "note": "Dissolves the list; contacts NOT deleted.",
         }
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=(
-                f"Delete contact list {contact_list_id}? (Members are kept; "
-                "only the list is removed.)"
-            ),
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 
@@ -265,14 +237,7 @@ def register_tools(mcp: FastMCP) -> None:
             "contact_ids": contact_ids,
             "count": len(contact_ids),
         }
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=(
-                f"Add {len(contact_ids)} contact(s) to list {contact_list_id}?"
-            ),
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 
@@ -320,14 +285,7 @@ def register_tools(mcp: FastMCP) -> None:
                 ),
                 "confirmed": False,
             }
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=(
-                f"Remove {len(contact_ids)} contact(s) from list {contact_list_id}?"
-            ),
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/contacts.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/contacts.py
@@ -219,12 +219,7 @@ def register_tools(mcp: FastMCP) -> None:
             "group_names": group_names,
             "list_names": list_names,
         }
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=f"Create contact '{name}'?",
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 
@@ -264,12 +259,7 @@ def register_tools(mcp: FastMCP) -> None:
             "name": name,
             "handles": handles,
         }
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=f"Create team contact on {team_id}?",
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 
@@ -306,12 +296,7 @@ def register_tools(mcp: FastMCP) -> None:
             "name": name,
             "handles": handles,
         }
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=f"Create teammate contact on {teammate_id}?",
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 
@@ -369,13 +354,7 @@ def register_tools(mcp: FastMCP) -> None:
                 "confirmed": False,
                 "result": "no_changes_requested",
             }
-        summary = ", ".join(f"{k}={v}" for k, v in changes.items())
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=f"Update contact {contact_id}: {summary}?",
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 
@@ -416,15 +395,7 @@ def register_tools(mcp: FastMCP) -> None:
             "target_contact_id": target_contact_id,
             "warning": "IRREVERSIBLE: merged contacts are deleted; their conversations move to the target.",
         }
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=(
-                f"IRREVERSIBLE: merge {len(contact_ids)} contacts "
-                f"(target={target_contact_id or 'auto'})?"
-            ),
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 
@@ -451,14 +422,7 @@ def register_tools(mcp: FastMCP) -> None:
             "contact_id": contact_id,
             "warning": "PERMANENT: removes the contact and all its handles. Cannot be undone.",
         }
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=(
-                f"PERMANENTLY DELETE contact {contact_id}? This deletes customer data."
-            ),
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 
@@ -486,12 +450,7 @@ def register_tools(mcp: FastMCP) -> None:
             "author_id": author_id,
             "body_preview": body[:200] + ("…" if len(body) > 200 else ""),
         }
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=f"Add internal note to contact {contact_id}?",
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 
@@ -523,12 +482,7 @@ def register_tools(mcp: FastMCP) -> None:
             "handle": handle,
             "source": source,
         }
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=f"Add {source} handle '{handle}' to contact {contact_id}?",
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 
@@ -566,14 +520,7 @@ def register_tools(mcp: FastMCP) -> None:
             "source": source,
             "force": force,
         }
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=(
-                f"Remove {source} handle '{handle}' from contact {contact_id}?"
-            ),
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/conversations.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/conversations.py
@@ -186,13 +186,7 @@ def register_tools(mcp: FastMCP) -> None:
                 "confirmed": False,
                 "result": "no_changes_requested",
             }
-        summary = ", ".join(f"{k}={v}" for k, v in changes.items())
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=f"Update conversation {conversation_id}: {summary}?",
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 
@@ -230,12 +224,7 @@ def register_tools(mcp: FastMCP) -> None:
             "body_preview": body[:200] + ("…" if len(body) > 200 else ""),
             "author_id": author_id,
         }
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=f"Add internal comment to conversation {conversation_id}?",
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/drafts.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/drafts.py
@@ -6,8 +6,7 @@ programmatic ``send_draft`` — sending is always human-in-the-loop.
 
 All four mutation tools (create-on-channel, create-reply, edit, delete) use
 the standard two-step confirm pattern: call with ``confirm=False`` for a
-preview, ``confirm=True`` to execute (which also elicits explicit user
-approval via ``ctx.elicit``).
+preview, then re-invoke with ``confirm=True`` once the user has agreed.
 
 Attachments: every create/edit tool accepts an optional ``attachment_paths``
 parameter — a list of absolute filesystem paths. Each path is read at tool-
@@ -117,12 +116,7 @@ def register_tools(mcp: FastMCP) -> None:
             "mode": mode,
             "attachments": attachment_preview,
         }
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=f"Create draft on channel {channel_id}?",
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 
@@ -200,12 +194,7 @@ def register_tools(mcp: FastMCP) -> None:
             "mode": mode,
             "attachments": attachment_preview,
         }
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=f"Create draft reply on conversation {conversation_id}?",
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 
@@ -292,12 +281,7 @@ def register_tools(mcp: FastMCP) -> None:
             "version": version,
             "attachments": attachment_preview,
         }
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=f"Edit draft {draft_id}? This replaces the current draft body.",
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 
@@ -330,12 +314,7 @@ def register_tools(mcp: FastMCP) -> None:
     ) -> dict[str, Any]:
         services = get_services(context)
         preview = {"action": "delete_draft", "draft_id": draft_id}
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=f"Delete draft {draft_id}?",
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/inboxes.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/inboxes.py
@@ -161,12 +161,7 @@ def register_tools(mcp: FastMCP) -> None:
             "teammate_ids": teammate_ids,
             "is_public": is_public,
         }
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=f"Create workspace inbox '{name}'?",
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 
@@ -201,12 +196,7 @@ def register_tools(mcp: FastMCP) -> None:
             "teammate_ids": teammate_ids,
             "is_public": is_public,
         }
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=f"Create team inbox '{name}' on team {team_id}?",
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 
@@ -234,14 +224,7 @@ def register_tools(mcp: FastMCP) -> None:
             "teammate_count": len(teammate_ids),
             "teammate_ids": teammate_ids,
         }
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=(
-                f"Grant inbox {inbox_id} access to {len(teammate_ids)} teammate(s)?"
-            ),
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 
@@ -272,14 +255,7 @@ def register_tools(mcp: FastMCP) -> None:
             "teammate_count": len(teammate_ids),
             "teammate_ids": teammate_ids,
         }
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=(
-                f"Revoke inbox {inbox_id} access from {len(teammate_ids)} teammate(s)?"
-            ),
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/knowledge_bases.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/knowledge_bases.py
@@ -245,14 +245,7 @@ def register_tools(mcp: FastMCP) -> None:
             "locale": locale,
             "status": "draft",  # always — see module docstring
         }
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=(
-                f"Create draft KB article '{subject}' in {knowledge_base_id}?"
-            ),
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 
@@ -301,12 +294,7 @@ def register_tools(mcp: FastMCP) -> None:
             "locale": locale,
             "note": "status unchanged — agents cannot flip draft/published",
         }
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=f"Update KB article {article_id}?",
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 
@@ -357,12 +345,7 @@ def register_tools(mcp: FastMCP) -> None:
             "description": description,
             "locale": locale,
         }
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=f"Create KB category '{name}' in {knowledge_base_id}?",
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 
@@ -403,12 +386,7 @@ def register_tools(mcp: FastMCP) -> None:
             "description": description,
             "locale": locale,
         }
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=f"Update KB category {category_id}?",
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/messages.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/messages.py
@@ -153,12 +153,7 @@ def register_tools(mcp: FastMCP) -> None:
         if teammate_id:
             prompt += f" as teammate {teammate_id}"
         prompt += "?"
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=prompt,
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/schemas.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/schemas.py
@@ -1,116 +1,55 @@
 """Shared schemas for Frontapp MCP tools.
 
-This module contains Pydantic models and helpers that are shared across multiple
-tool modules to ensure consistency and avoid duplication.
+This module contains helpers shared across multiple tool modules to ensure
+consistency and avoid duplication.
 """
 
-from enum import StrEnum
 from typing import Any
 
-from fastmcp import Context
-from pydantic import BaseModel, Field
 
-
-class ConfirmationSchema(BaseModel):
-    """Schema for user confirmation via elicitation.
-
-    This schema is used with FastMCP's `ctx.elicit()` to request explicit
-    user confirmation before executing destructive operations.
-
-    Attributes:
-        confirm: Boolean indicating whether the user confirms the action
-    """
-
-    confirm: bool = Field(..., description="Confirm the action (true to proceed)")
-
-
-class ConfirmationResult(StrEnum):
-    """Result of a confirmation request."""
-
-    CONFIRMED = "confirmed"
-    CANCELLED = "cancelled"
-    DECLINED = "declined"
-
-
-async def require_confirmation(context: Context, message: str) -> ConfirmationResult:
-    """Request user confirmation via elicitation.
-
-    Encapsulates the common elicitation pattern used across all confirm-mode tools.
-
-    Args:
-        context: FastMCP context for elicitation
-        message: Confirmation message to display
-
-    Returns:
-        ConfirmationResult indicating user's decision
-    """
-    elicit_result = await context.elicit(message, ConfirmationSchema)
-
-    if elicit_result.action != "accept":
-        return ConfirmationResult.CANCELLED
-
-    if not elicit_result.data.confirm:
-        return ConfirmationResult.DECLINED
-
-    return ConfirmationResult.CONFIRMED
-
-
-async def confirm_or_preview(
-    context: Context,
+def confirm_or_preview(
     *,
     preview: dict[str, Any],
     confirm: bool,
-    elicit_message: str,
 ) -> dict[str, Any] | None:
-    """Standard preview-then-elicit gate for mutating MCP tools.
+    """Standard preview-then-execute gate for mutating MCP tools.
 
-    Encapsulates the preview/confirm/elicit cascade that every two-step-confirm
-    tool runs. Returns the response dict the caller should return verbatim
-    when the gate blocks execution, or ``None`` when the caller should
-    proceed with the mutation.
+    Returns the response dict the caller should return verbatim on the
+    preview path (``confirm=False``), or ``None`` when the caller should
+    proceed with the mutation (``confirm=True``).
+
+    The contract is **two-call**: the LLM first invokes the tool with
+    ``confirm=False`` to get the preview, surfaces it to the user, and
+    only re-invokes with ``confirm=True`` after the user agrees. Mutation
+    tools should also carry the MCP ``destructiveHint`` annotation so
+    spec-compliant clients prompt natively (tracked separately).
+
+    Why no server-side elicitation: ``ctx.elicit`` is unreliable across
+    MCP clients (notably broken in Claude Desktop). Per the MCP Tools
+    spec, clients SHOULD prompt; servers SHOULD NOT.
 
     Args:
-        context: FastMCP context — passed through to ``require_confirmation``.
-        preview: The preview dict for the tool's planned action. Surfaced
-            on both the preview path (``confirm=False``) and the
-            declined-elicitation path so the agent can show the user
-            what would have happened.
-        confirm: The tool's ``confirm`` parameter. When ``False`` the gate
-            short-circuits to the preview response without elicitation.
-        elicit_message: Human-readable confirmation prompt for
-            ``ctx.elicit`` (e.g. ``"Update conversation cnv_abc?"``).
+        preview: The preview dict for the tool's planned action. Returned
+            on the preview path so the agent can show the user what would
+            have happened.
+        confirm: The tool's ``confirm`` parameter. ``False`` short-circuits
+            to the preview response.
 
     Returns:
-        ``None`` if the user explicitly confirmed the action — caller proceeds.
-        Otherwise a dict with ``confirmed: False`` (and optional
-        ``preview`` / ``result`` keys) suitable for returning directly
-        from the tool.
+        ``None`` when ``confirm=True`` — caller proceeds with the mutation.
+        Otherwise a dict with ``preview`` and ``confirmed: False`` suitable
+        for returning directly from the tool.
 
     Example:
         >>> preview = {"action": "update", "id": conversation_id}
-        >>> gate = await confirm_or_preview(
-        ...     context,
-        ...     preview=preview,
-        ...     confirm=confirm,
-        ...     elicit_message=f"Update conversation {conversation_id}?",
-        ... )
+        >>> gate = confirm_or_preview(preview=preview, confirm=confirm)
         >>> if gate is not None:
         ...     return gate
         >>> # ... proceed with mutation
     """
     if not confirm:
         return {"preview": preview, "confirmed": False}
-
-    result = await require_confirmation(context, elicit_message)
-    if result is not ConfirmationResult.CONFIRMED:
-        return {"preview": preview, "confirmed": False, "result": result.value}
-
     return None
 
 
-__all__ = [
-    "ConfirmationResult",
-    "ConfirmationSchema",
-    "confirm_or_preview",
-    "require_confirmation",
-]
+__all__ = ["confirm_or_preview"]

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/tags.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/tags.py
@@ -189,12 +189,7 @@ def register_tools(mcp: FastMCP) -> None:
             "tag_id": tag_id,
             "semantics": "delta — does not replace existing tags",
         }
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=f"Add tag {tag_id} to conversation {conversation_id}?",
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 
@@ -223,12 +218,7 @@ def register_tools(mcp: FastMCP) -> None:
             "tag_id": tag_id,
             "semantics": "delta — only removes this tag",
         }
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=f"Remove tag {tag_id} from conversation {conversation_id}?",
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 
@@ -271,12 +261,7 @@ def register_tools(mcp: FastMCP) -> None:
             "is_visible_in_conversation_lists": is_visible_in_conversation_lists,
             "scope": "workspace-wide",
         }
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=f"Create workspace tag '{name}'?",
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 
@@ -312,12 +297,7 @@ def register_tools(mcp: FastMCP) -> None:
             "name": name,
             "highlight": highlight,
         }
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=f"Create child tag '{name}' under {parent_tag_id}?",
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 
@@ -377,13 +357,7 @@ def register_tools(mcp: FastMCP) -> None:
                 "confirmed": False,
                 "result": "no_changes_requested",
             }
-        summary = ", ".join(f"{k}={v}" for k, v in changes.items())
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=f"Update tag {tag_id}: {summary}?",
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 
@@ -418,14 +392,7 @@ def register_tools(mcp: FastMCP) -> None:
                 "currently has it. Cannot be undone."
             ),
         }
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=(
-                f"PERMANENTLY DELETE tag {tag_id}? Removes from every conversation that had it."
-            ),
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/teammates.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/teammates.py
@@ -144,13 +144,7 @@ def register_tools(mcp: FastMCP) -> None:
                 "confirmed": False,
                 "result": "no_changes_requested",
             }
-        summary = ", ".join(f"{k}={v}" for k, v in changes.items())
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=f"Update teammate {teammate_id}: {summary}?",
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/teams.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/teams.py
@@ -9,7 +9,7 @@ Concrete agent value: "reassign capacity to a team during a spike",
 "onboard new teammate Alice to the support team". Both follow the
 two-step ``confirm_or_preview`` pattern; the preview shows the count
 + ids of teammates being added/removed so the human sees what would
-happen before approving the elicitation.
+happen before re-invoking with ``confirm=True``.
 
 There is no ``create_team`` / ``delete_team`` in Front's API — teams
 are workspace-admin primitives created in Front's UI.
@@ -54,12 +54,7 @@ def register_tools(mcp: FastMCP) -> None:
             "teammate_count": len(teammate_ids),
             "teammate_ids": teammate_ids,
         }
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=(f"Add {len(teammate_ids)} teammate(s) to team {team_id}?"),
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 
@@ -95,14 +90,7 @@ def register_tools(mcp: FastMCP) -> None:
             "teammate_count": len(teammate_ids),
             "teammate_ids": teammate_ids,
         }
-        gate = await confirm_or_preview(
-            context,
-            preview=preview,
-            confirm=confirm,
-            elicit_message=(
-                f"Remove {len(teammate_ids)} teammate(s) from team {team_id}?"
-            ),
-        )
+        gate = confirm_or_preview(preview=preview, confirm=confirm)
         if gate is not None:
             return gate
 

--- a/frontapp_mcp_server/tests/conftest.py
+++ b/frontapp_mcp_server/tests/conftest.py
@@ -1,7 +1,7 @@
 """Shared pytest fixtures for MCP server tests."""
 
 import os
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 import pytest_asyncio
@@ -41,49 +41,19 @@ async def frontapp_context():
     yield context
 
 
-def create_mock_context(
-    elicit_confirm: bool = True, *, elicit_action: str | None = None
-):
+def create_mock_context():
     """Build a mock FastMCP context for unit tests.
 
-    The three values of ``ConfirmationResult`` map to elicit-result shape:
-
-    - CONFIRMED: ``action='accept'`` + ``data.confirm=True``
-    - DECLINED:  ``action='accept'`` + ``data.confirm=False``
-    - CANCELLED: ``action != 'accept'`` (typically ``'decline'``)
-
-    Args:
-        elicit_confirm: If True, the elicitation models user-confirmation
-            (CONFIRMED). If False, by default the elicitation is cancelled
-            (action='decline' → CANCELLED) — that's the historical
-            behavior.
-        elicit_action: Override the ``action`` field explicitly. Pass
-            ``'accept'`` together with ``elicit_confirm=False`` to
-            exercise the DECLINED branch (where the elicitation succeeds
-            but the user un-checks the confirm flag).
-
-    Returns:
-        Tuple of (context, lifespan_context).
+    Returns a (context, lifespan_context) tuple where the lifespan is the
+    same mock the tool sees via ``context.request_context.lifespan_context``.
+    Test cases assign ``lifespan.client = AsyncMock()`` (or similar) to
+    stub the helpers the tool calls into.
     """
-    if elicit_action is None:
-        elicit_action = "accept" if elicit_confirm else "decline"
-
     context = MagicMock()
     mock_request_context = MagicMock()
     mock_lifespan_context = MagicMock()
     context.request_context = mock_request_context
     mock_request_context.lifespan_context = mock_lifespan_context
-
-    mock_elicit_result = MagicMock()
-    mock_elicit_result.action = elicit_action
-    if elicit_action == "accept":
-        mock_elicit_result.data = MagicMock()
-        mock_elicit_result.data.confirm = elicit_confirm
-    else:
-        mock_elicit_result.data = None
-
-    context.elicit = AsyncMock(return_value=mock_elicit_result)
-
     return context, mock_lifespan_context
 
 

--- a/frontapp_mcp_server/tests/test_attachments_tools.py
+++ b/frontapp_mcp_server/tests/test_attachments_tools.py
@@ -83,7 +83,6 @@ class TestDownloadAttachment:
             },
             "confirmed": False,
         }
-        context.elicit.assert_not_called()
 
     async def test_will_overwrite_flag_when_target_exists(
         self, attachments_tools, tmp_path: Path
@@ -101,7 +100,7 @@ class TestDownloadAttachment:
         assert result["preview"]["will_overwrite"] is True
 
     async def test_writes_bytes_when_confirmed(self, attachments_tools, tmp_path: Path):
-        context, lifespan = create_mock_context(elicit_confirm=True)
+        context, lifespan = create_mock_context()
 
         async def fake_stream(_url, *, chunk_size=65536):
             yield b"chunk-1-"
@@ -123,35 +122,11 @@ class TestDownloadAttachment:
             "size_bytes": len(b"chunk-1-chunk-2"),
         }
         assert target.read_bytes() == b"chunk-1-chunk-2"
-        context.elicit.assert_called_once()
-
-    async def test_declined_elicitation_does_not_write(
-        self, attachments_tools, tmp_path: Path
-    ):
-        context, lifespan = create_mock_context(
-            elicit_confirm=False, elicit_action="accept"
-        )
-        # If stream is invoked, the test should fail.
-        lifespan.client = AsyncMock()
-        lifespan.client.attachments.stream = AsyncMock(
-            side_effect=AssertionError("stream invoked on declined elicitation")
-        )
-
-        target = tmp_path / "saved.bin"
-        result = await attachments_tools["download_attachment"](
-            context,
-            attachment_url="https://api.frontapp.test/download/fil_x",
-            save_path=str(target),
-            confirm=True,
-        )
-        assert result["confirmed"] is False
-        assert result["result"] == "declined"
-        assert not target.exists()
 
     async def test_partial_write_cleaned_up_on_error(
         self, attachments_tools, tmp_path: Path
     ):
-        context, lifespan = create_mock_context(elicit_confirm=True)
+        context, lifespan = create_mock_context()
 
         async def fake_stream(_url, *, chunk_size=65536):
             yield b"first chunk"
@@ -181,7 +156,7 @@ class TestDraftAttachmentPaths:
     async def test_create_draft_on_channel_resolves_paths(
         self, drafts_tools, tmp_path: Path
     ):
-        context, lifespan = create_mock_context(elicit_confirm=True)
+        context, lifespan = create_mock_context()
         f1 = tmp_path / "doc.pdf"
         f1.write_bytes(b"%PDF-fake")
         f2 = tmp_path / "image.png"

--- a/frontapp_mcp_server/tests/test_contact_lists_tools.py
+++ b/frontapp_mcp_server/tests/test_contact_lists_tools.py
@@ -105,7 +105,6 @@ class TestPreviewPath:
 
         assert result["confirmed"] is False
         assert "preview" in result
-        context.elicit.assert_not_called()
 
     async def test_remove_over_50_returns_error_without_calling_elicit(
         self, lists_tools
@@ -123,7 +122,6 @@ class TestPreviewPath:
 
         assert result["confirmed"] is False
         assert "caps remove_contacts at 50" in result["error"]
-        context.elicit.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -160,16 +158,3 @@ class TestConfirmedExecution:
             "lst_a", ["crd_1", "crd_2"]
         )
         assert result["added_count"] == 2
-
-    async def test_declined_does_not_call_helper(self, lists_tools):
-        context, lifespan = create_mock_context(elicit_confirm=False)
-        lifespan.client = AsyncMock(
-            side_effect=AssertionError("client invoked when declined")
-        )
-
-        result = await lists_tools["delete_contact_list"](
-            context, contact_list_id="lst_a", confirm=True
-        )
-
-        assert result["confirmed"] is False
-        assert result["result"] == "cancelled"

--- a/frontapp_mcp_server/tests/test_contacts_tools.py
+++ b/frontapp_mcp_server/tests/test_contacts_tools.py
@@ -77,7 +77,6 @@ class TestPreviewPath:
 
         assert result["confirmed"] is False
         assert "preview" in result
-        context.elicit.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -94,28 +93,6 @@ class TestUpdateNoChanges:
             context, contact_id="crd_a", confirm=True
         )
         assert result["result"] == "no_changes_requested"
-        # Should NOT call the helper or elicit when nothing changes.
-        context.elicit.assert_not_called()
-
-
-# ---------------------------------------------------------------------------
-# Decline path
-# ---------------------------------------------------------------------------
-
-
-class TestDeclinePath:
-    async def test_delete_contact_declined(self, contacts_tools):
-        context, lifespan = create_mock_context(elicit_confirm=False)
-        lifespan.client = AsyncMock(
-            side_effect=AssertionError("client invoked after decline")
-        )
-
-        result = await contacts_tools["delete_contact"](
-            context, contact_id="crd_a", confirm=True
-        )
-        assert result["confirmed"] is False
-        assert result["result"] == "cancelled"
-        context.elicit.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/frontapp_mcp_server/tests/test_conversations_tools.py
+++ b/frontapp_mcp_server/tests/test_conversations_tools.py
@@ -137,7 +137,6 @@ class TestUpdateConversation:
 
         assert result["confirmed"] is False
         assert result["preview"]["changes"] == {"status": "archived"}
-        context.elicit.assert_not_called()
         lifespan.client.conversations.update.assert_not_awaited()
 
     async def test_no_changes_short_circuits(self, conversations_tools):
@@ -152,43 +151,6 @@ class TestUpdateConversation:
 
         assert result["result"] == "no_changes_requested"
         assert result["confirmed"] is False
-        context.elicit.assert_not_called()
-
-    async def test_cancelled_does_not_call_helper(self, conversations_tools):
-        """User cancelled the elicitation (``action='decline'``) → CANCELLED."""
-        context, lifespan = create_mock_context(elicit_action="decline")
-        lifespan.client = AsyncMock()
-        lifespan.client.conversations.update = AsyncMock(
-            side_effect=AssertionError("helper invoked after cancel")
-        )
-
-        result = await conversations_tools["update_conversation"](
-            context, conversation_id="cnv_a", status="archived", confirm=True
-        )
-
-        assert result["confirmed"] is False
-        assert result["result"] == "cancelled"
-        context.elicit.assert_called_once()
-        lifespan.client.conversations.update.assert_not_awaited()
-
-    async def test_declined_does_not_call_helper(self, conversations_tools):
-        """User accepted the elicitation but unchecked confirm → DECLINED."""
-        context, lifespan = create_mock_context(
-            elicit_confirm=False, elicit_action="accept"
-        )
-        lifespan.client = AsyncMock()
-        lifespan.client.conversations.update = AsyncMock(
-            side_effect=AssertionError("helper invoked after decline")
-        )
-
-        result = await conversations_tools["update_conversation"](
-            context, conversation_id="cnv_a", status="archived", confirm=True
-        )
-
-        assert result["confirmed"] is False
-        assert result["result"] == "declined"
-        context.elicit.assert_called_once()
-        lifespan.client.conversations.update.assert_not_awaited()
 
     async def test_confirmed_calls_helper(self, conversations_tools):
         context, lifespan = create_mock_context()
@@ -256,40 +218,6 @@ class TestAddConversationComment:
             context, conversation_id="cnv_a", body="Short", confirm=False
         )
         assert result["preview"]["body_preview"] == "Short"
-
-    async def test_cancelled_does_not_call_helper(self, conversations_tools):
-        """User cancelled the elicitation (``action='decline'``) → CANCELLED."""
-        context, lifespan = create_mock_context(elicit_action="decline")
-        lifespan.client = AsyncMock()
-        lifespan.client.conversations.add_comment = AsyncMock(
-            side_effect=AssertionError("helper invoked after cancel")
-        )
-
-        result = await conversations_tools["add_conversation_comment"](
-            context, conversation_id="cnv_a", body="Note", confirm=True
-        )
-
-        assert result["confirmed"] is False
-        assert result["result"] == "cancelled"
-        lifespan.client.conversations.add_comment.assert_not_awaited()
-
-    async def test_declined_does_not_call_helper(self, conversations_tools):
-        """User accepted the elicitation but unchecked confirm → DECLINED."""
-        context, lifespan = create_mock_context(
-            elicit_confirm=False, elicit_action="accept"
-        )
-        lifespan.client = AsyncMock()
-        lifespan.client.conversations.add_comment = AsyncMock(
-            side_effect=AssertionError("helper invoked after decline")
-        )
-
-        result = await conversations_tools["add_conversation_comment"](
-            context, conversation_id="cnv_a", body="Note", confirm=True
-        )
-
-        assert result["confirmed"] is False
-        assert result["result"] == "declined"
-        lifespan.client.conversations.add_comment.assert_not_awaited()
 
     async def test_confirmed_calls_helper(self, conversations_tools):
         context, lifespan = create_mock_context()

--- a/frontapp_mcp_server/tests/test_drafts_tools.py
+++ b/frontapp_mcp_server/tests/test_drafts_tools.py
@@ -58,8 +58,6 @@ class TestPreviewPath:
             },
             "confirmed": False,
         }
-        # elicit() is never invoked on the preview path.
-        context.elicit.assert_not_called()
 
     async def test_create_draft_reply_preview(self, drafts_tools):
         context, lifespan = create_mock_context()
@@ -111,30 +109,6 @@ class TestPreviewPath:
             "preview": {"action": "delete_draft", "draft_id": "msg_abc"},
             "confirmed": False,
         }
-
-
-# ---------------------------------------------------------------------------
-# Two-step confirm — declined elicitation
-# ---------------------------------------------------------------------------
-
-
-class TestDeclinedElicitation:
-    """When the user declines elicitation, the tool must NOT call the API."""
-
-    async def test_delete_draft_declined(self, drafts_tools):
-        context, lifespan = create_mock_context(elicit_confirm=False)
-        lifespan.client = AsyncMock(
-            side_effect=AssertionError("client invoked after decline")
-        )
-
-        result = await drafts_tools["delete_draft"](
-            context, draft_id="msg_abc", confirm=True
-        )
-
-        assert result["confirmed"] is False
-        assert result["result"] == "cancelled"
-        # Elicitation WAS invoked (unlike the preview path).
-        context.elicit.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/frontapp_mcp_server/tests/test_inboxes_tools.py
+++ b/frontapp_mcp_server/tests/test_inboxes_tools.py
@@ -82,7 +82,6 @@ class TestPreviewPath:
 
         assert result["confirmed"] is False
         assert "preview" in result
-        context.elicit.assert_not_called()
 
 
 class TestPreviewIncludesTeammateCount:
@@ -153,17 +152,3 @@ class TestConfirmedExecution:
             "inb_a", teammate_ids=["tea_1"]
         )
         assert result == {"confirmed": True, "revoked": True}
-
-
-class TestDeclinePath:
-    async def test_grant_access_declined(self, inboxes_tools):
-        context, lifespan = create_mock_context(elicit_confirm=False)
-        lifespan.client = AsyncMock(
-            side_effect=AssertionError("client invoked after decline")
-        )
-
-        result = await inboxes_tools["grant_inbox_access"](
-            context, inbox_id="inb_a", teammate_ids=["tea_1"], confirm=True
-        )
-        assert result["confirmed"] is False
-        assert result["result"] == "cancelled"

--- a/frontapp_mcp_server/tests/test_knowledge_bases_tools.py
+++ b/frontapp_mcp_server/tests/test_knowledge_bases_tools.py
@@ -166,7 +166,6 @@ class TestCreateArticleDraftsOnly:
         # The preview surfaces status: "draft" so the human sees what
         # publication state will result.
         assert result["preview"]["status"] == "draft"
-        context.elicit.assert_not_called()
 
     async def test_confirmed_calls_helper_with_draft_status(self, kb_tools):
         """The MCP layer's drafts-only policy: status='draft' is hardcoded
@@ -298,27 +297,3 @@ class TestCategoryMutations:
         assert call is not None
         assert call.kwargs["name"] == "Renamed"
         assert call.kwargs["description"] is None
-
-
-# ---------------------------------------------------------------------------
-# Decline path
-# ---------------------------------------------------------------------------
-
-
-class TestDeclinedElicitation:
-    async def test_create_article_declined_does_not_call_helper(self, kb_tools):
-        context, lifespan = create_mock_context(elicit_confirm=False)
-        lifespan.client = AsyncMock(
-            side_effect=AssertionError("client invoked after decline")
-        )
-
-        result = await kb_tools["create_kb_article"](
-            context,
-            knowledge_base_id="knb_1",
-            subject="x",
-            content="y",
-            confirm=True,
-        )
-        assert result["confirmed"] is False
-        assert result["result"] == "cancelled"
-        context.elicit.assert_called_once()

--- a/frontapp_mcp_server/tests/test_messages_tools.py
+++ b/frontapp_mcp_server/tests/test_messages_tools.py
@@ -101,21 +101,6 @@ class TestMarkMessageSeen:
         assert result["confirmed"] is False
         assert result["preview"]["message_id"] == "msg_abc"
         assert result["preview"]["rate_limit"] == "10 req/msg/hour"
-        context.elicit.assert_not_called()
-
-    async def test_declined_does_not_call_helper(self, messages_tools):
-        context, lifespan = create_mock_context(elicit_confirm=False)
-        lifespan.client = AsyncMock(
-            side_effect=AssertionError("client invoked after decline")
-        )
-
-        result = await messages_tools["mark_message_seen"](
-            context, message_id="msg_abc", confirm=True
-        )
-
-        assert result["confirmed"] is False
-        assert result["result"] == "cancelled"
-        context.elicit.assert_called_once()
 
     async def test_confirmed_calls_helper(self, messages_tools):
         context, lifespan = create_mock_context()

--- a/frontapp_mcp_server/tests/test_tags_tools.py
+++ b/frontapp_mcp_server/tests/test_tags_tools.py
@@ -92,7 +92,6 @@ class TestPreviewPath:
 
         assert result["confirmed"] is False
         assert "preview" in result
-        context.elicit.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -126,7 +125,6 @@ class TestUpdateNoChanges:
 
         result = await tags_tools["update_tag"](context, tag_id="tag_a", confirm=True)
         assert result["result"] == "no_changes_requested"
-        context.elicit.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -187,23 +185,6 @@ class TestConfirmedExecution:
 
         lifespan.client.tags.delete.assert_awaited_once_with("tag_abc")
         assert result == {"confirmed": True, "deleted": True}
-
-
-# ---------------------------------------------------------------------------
-# Decline path
-# ---------------------------------------------------------------------------
-
-
-class TestDeclinePath:
-    async def test_delete_tag_declined(self, tags_tools):
-        context, lifespan = create_mock_context(elicit_confirm=False)
-        lifespan.client = AsyncMock(
-            side_effect=AssertionError("client invoked after decline")
-        )
-
-        result = await tags_tools["delete_tag"](context, tag_id="tag_abc", confirm=True)
-        assert result["confirmed"] is False
-        assert result["result"] == "cancelled"
 
 
 # ---------------------------------------------------------------------------

--- a/frontapp_mcp_server/tests/test_teammates_tools.py
+++ b/frontapp_mcp_server/tests/test_teammates_tools.py
@@ -108,7 +108,6 @@ class TestUpdateTeammate:
 
         assert result["confirmed"] is False
         assert result["preview"]["changes"] == {"first_name": "Alicia"}
-        context.elicit.assert_not_called()
         lifespan.client.teammates.update.assert_not_awaited()
 
     async def test_no_changes_short_circuits(self, teammates_tools):
@@ -121,41 +120,6 @@ class TestUpdateTeammate:
 
         assert result["result"] == "no_changes_requested"
         assert result["confirmed"] is False
-        context.elicit.assert_not_called()
-
-    async def test_cancelled_does_not_call_helper(self, teammates_tools):
-        """User cancelled the elicitation (action='decline') → CANCELLED."""
-        context, lifespan = create_mock_context(elicit_action="decline")
-        lifespan.client = AsyncMock()
-        lifespan.client.teammates.update = AsyncMock(
-            side_effect=AssertionError("helper invoked after cancel")
-        )
-
-        result = await teammates_tools["update_teammate"](
-            context, teammate_id="tea_a", first_name="Alicia", confirm=True
-        )
-
-        assert result["confirmed"] is False
-        assert result["result"] == "cancelled"
-        lifespan.client.teammates.update.assert_not_awaited()
-
-    async def test_declined_does_not_call_helper(self, teammates_tools):
-        """User accepted but unchecked the confirm flag → DECLINED."""
-        context, lifespan = create_mock_context(
-            elicit_confirm=False, elicit_action="accept"
-        )
-        lifespan.client = AsyncMock()
-        lifespan.client.teammates.update = AsyncMock(
-            side_effect=AssertionError("helper invoked after decline")
-        )
-
-        result = await teammates_tools["update_teammate"](
-            context, teammate_id="tea_a", first_name="Alicia", confirm=True
-        )
-
-        assert result["confirmed"] is False
-        assert result["result"] == "declined"
-        lifespan.client.teammates.update.assert_not_awaited()
 
     async def test_confirmed_calls_helper(self, teammates_tools):
         context, lifespan = create_mock_context()

--- a/frontapp_mcp_server/tests/test_workspace_admin_closeouts_tools.py
+++ b/frontapp_mcp_server/tests/test_workspace_admin_closeouts_tools.py
@@ -51,7 +51,6 @@ class TestAddTeamMembers:
         assert result["confirmed"] is False
         assert result["preview"]["teammate_count"] == 2
         assert result["preview"]["teammate_ids"] == ["tea_a", "tea_b"]
-        context.elicit.assert_not_called()
 
     async def test_confirmed_calls_helper(self, teams_tools):
         context, lifespan = create_mock_context()
@@ -67,21 +66,6 @@ class TestAddTeamMembers:
         assert result["confirmed"] is True
         assert result["added_count"] == 1
         lifespan.client.teams.add_teammates.assert_awaited_once_with("tim_1", ["tea_a"])
-
-    async def test_declined_elicitation_does_not_call_helper(self, teams_tools):
-        context, lifespan = create_mock_context(elicit_confirm=False)
-        lifespan.client = AsyncMock(
-            side_effect=AssertionError("client invoked after decline")
-        )
-
-        result = await teams_tools["add_team_members"](
-            context,
-            team_id="tim_1",
-            teammate_ids=["tea_a"],
-            confirm=True,
-        )
-        assert result["confirmed"] is False
-        context.elicit.assert_called_once()
 
 
 class TestRemoveTeamMembers:
@@ -138,7 +122,6 @@ class TestTriggerApplicationEvent:
         assert result["confirmed"] is False
         assert result["preview"]["event_type"] == "customer_replied"
         assert result["preview"]["app_object_id"] == "cnv_abc"
-        context.elicit.assert_not_called()
 
     async def test_confirmed_with_id_calls_helper(self, applications_tools):
         context, lifespan = create_mock_context()
@@ -176,18 +159,3 @@ class TestTriggerApplicationEvent:
         assert call is not None
         assert call.kwargs["app_object_ext_link"] == "https://example.com/x"
         assert call.kwargs["app_object_id"] is None
-
-    async def test_declined_does_not_call_helper(self, applications_tools):
-        context, lifespan = create_mock_context(elicit_confirm=False)
-        lifespan.client = AsyncMock(
-            side_effect=AssertionError("client invoked after decline")
-        )
-
-        result = await applications_tools["trigger_application_event"](
-            context,
-            application_uid="app_xyz",
-            event_type="x",
-            app_object_id="cnv_y",
-            confirm=True,
-        )
-        assert result["confirmed"] is False


### PR DESCRIPTION
## Summary

`ctx.elicit()` is unreliable across MCP clients — notably broken in Claude Desktop and several others where the elicit call never resolves, so the user never sees the prompt and the mutation never executes (per the sibling investigation in [statuspro #52](https://github.com/dougborg/statuspro-openapi-client/pull/52)).

`confirm_or_preview` is now a sync, two-call gate:
- `confirm=False` → returns the preview dict
- `confirm=True` → returns `None` and the caller proceeds

The agent is responsible for surfacing the preview to the user and only re-invoking with `confirm=True` after the user agrees. This matches the MCP Tools spec: clients SHOULD prompt; servers SHOULD NOT.

## Changes

- `tools/schemas.py`: simplified `confirm_or_preview` signature; removed `ConfirmationSchema`, `ConfirmationResult`, `require_confirmation`
- All ~47 call sites in `tools/*.py` updated to the new signature (no `context` arg, no `elicit_message`, no `await`)
- Dead "user declined" / "user cancelled" test classes/methods removed
- `tests/conftest.py`: simplified `create_mock_context` (no elicit mocking)
- ADRs 0010, 0016, 0017: documented the post-elicit pattern with rationale
- `README.md`, `docs/examples.md`, `resources/help.py`: updated user-facing copy

Net diff: **+176 / −883 lines** across 32 files.

## Follow-up

Phase B — annotating mutation tools with `destructiveHint=True` so spec-compliant clients prompt natively — is tracked separately as #114.

## Test plan

- [x] `uv run poe check` passes (lint, typecheck, 608 tests, api-facts check)
- [x] `uv run poe full-check` passes (incl. mkdocs build)
- [ ] Manual smoke in Claude Desktop: `update_conversation` with `confirm=False` returns preview; subsequent call with `confirm=True` executes
- [ ] Manual smoke: confirm tools no longer hang on `ctx.elicit` in Claude Desktop

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)