### PR TITLE
feat(mcp): mark mutation tools with destructiveHint annotation (#114)

### DIFF
--- a/frontapp_mcp_server/src/frontapp_mcp/resources/help.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/resources/help.py
@@ -376,6 +376,12 @@ Every tool that changes data on the Front side takes `confirm: bool = False`.
   the preview to the user and only re-invoking with `confirm=True` after
   the user has agreed.
 
+Mutation tools also carry the MCP `destructiveHint=true` annotation so
+spec-compliant clients (Claude Desktop with appropriate settings, Cline,
+Cursor MCP integration, and others) prompt the user before invoking. The
+in-band `confirm=False` preview remains the canonical contract — the
+annotation is a client-side complement, not a replacement.
+
 ## Rate limits
 
 Front enforces per-endpoint rate limits documented in its API reference. The

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/applications.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/applications.py
@@ -22,7 +22,7 @@ from fastmcp import Context, FastMCP
 from pydantic import Field
 
 from frontapp_mcp.services import get_services
-from frontapp_mcp.tools.schemas import confirm_or_preview
+from frontapp_mcp.tools.schemas import DESTRUCTIVE, confirm_or_preview
 
 
 def register_tools(mcp: FastMCP) -> None:
@@ -40,6 +40,7 @@ def register_tools(mcp: FastMCP) -> None:
             "Two-step confirm because the event may trigger workflows "
             "that mutate conversation state."
         ),
+        annotations=DESTRUCTIVE,
     )
     async def trigger_application_event(
         context: Context,

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/attachments.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/attachments.py
@@ -24,6 +24,7 @@ from pydantic import Field
 
 from frontapp_mcp.services import get_services
 from frontapp_mcp.tools.schemas import (
+    DESTRUCTIVE,
     confirm_or_preview,
 )
 
@@ -41,6 +42,7 @@ def register_tools(mcp: FastMCP) -> None:
             "the file will be written; confirm=True performs the download. "
             "Returns the saved path and byte count."
         ),
+        annotations=DESTRUCTIVE,
     )
     async def download_attachment(
         context: Context,

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/contact_groups.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/contact_groups.py
@@ -24,7 +24,7 @@ from frontapp_mcp.projections import (
     to_contact_summary,
 )
 from frontapp_mcp.services import get_services
-from frontapp_mcp.tools.schemas import confirm_or_preview
+from frontapp_mcp.tools.schemas import DESTRUCTIVE, confirm_or_preview
 from frontapp_public_api_client.helpers.constants import (
     CONTACT_BUCKET_REMOVE_CAP,
     cap_error_message,
@@ -119,6 +119,7 @@ def register_tools(mcp: FastMCP) -> None:
             "create_team_contact_group when the team is known. Two-step "
             "confirm."
         ),
+        annotations=DESTRUCTIVE,
     )
     async def create_contact_group(
         context: Context,
@@ -141,6 +142,7 @@ def register_tools(mcp: FastMCP) -> None:
         description=(
             f"{_DEPRECATION_NOTE} Create a team-scoped contact group. Two-step confirm."
         ),
+        annotations=DESTRUCTIVE,
     )
     async def create_team_contact_group(
         context: Context,
@@ -169,6 +171,7 @@ def register_tools(mcp: FastMCP) -> None:
             f"{_DEPRECATION_NOTE} Create a teammate-scoped (private) "
             "contact group. Two-step confirm."
         ),
+        annotations=DESTRUCTIVE,
     )
     async def create_teammate_contact_group(
         context: Context,
@@ -198,6 +201,7 @@ def register_tools(mcp: FastMCP) -> None:
             "group and all memberships, but does NOT delete the underlying "
             "contacts. Two-step confirm."
         ),
+        annotations=DESTRUCTIVE,
     )
     async def delete_contact_group(
         context: Context,
@@ -226,6 +230,7 @@ def register_tools(mcp: FastMCP) -> None:
             "contact_ids accepts both 'crd_*' ids and Front resource "
             "aliases. Two-step confirm."
         ),
+        annotations=DESTRUCTIVE,
     )
     async def add_contacts_to_group(
         context: Context,
@@ -262,6 +267,7 @@ def register_tools(mcp: FastMCP) -> None:
             "contact_ids accepts both 'crd_*' ids and Front resource "
             "aliases. CAPPED at 50 contact_ids per call. Two-step confirm."
         ),
