### PR TITLE
ci(release): use GitHub App token for release-side pushes/tags

### DIFF
--- a/.github/workflows/release-ts.yml
+++ b/.github/workflows/release-ts.yml
@@ -68,6 +68,13 @@ jobs:
       released: ${{ steps.release.outputs.new_release_published }}
       version: ${{ steps.release.outputs.new_release_version }}
     steps:
+      - name: Mint GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
@@ -108,7 +115,7 @@ jobs:
         if: steps.check.outputs.has_changes == 'true' || inputs.force_publish == true
         working-directory: packages/frontapp-client
         env:
-          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           # @semantic-release/npm is configured with npmPublish: false, so this
           # step only runs analyzeCommits → version bump → tag → GitHub release.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,10 +68,17 @@ jobs:
       version: ${{ steps.release.outputs.version }}
       tag: ${{ steps.release.outputs.tag }}
     steps:
+      - name: Mint GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -101,7 +108,7 @@ jobs:
         id: release
         uses: python-semantic-release/python-semantic-release@v10.5.3
         with:
-          github_token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
           verbosity: 2
 
       - name: Build client package
@@ -135,10 +142,17 @@ jobs:
       version: ${{ steps.release.outputs.version }}
       tag: ${{ steps.release.outputs.tag }}
     steps:
+      - name: Mint GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -167,7 +181,7 @@ jobs:
         id: release
         uses: python-semantic-release/python-semantic-release@v10.5.3
         with:
-          github_token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
           verbosity: 2
           directory: frontapp_mcp_server
 
@@ -237,10 +251,17 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Mint GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/update-mcp-dependency.yml
+++ b/.github/workflows/update-mcp-dependency.yml
@@ -16,11 +16,18 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Mint GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Check for new client release
         id: check-release


### PR DESCRIPTION
## Summary

Release automation in this repo pushes commits and tags directly to `main` (via `python-semantic-release` in `release.yml`, and `@semantic-release/git`/`@semantic-release/github` in `release-ts.yml`), and `update-mcp-dependency.yml` pushes a dependency-bump commit after a successful release.

These jobs currently authenticate with `secrets.SEMANTIC_RELEASE_TOKEN`, which is **not actually configured** as a repo secret (confirmed via `gh secret list` — it doesn't exist, so it resolves to an empty string at runtime). Even once configured, a PAT works, but pushes made with `GITHUB_TOKEN` (or a missing/empty token falling back to the default) do not trigger other `push`-triggered workflows in this repo: `ci.yml`, `docs.yml`, `security.yml`, `codespaces-prebuild.yml` (paths-permitting), and tag pushes matching `mcp-v*` wouldn't fire `release-mcp.yml`.

A dedicated GitHub App (`dougborg-release-please`, App ID 4392719) is now installed on this repo, with its credentials already present as `vars.RELEASE_PLEASE_APP_ID` / `secrets.RELEASE_PLEASE_APP_PRIVATE_KEY`. Its installation token is a real actor, so pushes/tags it makes trigger downstream workflows normally.

## Changes

- `release.yml`: `release-client`, `release-mcp`, and `sync-lockfile` jobs now mint an App installation token via `actions/create-github-app-token@v3` and use it for checkout + `python-semantic-release`'s `github_token` input, replacing `secrets.SEMANTIC_RELEASE_TOKEN`.
- `release-ts.yml`: `release-ts` job mints an App token and passes it as `GITHUB_TOKEN` to `npx semantic-release` (used by `@semantic-release/git` for the version-bump commit/tag and `@semantic-release/github` for the GitHub Release), replacing `secrets.SEMANTIC_RELEASE_TOKEN`.
- `update-mcp-dependency.yml`: mints an App token for checkout so the dependency-bump commit it pushes to `main` is attributed to a real actor.

## Left unchanged (deliberately)

- PyPI publishing (`publish-client-pypi`, `publish-mcp-pypi` in `release.yml`, `publish-pypi` in `release-mcp.yml`) — uses OIDC trusted publishing, no GitHub token involved.
- npm publishing step in `release-ts.yml` — uses OIDC trusted publishing.
- GHCR docker login in `release.yml`'s `publish-mcp-docker` job — registry auth via `secrets.GITHUB_TOKEN`, not a GitHub-side release action.
- `release-mcp.yml` — only builds/tests/publishes on an already-pushed tag; doesn't push commits, tags, or PRs itself, so there's nothing for the App token to help with.

## Notes

- The default branch (`main`) has **no branch protection / no rulesets** (`gh api .../branches/main/protection` → 404, `gh api .../rulesets` → `[]`), so there are no required status checks today. This change is still worthwhile because it makes push-triggered workflows (CI, docs, security scanning) actually fire on release commits/tags, which they currently don't.
- Did not touch or create any secrets/variables — `RELEASE_PLEASE_APP_ID` / `RELEASE_PLEASE_APP_PRIVATE_KEY` were already present.
- `actionlint` run against the modified workflows shows only pre-existing shellcheck SC2046/SC2086 warnings in unrelated `run:` blocks (confirmed identical on `main` before this change) — nothing new introduced.

## Test plan

- [ ] `actions/create-github-app-token@v3` mints a token successfully in each modified job (verify on a workflow_dispatch run of `release.yml`/`release-ts.yml`, or the next real release)
- [ ] Confirm a commit/tag pushed by the App triggers `ci.yml` / `docs.yml` / `security.yml` as expected
- [ ] Confirm PyPI/npm publishing steps are unaffected (still auth via OIDC)

Not merging — for review first.