### PR TITLE
fix(tests): set MCP package asyncio_mode to auto

### DIFF
--- a/frontapp_mcp_server/pyproject.toml
+++ b/frontapp_mcp_server/pyproject.toml
@@ -69,7 +69,7 @@ packages = ["src/frontapp_mcp"]
 # Pytest Configuration (Native TOML - pytest 9.0+)
 [tool.pytest]
 testpaths = ["tests"]
-asyncio_mode = "strict"
+asyncio_mode = "auto"
 markers = [
     "unit: Unit tests with mocks",
     "integration: Integration tests requiring API key",


### PR DESCRIPTION
Fixes #166.

## Problem

`frontapp_mcp_server/pyproject.toml:72` set `asyncio_mode = "strict"`; the root sets `"auto"`. pytest picks `rootdir`/`configfile` from the target path, so the two invocations read different configs:

```console
$ uv run pytest frontapp_mcp_server/tests -q
136 failed, 48 passed, 7 errors in 1.76s
```

Every failure was the same setup error — `requested an async fixture 'make_client', with no plugin or hook that handled it` — not a product defect. CI never caught it because it always runs pytest from the repo root, where `auto` applies.

## Fix

One line: `strict` → `auto` in the MCP package config.

`auto` is the correct value rather than a workaround — this package's tests are written for it. Roughly 117 of its 131 async tests carry no `@pytest.mark.asyncio`, and its async fixtures use bare `@pytest.fixture`, both of which only work under `auto`.

I deliberately did **not** delete the `[tool.pytest]` block, even though a single root-level config would be tidier: the block also carries `testpaths` and the `unit`/`integration` marker registrations, which would be lost.

## Verification

| Invocation | Before | After |
|---|---|---|
| `pytest frontapp_mcp_server/tests` | 136 failed, 48 passed, 7 errors | **191 passed** |
| `pytest -n 4 -m 'not docs and not schema_validation and not integration'` (CI path) | 610 passed, 1 skipped | 610 passed, 1 skipped |

## Note on the MCP server itself

Unrelated to this change, but worth recording since the failures looked alarming: the server is healthy. It boots and registers **96 tools** and 9 resources. What blocks it is packaging, not code — see #10, #165.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRhJ5dF3N3z7X63aRaDBcQ