+        annotations=DESTRUCTIVE,
     )
     async def remove_contacts_from_group(
         context: Context,

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/contact_lists.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/contact_lists.py
@@ -20,7 +20,7 @@ from frontapp_mcp.projections import (
     to_contact_summary,
 )
 from frontapp_mcp.services import get_services
-from frontapp_mcp.tools.schemas import confirm_or_preview
+from frontapp_mcp.tools.schemas import DESTRUCTIVE, confirm_or_preview
 from frontapp_public_api_client.helpers.constants import (
     CONTACT_BUCKET_REMOVE_CAP,
     cap_error_message,
@@ -111,6 +111,7 @@ def register_tools(mcp: FastMCP) -> None:
             "team. Two-step confirm. The new list's id is NOT returned by "
             "Front; follow up with list_contact_lists and match by name."
         ),
+        annotations=DESTRUCTIVE,
     )
     async def create_contact_list(
         context: Context,
@@ -134,6 +135,7 @@ def register_tools(mcp: FastMCP) -> None:
             "Create a team-scoped contact list. Preferred over "
             "create_contact_list when the team is known. Two-step confirm."
         ),
+        annotations=DESTRUCTIVE,
     )
     async def create_team_contact_list(
         context: Context,
@@ -159,6 +161,7 @@ def register_tools(mcp: FastMCP) -> None:
     @mcp.tool(
         name="create_teammate_contact_list",
         description="Create a teammate-scoped (private) contact list. Two-step confirm.",
+        annotations=DESTRUCTIVE,
     )
     async def create_teammate_contact_list(
         context: Context,
@@ -190,6 +193,7 @@ def register_tools(mcp: FastMCP) -> None:
             "memberships, but does NOT delete the underlying contacts — "
             "they remain in the workspace. Two-step confirm."
         ),
+        annotations=DESTRUCTIVE,
     )
     async def delete_contact_list(
         context: Context,
@@ -218,6 +222,7 @@ def register_tools(mcp: FastMCP) -> None:
             "'crd_*' ids and Front resource aliases like "
             "'alt:email:foo@example.com'. Two-step confirm."
         ),
+        annotations=DESTRUCTIVE,
     )
     async def add_contacts_to_contact_list(
         context: Context,
@@ -257,6 +262,7 @@ def register_tools(mcp: FastMCP) -> None:
             "call by Front's server-side validation — split larger "
             "removals into multiple calls. Two-step confirm."
         ),
+        annotations=DESTRUCTIVE,
     )
     async def remove_contacts_from_contact_list(
         context: Context,

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/contacts.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/contacts.py
@@ -29,6 +29,7 @@ from frontapp_mcp.projections import (
 )
 from frontapp_mcp.services import get_services
 from frontapp_mcp.tools.schemas import (
+    DESTRUCTIVE,
     confirm_or_preview,
 )
 
@@ -184,6 +185,7 @@ def register_tools(mcp: FastMCP) -> None:
             "list of {handle, source} dicts, where source is one of email, "
             "phone, custom, facebook, front_chat, intercom, twitter."
         ),
+        annotations=DESTRUCTIVE,
     )
     async def create_contact(
         context: Context,
@@ -236,6 +238,7 @@ def register_tools(mcp: FastMCP) -> None:
     @mcp.tool(
         name="create_team_contact",
         description="Create a contact owned by a team. Same shape as create_contact, scoped to a team_id.",
+        annotations=DESTRUCTIVE,
     )
     async def create_team_contact(
         context: Context,
@@ -276,6 +279,7 @@ def register_tools(mcp: FastMCP) -> None:
     @mcp.tool(
         name="create_teammate_contact",
         description="Create a contact owned by a teammate. Scoped to a teammate_id.",
+        annotations=DESTRUCTIVE,
     )
     async def create_teammate_contact(
         context: Context,
@@ -316,6 +320,7 @@ def register_tools(mcp: FastMCP) -> None:
             "changes go through add_contact_handle / delete_contact_handle, "
             "NOT this tool — Front's PATCH body doesn't accept handles."
         ),
+        annotations=DESTRUCTIVE,
     )
     async def update_contact(
         context: Context,
@@ -376,6 +381,7 @@ def register_tools(mcp: FastMCP) -> None:
             "the merged contacts are deleted. If target_contact_id is "
             "omitted, Front picks the target. Two-step confirm."
         ),
+        annotations=DESTRUCTIVE,
     )
     async def merge_contacts(
         context: Context,
@@ -410,6 +416,7 @@ def register_tools(mcp: FastMCP) -> None:
             "DESTRUCTIVE: permanently delete a contact and all its handles. "
             "Cannot be undone. Two-step confirm."
         ),
