### PR TITLE
docs(claude): backport three Known Pitfalls from sibling repos (#113)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,23 @@ Common mistakes to avoid:
   `scripts/pre-push-guard.sh` pre-commit hook blocks this. The right form for first-time
   pushes is `git push -u origin HEAD:refs/heads/<branch-name>`. `--no-verify` is
   forbidden — fix the push command instead.
+- **`uv.lock` drift you didn't cause** — when you start a branch off an older `main` and
+  a sibling-package release (e.g. `mcp-vX.Y.Z`) lands on `main` while you work, your
+  `uv.lock` will show modifications you didn't make once you sync or run `uv sync`.
+  Stage and commit it (`git add uv.lock`) bundled with your other work — don't try to
+  revert it. The lockfile is authoritative and CI re-resolves from `pyproject.toml`
+  anyway, so a stale lockfile causes spurious CI diffs.
+- **Generator/script edits without committing the regen** — when you edit
+  `scripts/vendor_spec.py`, `scripts/regenerate_client.py`, or
+  `scripts/generate_api_facts.py`, you must also run the corresponding regenerate task
+  and commit the regenerated output. `block-generated-edits.sh` blocks direct edits to
+  generated files but doesn't catch this case (the generator changes look unrelated). CI
+  will fail on `facts-check` or generated-client diff if you forget.
+- **Live Front API data must not enter the repo** — when testing against a real Front
+  workspace, never commit raw response fixtures, names, emails, or conversation bodies
+  from real customers. Sanitize to placeholders (`cnv_TEST`, `customer@example.com`,
+  generic message bodies) before saving as a test fixture or example. Front workspaces
+  contain customer PII and the published client is a public package.
 
 ## Using the LSP tool
 


### PR DESCRIPTION
## Summary

After investigating the CLAUDE.md files in dougborg/katana-openapi-client, dougborg/stocktrim-openapi-client, and dougborg/statuspro-openapi-client, three recurring lessons are worth porting here. Selected three; deliberately skipped several others as either repo-specific or already covered.

## Pitfalls added

1. **`uv.lock` drift you didn't cause** — when a sibling-package release lands on main during a feature branch, the lockfile picks up changes you didn't author. Pattern: stage and bundle with your commit, don't revert.

2. **Generator/script edits without committing the regen** — editing `vendor_spec.py` / `regenerate_client.py` / `generate_api_facts.py` without committing the regenerated output causes silent CI diffs (`facts-check` or generated-client diff). `block-generated-edits.sh` doesn't catch this case because the generator changes themselves look unrelated.

3. **Live Front API data must not enter the repo** — Front workspaces contain customer PII; never commit raw response fixtures with real names/emails/bodies. Sanitize to placeholders before committing as a test fixture or example.

## Skipped (deliberately)

- **Harness-kit migration sections** — frontapp already had a harness-kit run (per memory); not re-litigating.
- **Strict-quality-checklist FORBIDDEN-style language** — frontapp's existing "Zero Tolerance" section already covers this in spirit; rewriting in stocktrim's emphatic style would be churn.
- **Katana-specific `data` array list responses** — Front uses `field_results`, not `data`; not applicable.
- **\"Always use keyword arguments\"** — too generic, not a pattern this codebase has actually been bitten by.

## Test plan

- [x] `uv run poe check` passes
- [x] Pitfalls cover real recurring patterns (uv.lock drift has been observed; generator-regen forgetting was a katana lesson but mechanically applies here too)

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)