### PR TITLE
chore(ci): add pre-push guard hook to block accidental main pushes (#105)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,11 @@
 #
 # See issue #134 for background on why we use local hooks.
 
+# Make `pre-commit install` set up the pre-push hook too. Without this, the
+# pre-push hook would silently not run for contributors who only ran the bare
+# `pre-commit install` from the README. See block-push-to-main below.
+default_install_hook_types: [pre-commit, pre-push]
+
 repos:
   - repo: local
     hooks:
@@ -53,5 +58,15 @@ repos:
         name: pytest
         entry: uv run poe test
         language: system
+        pass_filenames: false
+        always_run: true
+
+      # Pre-push guard: block accidental pushes to main from a non-main branch.
+      # See scripts/pre-push-guard.sh and CLAUDE.md "Known Pitfalls".
+      - id: block-push-to-main
+        name: block direct push to main from a non-main branch
+        entry: scripts/pre-push-guard.sh
+        language: system
+        stages: [pre-push]
         pass_filenames: false
         always_run: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,12 @@ Common mistakes to avoid:
   hand-written modules, extend the `typecheck` task path list in `pyproject.toml` to
   include them. Revisit the exclusion when ty hits 1.0 — tracked in
   [issue #8](https://github.com/dougborg/frontapp-openapi-client/issues/8).
+- **`git push -u origin <branch>` can land on main** — when a feature branch is created
+  via `git checkout -b <name> origin/main`, its upstream is `origin/main`, so a bare
+  `git push -u origin <name>` resolves to main and bypasses PR review. The
+  `scripts/pre-push-guard.sh` pre-commit hook blocks this. The right form for first-time
+  pushes is `git push -u origin HEAD:refs/heads/<branch-name>`. `--no-verify` is
+  forbidden — fix the push command instead.
 
 ## Using the LSP tool
 

--- a/scripts/pre-push-guard.sh
+++ b/scripts/pre-push-guard.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Pre-push guard: refuse pushes that land non-main commits on the `main` ref.
+#
+# Why this exists: when a feature branch is created via
+#   git checkout -b <name> origin/main
+# git sets the new local branch's upstream to origin/main. A subsequent
+#   git push -u origin <name>
+# resolves <name> to the tracked upstream and pushes straight to main —
+# bypassing PR review and triggering whatever release automation is wired
+# into the main branch. A sibling repo hit this exactly once and required
+# a force-revert; this guard prevents the same mistake here.
+#
+# pre-commit invokes this with the remote name as $1, the URL as $2, and
+# `<local-ref> <local-sha> <remote-ref> <remote-sha>` lines on stdin.
+#
+# Bypass via --no-verify is forbidden by project policy (see CLAUDE.md). The
+# right form for first-time feature-branch pushes is:
+#   git push -u origin HEAD:refs/heads/<branch-name>
+
+set -euo pipefail
+
+EXIT_CODE=0
+
+while read -r local_ref _local_sha remote_ref _remote_sha; do
+    # Skip deletions (local_ref is empty when a remote ref is being deleted).
+    [ -z "$local_ref" ] && continue
+
+    # Only guard pushes that target main.
+    case "$remote_ref" in
+        refs/heads/main) ;;
+        *) continue ;;
+    esac
+
+    # The local ref-name pushed to main must itself be `main`. Refuse anything else.
+    case "$local_ref" in
+        refs/heads/main)
+            # ok — main → main is the legitimate path for admins/release automation
+            ;;
+        refs/heads/*)
+            # Branch other than main → main: the common upstream-tracking mistake.
+            # Suggest the canonical safe form with the actual branch name.
+            local_short="${local_ref#refs/heads/}"
+            cat >&2 <<EOF
+ERROR: refusing to push '$local_short' to remote 'main'.
+
+This is almost always git's tracked-upstream resolution biting you — the
+local branch was probably created via 'git checkout -b $local_short origin/main',
+so its upstream is origin/main and a bare 'git push -u origin $local_short' targets main.
+
+The fix: use an explicit destination ref so the remote branch name matches:
+
+    git push -u origin HEAD:refs/heads/$local_short
+
+If you genuinely need to push to main from a non-main branch (rare), do it
+through a PR. Bypassing this hook with --no-verify is forbidden by project policy
+— see CLAUDE.md 'Known Pitfalls'.
+EOF
+            EXIT_CODE=1
+            ;;
+        *)
+            # Detached HEAD push, tag-to-main push, or some other unusual ref shape.
+            # Don't try to construct a branch name from a ref we don't understand —
+            # print a generic safe form instead.
+            cat >&2 <<EOF
+ERROR: refusing to push '$local_ref' to remote 'main'.
+
+The local ref isn't a normal branch (got: $local_ref). Pushes to main from
+anything other than the local 'main' branch are blocked.
+
+If you intended to push your current work to a new feature branch:
+
+    git push -u origin HEAD:refs/heads/<branch-name>
+
+Then open a PR. Bypassing this hook with --no-verify is forbidden by project
+policy — see CLAUDE.md 'Known Pitfalls'.
+EOF
+            EXIT_CODE=1
+            ;;
+    esac
+done
+
+exit "$EXIT_CODE"


### PR DESCRIPTION
## Summary

Adds a pre-push hook that refuses `git push` operations targeting `refs/heads/main` from any local ref other than `main` itself.

**Why**: Git's tracked-upstream resolution can land an unrelated feature branch on main if upstream is misconfigured. When a feature branch is created via `git checkout -b <name> origin/main`, its upstream is `origin/main`, so a bare `git push -u origin <name>` resolves to main and bypasses PR review. A sibling repo (katana) hit this exactly once and needed a force-revert.

The right form for first-time feature-branch pushes is now `git push -u origin HEAD:refs/heads/<branch-name>` — the hook's error message tells you the exact safe command for your branch.

## Changes

- `scripts/pre-push-guard.sh` — guard script, adapted from [katana #434](https://github.com/dougborg/katana-openapi-client/pull/434)
- `.pre-commit-config.yaml` — wires the script as a `pre-push` stage hook, plus `default_install_hook_types: [pre-commit, pre-push]` so a bare `pre-commit install` enables both stages
- `CLAUDE.md` "Known Pitfalls" — entry pointing at the guard and the safe push form

## Test plan

Manually verified the four acceptance criteria from #105:

- [x] `git push origin HEAD:main` from a feature branch is blocked with an explanatory message (exit 1)
- [x] `git push` from `main` to `origin/main` still works (exit 0)
- [x] `git push -u origin HEAD:refs/heads/<branch>` for normal feature work passes (exit 0) — verified by this PR's own push, where the hook ran and Passed
- [x] Hook runs only at the `pre-push` stage, not on every commit

The hook also handles edge cases: branch deletions are allowed, detached-HEAD pushes to main are blocked with a generic message.

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)