+        annotations=DESTRUCTIVE,
     )
     async def delete_contact(
         context: Context,
@@ -432,6 +439,7 @@ def register_tools(mcp: FastMCP) -> None:
     @mcp.tool(
         name="add_contact_note",
         description="Add an internal teammate note to a contact (not visible to customer).",
+        annotations=DESTRUCTIVE,
     )
     async def add_contact_note(
         context: Context,
@@ -462,6 +470,7 @@ def register_tools(mcp: FastMCP) -> None:
     @mcp.tool(
         name="add_contact_handle",
         description="Add a handle (email/phone/etc.) to an existing contact.",
+        annotations=DESTRUCTIVE,
     )
     async def add_contact_handle(
         context: Context,
@@ -497,6 +506,7 @@ def register_tools(mcp: FastMCP) -> None:
             "Remove a handle from a contact. Pass force=true to delete the "
             "contact's last handle (would otherwise leave it unreachable)."
         ),
+        annotations=DESTRUCTIVE,
     )
     async def delete_contact_handle(
         context: Context,

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/conversations.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/conversations.py
@@ -19,6 +19,7 @@ from pydantic import Field
 from frontapp_mcp.projections import ConversationSummary, to_summary
 from frontapp_mcp.services import get_services
 from frontapp_mcp.tools.schemas import (
+    DESTRUCTIVE,
     confirm_or_preview,
 )
 
@@ -143,6 +144,7 @@ def register_tools(mcp: FastMCP) -> None:
             "Update a conversation: status ('open'/'archived'/'deleted'/'spam'), "
             "assignee, inbox, or tag set. Two-step confirm."
         ),
+        annotations=DESTRUCTIVE,
     )
     async def update_conversation(
         context: Context,
@@ -205,6 +207,7 @@ def register_tools(mcp: FastMCP) -> None:
             "Add an internal comment to a conversation (visible to teammates "
             "only — does NOT reach the customer). Two-step confirm."
         ),
+        annotations=DESTRUCTIVE,
     )
     async def add_conversation_comment(
         context: Context,

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/drafts.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/drafts.py
@@ -26,6 +26,7 @@ from pydantic import Field
 from frontapp_mcp.projections import DraftSummary, to_draft_summary
 from frontapp_mcp.services import get_services
 from frontapp_mcp.tools.schemas import (
+    DESTRUCTIVE,
     confirm_or_preview,
 )
 from frontapp_public_api_client.helpers.attachments import (
@@ -71,6 +72,7 @@ def register_tools(mcp: FastMCP) -> None:
             "Two-step confirm: confirm=False returns a preview; confirm=True "
             "creates the draft (human still has to click send in Front)."
         ),
+        annotations=DESTRUCTIVE,
     )
     async def create_draft_on_channel(
         context: Context,
@@ -142,6 +144,7 @@ def register_tools(mcp: FastMCP) -> None:
             "Two-step confirm: confirm=False returns a preview; confirm=True "
             "creates the draft."
         ),
+        annotations=DESTRUCTIVE,
     )
     async def create_draft_reply(
         context: Context,
@@ -227,6 +230,7 @@ def register_tools(mcp: FastMCP) -> None:
             "only changing metadata. Pass version (from a prior draft fetch) "
             "to avoid clobbering concurrent edits. Two-step confirm."
         ),
+        annotations=DESTRUCTIVE,
     )
     async def edit_draft(
         context: Context,
@@ -306,6 +310,7 @@ def register_tools(mcp: FastMCP) -> None:
             "Delete a draft by id. Two-step confirm — deleting clobbers any "
             "in-progress edits in Front."
         ),
+        annotations=DESTRUCTIVE,
     )
     async def delete_draft(
         context: Context,

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/inboxes.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/inboxes.py
@@ -27,7 +27,7 @@ from frontapp_mcp.projections import (
     to_summary,
 )
 from frontapp_mcp.services import get_services
-from frontapp_mcp.tools.schemas import confirm_or_preview
+from frontapp_mcp.tools.schemas import DESTRUCTIVE, confirm_or_preview
 
 
 def register_tools(mcp: FastMCP) -> None:
@@ -140,6 +140,7 @@ def register_tools(mcp: FastMCP) -> None:
             "Create a workspace-scoped inbox. Channels still need to be "
             "wired up separately. WORKSPACE-WIDE."
         ),
+        annotations=DESTRUCTIVE,
     )
     async def create_inbox(
         context: Context,
@@ -173,6 +174,7 @@ def register_tools(mcp: FastMCP) -> None:
     @mcp.tool(
         name="create_team_inbox",
         description="Create an inbox owned by a team (`team_id` like 'tim_abc').",
+        annotations=DESTRUCTIVE,
     )
     async def create_team_inbox(
         context: Context,
@@ -208,6 +210,7 @@ def register_tools(mcp: FastMCP) -> None:
     @mcp.tool(
         name="grant_inbox_access",
         description="Grant inbox access to one or more teammates.",
+        annotations=DESTRUCTIVE,
     )
     async def grant_inbox_access(
         context: Context,
@@ -239,6 +242,7 @@ def register_tools(mcp: FastMCP) -> None:
             "Revoke inbox access from one or more teammates. The named "
             "teammates lose visibility into this inbox immediately."
         ),
+        annotations=DESTRUCTIVE,
     )
     async def revoke_inbox_access(
         context: Context,

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/knowledge_bases.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/knowledge_bases.py
@@ -39,7 +39,7 @@ from frontapp_mcp.projections import (
     to_kb_ref,
 )
 from frontapp_mcp.services import get_services
-from frontapp_mcp.tools.schemas import confirm_or_preview
+from frontapp_mcp.tools.schemas import DESTRUCTIVE, confirm_or_preview
 
 
 def _content_preview(content: str | None, max_chars: int = 200) -> str | None:
@@ -209,6 +209,7 @@ def register_tools(mcp: FastMCP) -> None:
             "Two-step confirm: confirm=False returns a preview; "
             "confirm=True creates the draft."
         ),
+        annotations=DESTRUCTIVE,
     )
     async def create_kb_article(
         context: Context,
@@ -269,6 +270,7 @@ def register_tools(mcp: FastMCP) -> None:
             "already has. (To publish a draft, a human flips it in "
             "Front's UI.) Two-step confirm."
         ),
+        annotations=DESTRUCTIVE,
     )
     async def update_kb_article(
         context: Context,
@@ -317,6 +319,7 @@ def register_tools(mcp: FastMCP) -> None:
             "Create a new category within a knowledge base. Categories "
             "organize articles. Two-step confirm."
         ),
+        annotations=DESTRUCTIVE,
     )
     async def create_kb_category(
         context: Context,
@@ -364,6 +367,7 @@ def register_tools(mcp: FastMCP) -> None:
             "Update an existing KB category (name and/or description). "
             "Two-step confirm."
         ),
+        annotations=DESTRUCTIVE,
     )
     async def update_kb_category(
         context: Context,

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/messages.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/messages.py
@@ -20,6 +20,7 @@ from pydantic import Field
 
 from frontapp_mcp.services import get_services
 from frontapp_mcp.tools.schemas import (
+    DESTRUCTIVE,
     confirm_or_preview,
 )
 from frontapp_public_api_client.domain.converters import unwrap_unset
@@ -130,6 +131,7 @@ def register_tools(mcp: FastMCP) -> None:
             "Optional teammate_id attributes the seen event to a "
             "specific 'tea_*' teammate. Two-step confirm."
         ),
+        annotations=DESTRUCTIVE,
     )
     async def mark_message_seen(
         context: Context,

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/schemas.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/schemas.py
@@ -1,10 +1,18 @@
-"""Shared schemas for Frontapp MCP tools.
+"""Shared schemas and annotations for Frontapp MCP tools.
 
 This module contains helpers shared across multiple tool modules to ensure
 consistency and avoid duplication.
 """
 
 from typing import Any
+
+from mcp.types import ToolAnnotations
+
+# Canonical destructive-mutation annotation. Apply to every @mcp.tool decorator
+# that takes a `confirm:` parameter so spec-compliant clients prompt the user
+# natively before invoking. This is the client-side complement to the in-band
+# two-call gate enforced by `confirm_or_preview` — see ADR-0016.
+DESTRUCTIVE = ToolAnnotations(destructiveHint=True)
 
 
 def confirm_or_preview(
@@ -21,8 +29,9 @@ def confirm_or_preview(
     The contract is **two-call**: the LLM first invokes the tool with
     ``confirm=False`` to get the preview, surfaces it to the user, and
     only re-invokes with ``confirm=True`` after the user agrees. Mutation
-    tools should also carry the MCP ``destructiveHint`` annotation so
-    spec-compliant clients prompt natively (tracked separately).
+    tools should also carry the MCP ``destructiveHint`` annotation
+    (via ``DESTRUCTIVE`` in this module) so spec-compliant clients
+    prompt natively.
 
     Why no server-side elicitation: ``ctx.elicit`` is unreliable across
     MCP clients (notably broken in Claude Desktop). Per the MCP Tools
@@ -52,4 +61,4 @@ def confirm_or_preview(
     return None
 
 
-__all__ = ["confirm_or_preview"]
+__all__ = ["DESTRUCTIVE", "confirm_or_preview"]

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/tags.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/tags.py
@@ -37,6 +37,7 @@ from frontapp_mcp.projections import (
 )
 from frontapp_mcp.services import get_services
 from frontapp_mcp.tools.schemas import (
+    DESTRUCTIVE,
     confirm_or_preview,
 )
 from frontapp_public_api_client.helpers.tags import HighlightLiteral
@@ -175,6 +176,7 @@ def register_tools(mcp: FastMCP) -> None:
             "tags untouched. For full-set replacement use "
             "update_conversation(tag_ids=[...]) in the conversations vertical."
         ),
+        annotations=DESTRUCTIVE,
     )
     async def add_tag_to_conversation(
         context: Context,
@@ -204,6 +206,7 @@ def register_tools(mcp: FastMCP) -> None:
             "Remove a single tag from a conversation. DELTA — leaves "
             "other tags untouched."
         ),
+        annotations=DESTRUCTIVE,
     )
     async def remove_tag_from_conversation(
         context: Context,
@@ -235,6 +238,7 @@ def register_tools(mcp: FastMCP) -> None:
             "Create a workspace-scoped tag. WORKSPACE-WIDE — visible to "
             "every teammate immediately."
         ),
+        annotations=DESTRUCTIVE,
     )
     async def create_tag(
         context: Context,
@@ -276,6 +280,7 @@ def register_tools(mcp: FastMCP) -> None:
     @mcp.tool(
         name="create_child_tag",
         description="Create a child tag under an existing parent. WORKSPACE-WIDE.",
+        annotations=DESTRUCTIVE,
     )
     async def create_child_tag(
         context: Context,
@@ -316,6 +321,7 @@ def register_tools(mcp: FastMCP) -> None:
             "Update mutable fields on a tag. WORKSPACE-WIDE — a rename "
             "ripples to every conversation instantly."
         ),
+        annotations=DESTRUCTIVE,
     )
     async def update_tag(
         context: Context,
@@ -377,6 +383,7 @@ def register_tools(mcp: FastMCP) -> None:
             "DESTRUCTIVE: permanently delete a tag. Removes it from every "
             "conversation that had it. Irreversible. WORKSPACE-WIDE."
         ),
+        annotations=DESTRUCTIVE,
     )
     async def delete_tag(
         context: Context,

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/teammates.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/teammates.py
@@ -20,6 +20,7 @@ from pydantic import Field
 from frontapp_mcp.projections import ConversationSummary, to_summary
 from frontapp_mcp.services import get_services
 from frontapp_mcp.tools.schemas import (
+    DESTRUCTIVE,
     confirm_or_preview,
 )
 from frontapp_public_api_client.domain import Inbox, Teammate
@@ -97,6 +98,7 @@ def register_tools(mcp: FastMCP) -> None:
             "admin status are NOT changeable via this API — manage those "
             "in Front's admin UI. Two-step confirm."
         ),
+        annotations=DESTRUCTIVE,
     )
     async def update_teammate(
         context: Context,

--- a/frontapp_mcp_server/src/frontapp_mcp/tools/teams.py
+++ b/frontapp_mcp_server/src/frontapp_mcp/tools/teams.py
@@ -23,7 +23,7 @@ from fastmcp import Context, FastMCP
 from pydantic import Field
 
 from frontapp_mcp.services import get_services
-from frontapp_mcp.tools.schemas import confirm_or_preview
+from frontapp_mcp.tools.schemas import DESTRUCTIVE, confirm_or_preview
 
 
 def register_tools(mcp: FastMCP) -> None:
@@ -38,6 +38,7 @@ def register_tools(mcp: FastMCP) -> None:
             "frontapp://teams to translate a team name into a "
             "`tim_*` id and frontapp://teammates for `tea_*` ids."
         ),
+        annotations=DESTRUCTIVE,
     )
     async def add_team_members(
         context: Context,
@@ -74,6 +75,7 @@ def register_tools(mcp: FastMCP) -> None:
             "from their last team typically leaves them workspace-"
             "scoped only — verify with the user if that's intended."
         ),
+        annotations=DESTRUCTIVE,
     )
     async def remove_team_members(
         context: Context,

--- a/frontapp_mcp_server/tests/test_tool_annotations.py
+++ b/frontapp_mcp_server/tests/test_tool_annotations.py
@@ -1,0 +1,64 @@
+"""Tests for MCP tool annotations.
+
+Every mutation tool (one that takes a ``confirm:`` parameter) must carry
+the ``destructiveHint`` annotation so spec-compliant clients prompt the
+user before invoking. Read-only tools must not carry that hint.
+
+This is the contract documented in ADR-0016 (post-elicit) and the
+``DESTRUCTIVE`` constant in ``frontapp_mcp.tools.schemas``.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+from fastmcp import FastMCP
+from frontapp_mcp.tools import register_all_tools
+
+
+@pytest.fixture
+def registered_tools():
+    """Return the live tool registry after ``register_all_tools`` has run."""
+    mcp = FastMCP("annotation-test")
+    register_all_tools(mcp)
+    return mcp
+
+
+def _is_mutation(fn) -> bool:
+    """A tool is a mutation iff its callable takes a ``confirm`` parameter."""
+    return "confirm" in inspect.signature(fn).parameters
+
+
+async def test_every_mutation_tool_carries_destructive_hint(registered_tools):
+    tools = await registered_tools.list_tools()
+    mutations: list[str] = []
+    missing: list[str] = []
+    for tool in tools:
+        if not _is_mutation(tool.fn):
+            continue
+        mutations.append(tool.name)
+        ann = tool.annotations
+        if ann is None or ann.destructiveHint is not True:
+            missing.append(tool.name)
+    assert mutations, "Expected at least one mutation tool to be discovered"
+    assert not missing, (
+        f"{len(missing)} mutation tool(s) missing destructiveHint=True: {missing}"
+    )
+
+
+async def test_read_tools_do_not_set_destructive_hint(registered_tools):
+    tools = await registered_tools.list_tools()
+    reads: list[str] = []
+    misannotated: list[str] = []
+    for tool in tools:
+        if _is_mutation(tool.fn):
+            continue
+        reads.append(tool.name)
+        ann = tool.annotations
+        if ann is not None and ann.destructiveHint is True:
+            misannotated.append(tool.name)
+    assert reads, "Expected at least one read tool to be discovered"
+    assert not misannotated, (
+        f"Read tool(s) incorrectly annotated as destructive: {misannotated}"
+    )


### PR DESCRIPTION
## Summary

Phase B follow-up to #104. Adds the MCP-spec `destructiveHint=true` annotation on every mutation tool so spec-compliant clients (Claude Desktop with appropriate settings, Cline, Cursor MCP integration, and others) prompt the user before invoking.

The in-band `confirm=False` preview path remains the canonical contract — this annotation is a **client-side complement**, not a replacement. Per the MCP Tools spec: clients SHOULD prompt; servers SHOULD NOT.

## Changes

- **New `DESTRUCTIVE` constant** in `tools/schemas.py` — `ToolAnnotations(destructiveHint=True)`. Single source of truth so the annotation can't drift across files.
- **47 mutation tools** across 13 files now pass `annotations=DESTRUCTIVE` to their `@mcp.tool` decorator: applications, attachments, contact_groups, contact_lists, contacts, conversations, drafts, inboxes, knowledge_bases, messages, tags, teammates, teams. (Identified by which tools take a `confirm:` parameter.)
- **New regression-guard test** `tests/test_tool_annotations.py` registers all tools via `register_all_tools(FastMCP(...))` and asserts:
  - every mutation has `destructiveHint=True`
  - no read tool has it set
- **Help resource** documents the convention so the agent surface explains the contract.

## Test plan

- [x] `uv run poe check` passes (610 tests, was 608 + 2 new annotation tests)
- [x] All 47 mutations carry the annotation; all 49 reads are correctly unannotated
- [ ] Manual smoke in Claude Desktop: `update_conversation` triggers the destructive-tool dialog if user has it enabled
- [ ] Manual smoke in Cline: same

## Future verticals

The new annotation test acts as a regression guard. When `/new-vertical` adds a vertical with a mutation, the test will fail until `annotations=DESTRUCTIVE` is added — keeping the convention enforced as the surface grows.

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)